### PR TITLE
perf: specialize strict function calls without this

### DIFF
--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
@@ -659,11 +659,13 @@ public sealed partial class HIRToLIRLowerer
 
             var callableId = symbol.BindingInfo.Callable;
 
-            // Strict bare calls must preserve undefined `this`; route them through the function-value
-            // dispatch path instead of the direct static-call fast path.
+            // Strict bare calls only require function-value dispatch when the
+            // undefined `this` binding is observable.
             // Non-function bindings also use runtime dispatch (e.g., locals/consts holding closures).
             if (symbol.Kind != BindingKind.Function
-                || callableId?.HasRestrictedFunctionProperties == true
+                || (callableId?.HasRestrictedFunctionProperties == true
+                    && (callableId.Semantics.UsesThis
+                        || callableId.Semantics.NestedArrowUsesThis))
                 || RequiresFunctionObjectInvocation(callableId))
             {
                 // Lower callee value

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -2003,55 +2003,45 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 109 (0x6d)
+			// Code size: 92 (0x5c)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[0] object,
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldarg.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0018: stloc.1
-			IL_0019: ldloc.1
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: stloc.1
-			IL_0020: ldstr "^\\/+"
-			IL_0025: ldstr ""
-			IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_002f: stloc.2
-			IL_0030: ldloc.1
-			IL_0031: ldstr "replace"
-			IL_0036: ldloc.2
-			IL_0037: ldstr ""
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0041: stloc.1
-			IL_0042: ldloc.1
-			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0048: stloc.1
-			IL_0049: ldstr "\\/+$"
-			IL_004e: ldstr ""
-			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0058: stloc.2
-			IL_0059: ldloc.1
-			IL_005a: ldstr "replace"
-			IL_005f: ldloc.2
-			IL_0060: ldstr ""
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_006a: stloc.1
-			IL_006b: ldloc.1
-			IL_006c: ret
+			IL_0000: ldnull
+			IL_0001: ldarg.2
+			IL_0002: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_0007: stloc.0
+			IL_0008: ldloc.0
+			IL_0009: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000e: stloc.0
+			IL_000f: ldstr "^\\/+"
+			IL_0014: ldstr ""
+			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_001e: stloc.1
+			IL_001f: ldloc.0
+			IL_0020: ldstr "replace"
+			IL_0025: ldloc.1
+			IL_0026: ldstr ""
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0030: stloc.0
+			IL_0031: ldloc.0
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0037: stloc.0
+			IL_0038: ldstr "\\/+$"
+			IL_003d: ldstr ""
+			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0047: stloc.1
+			IL_0048: ldloc.0
+			IL_0049: ldstr "replace"
+			IL_004e: ldloc.1
+			IL_004f: ldstr ""
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0059: stloc.0
+			IL_005a: ldloc.0
+			IL_005b: ret
 		} // end of method normalizeSpecPath::__js_call__
 
 	} // end of class normalizeSpecPath
@@ -2998,7 +2988,7 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 277 (0x115)
+			// Code size: 254 (0xfe)
 			.maxstack 10
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -3007,136 +2997,124 @@
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.Error,
 				[5] object,
-				[6] object[],
-				[7] bool
+				[6] bool
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_0006: stloc.s 5
-			IL_0008: ldc.i4.1
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: stloc.s 6
-			IL_0014: ldloc.s 5
-			IL_0016: ldloc.s 6
-			IL_0018: ldarg.2
-			IL_0019: ldstr "excludedFromMvp"
-			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0023: pop
-			IL_0024: ldarg.2
-			IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_002a: stloc.0
-			IL_002b: ldc.i4.0
-			IL_002c: stloc.1
-			IL_002d: ldc.i4.0
-			IL_002e: stloc.2
+			IL_0000: ldnull
+			IL_0001: ldarg.2
+			IL_0002: ldstr "excludedFromMvp"
+			IL_0007: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+			IL_000c: pop
+			IL_000d: ldarg.2
+			IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0013: stloc.0
+			IL_0014: ldc.i4.0
+			IL_0015: stloc.1
+			IL_0016: ldc.i4.0
+			IL_0017: stloc.2
 			.try
 			{
-				// loop start (head: IL_002f)
-					IL_002f: ldc.i4.1
-					IL_0030: stloc.1
-					IL_0031: ldloc.0
-					IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_0037: stloc.s 5
-					IL_0039: ldloc.s 5
-					IL_003b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_0040: stloc.s 7
-					IL_0042: ldloc.s 7
-					IL_0044: brtrue IL_00f9
+				// loop start (head: IL_0018)
+					IL_0018: ldc.i4.1
+					IL_0019: stloc.1
+					IL_001a: ldloc.0
+					IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_0020: stloc.s 5
+					IL_0022: ldloc.s 5
+					IL_0024: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_0029: stloc.s 6
+					IL_002b: ldloc.s 6
+					IL_002d: brtrue IL_00e2
 
-					IL_0049: ldloc.s 5
-					IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_0050: stloc.s 5
-					IL_0052: ldc.i4.0
-					IL_0053: stloc.1
-					IL_0054: ldloc.s 5
-					IL_0056: stloc.3
-					IL_0057: ldloc.3
-					IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_005d: stloc.s 5
-					IL_005f: ldc.i4.0
-					IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-					IL_0065: brfalse IL_00a1
+					IL_0032: ldloc.s 5
+					IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_0039: stloc.s 5
+					IL_003b: ldc.i4.0
+					IL_003c: stloc.1
+					IL_003d: ldloc.s 5
+					IL_003f: stloc.3
+					IL_0040: ldloc.3
+					IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0046: stloc.s 5
+					IL_0048: ldc.i4.0
+					IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+					IL_004e: brfalse IL_008a
 
-					IL_006a: ldloc.s 5
-					IL_006c: isinst [System.Runtime]System.String
-					IL_0071: dup
-					IL_0072: brtrue IL_008a
+					IL_0053: ldloc.s 5
+					IL_0055: isinst [System.Runtime]System.String
+					IL_005a: dup
+					IL_005b: brtrue IL_0073
 
-					IL_0077: pop
-					IL_0078: ldloc.s 5
-					IL_007a: ldstr "startsWith"
-					IL_007f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-					IL_0084: dup
-					IL_0085: brfalse IL_00a0
+					IL_0060: pop
+					IL_0061: ldloc.s 5
+					IL_0063: ldstr "startsWith"
+					IL_0068: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+					IL_006d: dup
+					IL_006e: brfalse IL_0089
 
-					IL_008a: ldstr "frontmatter:"
-					IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-					IL_0094: box [System.Runtime]System.Boolean
-					IL_0099: stloc.s 5
-					IL_009b: br IL_00b4
+					IL_0073: ldstr "frontmatter:"
+					IL_0078: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+					IL_007d: box [System.Runtime]System.Boolean
+					IL_0082: stloc.s 5
+					IL_0084: br IL_009d
 
-					IL_00a0: pop
+					IL_0089: pop
 
-					IL_00a1: ldloc.s 5
-					IL_00a3: ldstr "startsWith"
-					IL_00a8: ldstr "frontmatter:"
-					IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_00b2: stloc.s 5
+					IL_008a: ldloc.s 5
+					IL_008c: ldstr "startsWith"
+					IL_0091: ldstr "frontmatter:"
+					IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_009b: stloc.s 5
 
-					IL_00b4: ldloc.s 5
-					IL_00b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00bb: stloc.s 7
-					IL_00bd: ldloc.s 7
-					IL_00bf: brfalse IL_00e7
+					IL_009d: ldloc.s 5
+					IL_009f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00a4: stloc.s 6
+					IL_00a6: ldloc.s 6
+					IL_00a8: brfalse IL_00d0
 
-					IL_00c4: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
-					IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_00ce: stloc.s 4
-					IL_00d0: ldloc.s 4
-					IL_00d2: isinst [System.Runtime]System.Exception
-					IL_00d7: dup
-					IL_00d8: brtrue IL_00e6
+					IL_00ad: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
+					IL_00b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00b7: stloc.s 4
+					IL_00b9: ldloc.s 4
+					IL_00bb: isinst [System.Runtime]System.Exception
+					IL_00c0: dup
+					IL_00c1: brtrue IL_00cf
 
-					IL_00dd: pop
-					IL_00de: ldloc.s 4
-					IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_00e5: throw
+					IL_00c6: pop
+					IL_00c7: ldloc.s 4
+					IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_00ce: throw
 
-					IL_00e6: throw
+					IL_00cf: throw
 
-					IL_00e7: br IL_002f
+					IL_00d0: br IL_0018
 				// end loop
-				IL_00ec: ldloc.0
-				IL_00ed: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_00f2: ldc.i4.1
-				IL_00f3: stloc.2
-				IL_00f4: leave IL_0113
+				IL_00d5: ldloc.0
+				IL_00d6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_00db: ldc.i4.1
+				IL_00dc: stloc.2
+				IL_00dd: leave IL_00fc
 
-				IL_00f9: ldc.i4.1
-				IL_00fa: stloc.1
-				IL_00fb: leave IL_0113
+				IL_00e2: ldc.i4.1
+				IL_00e3: stloc.1
+				IL_00e4: leave IL_00fc
 			} // end .try
 			finally
 			{
-				IL_0100: ldloc.1
-				IL_0101: brtrue IL_0112
+				IL_00e9: ldloc.1
+				IL_00ea: brtrue IL_00fb
 
-				IL_0106: ldloc.2
-				IL_0107: brtrue IL_0112
+				IL_00ef: ldloc.2
+				IL_00f0: brtrue IL_00fb
 
-				IL_010c: ldloc.0
-				IL_010d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_00f5: ldloc.0
+				IL_00f6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0112: endfinally
+				IL_00fb: endfinally
 			} // end handler
 
-			IL_0113: ldnull
-			IL_0114: ret
+			IL_00fc: ldnull
+			IL_00fd: ret
 		} // end of method validateExcludedFromMvp::__js_call__
 
 	} // end of class validateExcludedFromMvp
@@ -3345,7 +3323,7 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2195 (0x893)
+			// Code size: 1833 (0x729)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Error,
@@ -3359,9 +3337,7 @@
 				[8] object,
 				[9] object,
 				[10] object,
-				[11] object[],
-				[12] object,
-				[13] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
 			IL_0000: ldarg.2
@@ -3500,662 +3476,488 @@
 
 			IL_0157: throw
 
-			IL_0158: ldarg.0
-			IL_0159: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_015e: stloc.s 9
-			IL_0160: ldc.i4.1
-			IL_0161: newarr [System.Runtime]System.Object
-			IL_0166: dup
-			IL_0167: ldc.i4.0
-			IL_0168: ldarg.0
-			IL_0169: stelem.ref
-			IL_016a: stloc.s 11
-			IL_016c: volatile.
-			IL_016e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-			IL_0173: brfalse IL_0188
+			IL_0158: volatile.
+			IL_015a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_015f: brfalse IL_0174
 
-			IL_0178: ldarg.2
-			IL_0179: ldstr "upstream"
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0183: br IL_019d
+			IL_0164: ldarg.2
+			IL_0165: ldstr "upstream"
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016f: br IL_0189
 
-			IL_0188: ldarg.2
-			IL_0189: ldstr "upstream"
-			IL_018e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:57"
-			IL_0193: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0174: ldarg.2
+			IL_0175: ldstr "upstream"
+			IL_017a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:55"
+			IL_017f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_019d: stloc.s 12
-			IL_019f: volatile.
-			IL_01a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-			IL_01a6: brfalse IL_01bc
+			IL_0189: stloc.s 9
+			IL_018b: volatile.
+			IL_018d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0192: brfalse IL_01a8
 
-			IL_01ab: ldloc.s 12
-			IL_01ad: ldstr "owner"
-			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b7: br IL_01d2
+			IL_0197: ldloc.s 9
+			IL_0199: ldstr "owner"
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01a3: br IL_01be
 
-			IL_01bc: ldloc.s 12
-			IL_01be: ldstr "owner"
-			IL_01c3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:59"
-			IL_01c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01a8: ldloc.s 9
+			IL_01aa: ldstr "owner"
+			IL_01af: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:57"
+			IL_01b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01d2: stloc.s 12
-			IL_01d4: ldloc.s 9
-			IL_01d6: ldloc.s 11
-			IL_01d8: ldloc.s 12
-			IL_01da: ldstr "upstream.owner"
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01e4: pop
-			IL_01e5: ldarg.0
-			IL_01e6: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_01eb: stloc.s 12
-			IL_01ed: ldc.i4.1
-			IL_01ee: newarr [System.Runtime]System.Object
-			IL_01f3: dup
-			IL_01f4: ldc.i4.0
-			IL_01f5: ldarg.0
-			IL_01f6: stelem.ref
-			IL_01f7: stloc.s 11
-			IL_01f9: volatile.
-			IL_01fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-			IL_0200: brfalse IL_0215
+			IL_01be: stloc.s 9
+			IL_01c0: ldnull
+			IL_01c1: ldloc.s 9
+			IL_01c3: ldstr "upstream.owner"
+			IL_01c8: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+			IL_01cd: pop
+			IL_01ce: volatile.
+			IL_01d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_01d5: brfalse IL_01ea
 
-			IL_0205: ldarg.2
-			IL_0206: ldstr "upstream"
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0210: br IL_022a
+			IL_01da: ldarg.2
+			IL_01db: ldstr "upstream"
+			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01e5: br IL_01ff
 
-			IL_0215: ldarg.2
-			IL_0216: ldstr "upstream"
-			IL_021b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:67"
-			IL_0220: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01ea: ldarg.2
+			IL_01eb: ldstr "upstream"
+			IL_01f0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:64"
+			IL_01f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_022a: stloc.s 9
-			IL_022c: volatile.
-			IL_022e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_0233: brfalse IL_0249
+			IL_01ff: stloc.s 9
+			IL_0201: volatile.
+			IL_0203: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_0208: brfalse IL_021e
 
-			IL_0238: ldloc.s 9
-			IL_023a: ldstr "repo"
-			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0244: br IL_025f
+			IL_020d: ldloc.s 9
+			IL_020f: ldstr "repo"
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0219: br IL_0234
 
-			IL_0249: ldloc.s 9
-			IL_024b: ldstr "repo"
-			IL_0250: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:69"
-			IL_0255: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_021e: ldloc.s 9
+			IL_0220: ldstr "repo"
+			IL_0225: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:66"
+			IL_022a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_025f: stloc.s 9
-			IL_0261: ldloc.s 12
-			IL_0263: ldloc.s 11
-			IL_0265: ldloc.s 9
-			IL_0267: ldstr "upstream.repo"
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0271: pop
-			IL_0272: ldarg.0
-			IL_0273: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_0278: stloc.s 9
-			IL_027a: ldc.i4.1
-			IL_027b: newarr [System.Runtime]System.Object
-			IL_0280: dup
-			IL_0281: ldc.i4.0
-			IL_0282: ldarg.0
-			IL_0283: stelem.ref
-			IL_0284: stloc.s 11
-			IL_0286: volatile.
-			IL_0288: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_028d: brfalse IL_02a2
+			IL_0234: stloc.s 9
+			IL_0236: ldnull
+			IL_0237: ldloc.s 9
+			IL_0239: ldstr "upstream.repo"
+			IL_023e: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+			IL_0243: pop
+			IL_0244: volatile.
+			IL_0246: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_024b: brfalse IL_0260
 
-			IL_0292: ldarg.2
-			IL_0293: ldstr "upstream"
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029d: br IL_02b7
+			IL_0250: ldarg.2
+			IL_0251: ldstr "upstream"
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025b: br IL_0275
 
-			IL_02a2: ldarg.2
-			IL_02a3: ldstr "upstream"
-			IL_02a8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:77"
-			IL_02ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0260: ldarg.2
+			IL_0261: ldstr "upstream"
+			IL_0266: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:73"
+			IL_026b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02b7: stloc.s 12
-			IL_02b9: volatile.
-			IL_02bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-			IL_02c0: brfalse IL_02d6
+			IL_0275: stloc.s 9
+			IL_0277: volatile.
+			IL_0279: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_027e: brfalse IL_0294
 
-			IL_02c5: ldloc.s 12
-			IL_02c7: ldstr "cloneUrl"
+			IL_0283: ldloc.s 9
+			IL_0285: ldstr "cloneUrl"
+			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028f: br IL_02aa
+
+			IL_0294: ldloc.s 9
+			IL_0296: ldstr "cloneUrl"
+			IL_029b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:75"
+			IL_02a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_02aa: stloc.s 9
+			IL_02ac: ldnull
+			IL_02ad: ldloc.s 9
+			IL_02af: ldstr "upstream.cloneUrl"
+			IL_02b4: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+			IL_02b9: pop
+			IL_02ba: volatile.
+			IL_02bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_02c1: brfalse IL_02d6
+
+			IL_02c6: ldarg.2
+			IL_02c7: ldstr "upstream"
 			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02d1: br IL_02ec
+			IL_02d1: br IL_02eb
 
-			IL_02d6: ldloc.s 12
-			IL_02d8: ldstr "cloneUrl"
-			IL_02dd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:79"
-			IL_02e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02d6: ldarg.2
+			IL_02d7: ldstr "upstream"
+			IL_02dc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:82"
+			IL_02e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02ec: stloc.s 12
-			IL_02ee: ldloc.s 9
-			IL_02f0: ldloc.s 11
-			IL_02f2: ldloc.s 12
-			IL_02f4: ldstr "upstream.cloneUrl"
-			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02fe: pop
-			IL_02ff: ldarg.0
-			IL_0300: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_0305: stloc.s 12
-			IL_0307: ldc.i4.1
-			IL_0308: newarr [System.Runtime]System.Object
-			IL_030d: dup
-			IL_030e: ldc.i4.0
-			IL_030f: ldarg.0
-			IL_0310: stelem.ref
-			IL_0311: stloc.s 11
-			IL_0313: volatile.
-			IL_0315: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_031a: brfalse IL_032f
+			IL_02eb: stloc.s 9
+			IL_02ed: volatile.
+			IL_02ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_02f4: brfalse IL_030a
 
-			IL_031f: ldarg.2
-			IL_0320: ldstr "upstream"
-			IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_032a: br IL_0344
+			IL_02f9: ldloc.s 9
+			IL_02fb: ldstr "commit"
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0305: br IL_0320
 
-			IL_032f: ldarg.2
-			IL_0330: ldstr "upstream"
-			IL_0335: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:87"
-			IL_033a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_030a: ldloc.s 9
+			IL_030c: ldstr "commit"
+			IL_0311: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:84"
+			IL_0316: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0344: stloc.s 9
-			IL_0346: volatile.
-			IL_0348: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_034d: brfalse IL_0363
+			IL_0320: stloc.s 9
+			IL_0322: ldnull
+			IL_0323: ldloc.s 9
+			IL_0325: ldstr "upstream.commit"
+			IL_032a: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+			IL_032f: pop
+			IL_0330: volatile.
+			IL_0332: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0337: brfalse IL_034c
 
-			IL_0352: ldloc.s 9
-			IL_0354: ldstr "commit"
-			IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_035e: br IL_0379
+			IL_033c: ldarg.2
+			IL_033d: ldstr "upstream"
+			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0347: br IL_0361
 
-			IL_0363: ldloc.s 9
-			IL_0365: ldstr "commit"
-			IL_036a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:89"
-			IL_036f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_034c: ldarg.2
+			IL_034d: ldstr "upstream"
+			IL_0352: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:91"
+			IL_0357: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0379: stloc.s 9
-			IL_037b: ldloc.s 12
-			IL_037d: ldloc.s 11
-			IL_037f: ldloc.s 9
-			IL_0381: ldstr "upstream.commit"
-			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_038b: pop
-			IL_038c: ldarg.0
-			IL_038d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_0392: stloc.s 9
-			IL_0394: ldc.i4.1
-			IL_0395: newarr [System.Runtime]System.Object
-			IL_039a: dup
-			IL_039b: ldc.i4.0
-			IL_039c: ldarg.0
-			IL_039d: stelem.ref
-			IL_039e: stloc.s 11
-			IL_03a0: volatile.
-			IL_03a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_03a7: brfalse IL_03bc
+			IL_0361: stloc.s 9
+			IL_0363: volatile.
+			IL_0365: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_036a: brfalse IL_0380
 
-			IL_03ac: ldarg.2
-			IL_03ad: ldstr "upstream"
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b7: br IL_03d1
+			IL_036f: ldloc.s 9
+			IL_0371: ldstr "packageVersion"
+			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_037b: br IL_0396
 
-			IL_03bc: ldarg.2
-			IL_03bd: ldstr "upstream"
-			IL_03c2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:97"
-			IL_03c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0380: ldloc.s 9
+			IL_0382: ldstr "packageVersion"
+			IL_0387: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:93"
+			IL_038c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03d1: stloc.s 12
-			IL_03d3: volatile.
-			IL_03d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_03da: brfalse IL_03f0
+			IL_0396: stloc.s 9
+			IL_0398: ldnull
+			IL_0399: ldloc.s 9
+			IL_039b: ldstr "upstream.packageVersion"
+			IL_03a0: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+			IL_03a5: pop
+			IL_03a6: volatile.
+			IL_03a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_03ad: brfalse IL_03c2
 
-			IL_03df: ldloc.s 12
-			IL_03e1: ldstr "packageVersion"
-			IL_03e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03eb: br IL_0406
+			IL_03b2: ldarg.2
+			IL_03b3: ldstr "localOverrideEnvVar"
+			IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03bd: br IL_03d7
 
-			IL_03f0: ldloc.s 12
-			IL_03f2: ldstr "packageVersion"
-			IL_03f7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:99"
-			IL_03fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03c2: ldarg.2
+			IL_03c3: ldstr "localOverrideEnvVar"
+			IL_03c8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:100"
+			IL_03cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0406: stloc.s 12
-			IL_0408: ldloc.s 9
-			IL_040a: ldloc.s 11
-			IL_040c: ldloc.s 12
-			IL_040e: ldstr "upstream.packageVersion"
-			IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0418: pop
-			IL_0419: ldarg.0
-			IL_041a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_041f: stloc.s 12
-			IL_0421: ldc.i4.1
-			IL_0422: newarr [System.Runtime]System.Object
-			IL_0427: dup
-			IL_0428: ldc.i4.0
-			IL_0429: ldarg.0
-			IL_042a: stelem.ref
-			IL_042b: stloc.s 11
-			IL_042d: volatile.
-			IL_042f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_0434: brfalse IL_0449
+			IL_03d7: stloc.s 9
+			IL_03d9: ldnull
+			IL_03da: ldloc.s 9
+			IL_03dc: ldstr "localOverrideEnvVar"
+			IL_03e1: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+			IL_03e6: pop
+			IL_03e7: volatile.
+			IL_03e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_03ee: brfalse IL_0403
 
-			IL_0439: ldarg.2
-			IL_043a: ldstr "localOverrideEnvVar"
-			IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0444: br IL_045e
+			IL_03f3: ldarg.2
+			IL_03f4: ldstr "managedRoot"
+			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03fe: br IL_0418
 
-			IL_0449: ldarg.2
-			IL_044a: ldstr "localOverrideEnvVar"
-			IL_044f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:107"
-			IL_0454: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0403: ldarg.2
+			IL_0404: ldstr "managedRoot"
+			IL_0409: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:107"
+			IL_040e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_045e: stloc.s 9
-			IL_0460: ldloc.s 12
-			IL_0462: ldloc.s 11
-			IL_0464: ldloc.s 9
-			IL_0466: ldstr "localOverrideEnvVar"
-			IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0470: pop
-			IL_0471: ldarg.0
-			IL_0472: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_0477: stloc.s 9
-			IL_0479: ldc.i4.1
-			IL_047a: newarr [System.Runtime]System.Object
-			IL_047f: dup
-			IL_0480: ldc.i4.0
-			IL_0481: ldarg.0
-			IL_0482: stelem.ref
-			IL_0483: stloc.s 11
-			IL_0485: volatile.
-			IL_0487: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_048c: brfalse IL_04a1
+			IL_0418: stloc.s 9
+			IL_041a: ldnull
+			IL_041b: ldloc.s 9
+			IL_041d: ldstr "managedRoot"
+			IL_0422: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+			IL_0427: pop
+			IL_0428: volatile.
+			IL_042a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_042f: brfalse IL_0444
 
-			IL_0491: ldarg.2
-			IL_0492: ldstr "managedRoot"
-			IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_049c: br IL_04b6
+			IL_0434: ldarg.2
+			IL_0435: ldstr "lineEndings"
+			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_043f: br IL_0459
 
-			IL_04a1: ldarg.2
-			IL_04a2: ldstr "managedRoot"
-			IL_04a7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:115"
-			IL_04ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0444: ldarg.2
+			IL_0445: ldstr "lineEndings"
+			IL_044a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:114"
+			IL_044f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04b6: stloc.s 12
-			IL_04b8: ldloc.s 9
-			IL_04ba: ldloc.s 11
-			IL_04bc: ldloc.s 12
-			IL_04be: ldstr "managedRoot"
-			IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04c8: pop
-			IL_04c9: ldarg.0
-			IL_04ca: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_04cf: stloc.s 12
-			IL_04d1: ldc.i4.1
-			IL_04d2: newarr [System.Runtime]System.Object
-			IL_04d7: dup
-			IL_04d8: ldc.i4.0
-			IL_04d9: ldarg.0
-			IL_04da: stelem.ref
-			IL_04db: stloc.s 11
-			IL_04dd: volatile.
-			IL_04df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_04e4: brfalse IL_04f9
+			IL_0459: stloc.s 9
+			IL_045b: ldnull
+			IL_045c: ldloc.s 9
+			IL_045e: ldstr "lineEndings"
+			IL_0463: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+			IL_0468: pop
+			IL_0469: volatile.
+			IL_046b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0470: brfalse IL_0485
 
-			IL_04e9: ldarg.2
-			IL_04ea: ldstr "lineEndings"
-			IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04f4: br IL_050e
+			IL_0475: ldarg.2
+			IL_0476: ldstr "updateStrategy"
+			IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0480: br IL_049a
 
-			IL_04f9: ldarg.2
-			IL_04fa: ldstr "lineEndings"
-			IL_04ff: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:123"
-			IL_0504: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0485: ldarg.2
+			IL_0486: ldstr "updateStrategy"
+			IL_048b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:121"
+			IL_0490: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_050e: stloc.s 9
-			IL_0510: ldloc.s 12
-			IL_0512: ldloc.s 11
-			IL_0514: ldloc.s 9
-			IL_0516: ldstr "lineEndings"
-			IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0520: pop
-			IL_0521: ldarg.0
-			IL_0522: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
-			IL_0527: stloc.s 9
-			IL_0529: ldc.i4.1
-			IL_052a: newarr [System.Runtime]System.Object
-			IL_052f: dup
-			IL_0530: ldc.i4.0
-			IL_0531: ldarg.0
-			IL_0532: stelem.ref
-			IL_0533: stloc.s 11
-			IL_0535: volatile.
-			IL_0537: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_053c: brfalse IL_0551
+			IL_049a: stloc.s 9
+			IL_049c: ldnull
+			IL_049d: ldloc.s 9
+			IL_049f: ldstr "updateStrategy"
+			IL_04a4: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+			IL_04a9: pop
+			IL_04aa: volatile.
+			IL_04ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_04b1: brfalse IL_04c6
 
-			IL_0541: ldarg.2
-			IL_0542: ldstr "updateStrategy"
-			IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_054c: br IL_0566
+			IL_04b6: ldarg.2
+			IL_04b7: ldstr "includeFiles"
+			IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04c1: br IL_04db
 
-			IL_0551: ldarg.2
-			IL_0552: ldstr "updateStrategy"
-			IL_0557: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:131"
-			IL_055c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04c6: ldarg.2
+			IL_04c7: ldstr "includeFiles"
+			IL_04cc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:128"
+			IL_04d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0566: stloc.s 12
-			IL_0568: ldloc.s 9
-			IL_056a: ldloc.s 11
-			IL_056c: ldloc.s 12
-			IL_056e: ldstr "updateStrategy"
-			IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0578: pop
-			IL_0579: ldarg.0
-			IL_057a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_057f: stloc.s 12
-			IL_0581: ldc.i4.1
-			IL_0582: newarr [System.Runtime]System.Object
-			IL_0587: dup
-			IL_0588: ldc.i4.0
-			IL_0589: ldarg.0
-			IL_058a: stelem.ref
-			IL_058b: stloc.s 11
-			IL_058d: volatile.
-			IL_058f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_0594: brfalse IL_05a9
+			IL_04db: stloc.s 9
+			IL_04dd: ldnull
+			IL_04de: ldloc.s 9
+			IL_04e0: ldstr "includeFiles"
+			IL_04e5: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+			IL_04ea: pop
+			IL_04eb: volatile.
+			IL_04ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_04f2: brfalse IL_0507
 
-			IL_0599: ldarg.2
-			IL_059a: ldstr "includeFiles"
-			IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05a4: br IL_05be
+			IL_04f7: ldarg.2
+			IL_04f8: ldstr "includeDirectories"
+			IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0502: br IL_051c
 
-			IL_05a9: ldarg.2
-			IL_05aa: ldstr "includeFiles"
-			IL_05af: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:139"
-			IL_05b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0507: ldarg.2
+			IL_0508: ldstr "includeDirectories"
+			IL_050d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:135"
+			IL_0512: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0517: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_05be: stloc.s 9
-			IL_05c0: ldloc.s 12
-			IL_05c2: ldloc.s 11
-			IL_05c4: ldloc.s 9
-			IL_05c6: ldstr "includeFiles"
-			IL_05cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05d0: pop
-			IL_05d1: ldarg.0
-			IL_05d2: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_05d7: stloc.s 9
-			IL_05d9: ldc.i4.1
-			IL_05da: newarr [System.Runtime]System.Object
-			IL_05df: dup
-			IL_05e0: ldc.i4.0
-			IL_05e1: ldarg.0
-			IL_05e2: stelem.ref
-			IL_05e3: stloc.s 11
-			IL_05e5: volatile.
-			IL_05e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_05ec: brfalse IL_0601
+			IL_051c: stloc.s 9
+			IL_051e: ldnull
+			IL_051f: ldloc.s 9
+			IL_0521: ldstr "includeDirectories"
+			IL_0526: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+			IL_052b: pop
+			IL_052c: volatile.
+			IL_052e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0533: brfalse IL_0548
 
-			IL_05f1: ldarg.2
-			IL_05f2: ldstr "includeDirectories"
-			IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05fc: br IL_0616
+			IL_0538: ldarg.2
+			IL_0539: ldstr "requiredFiles"
+			IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0543: br IL_055d
 
-			IL_0601: ldarg.2
-			IL_0602: ldstr "includeDirectories"
-			IL_0607: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:147"
-			IL_060c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0548: ldarg.2
+			IL_0549: ldstr "requiredFiles"
+			IL_054e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:142"
+			IL_0553: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0616: stloc.s 12
-			IL_0618: ldloc.s 9
-			IL_061a: ldloc.s 11
-			IL_061c: ldloc.s 12
-			IL_061e: ldstr "includeDirectories"
-			IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0628: pop
-			IL_0629: ldarg.0
-			IL_062a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_062f: stloc.s 12
-			IL_0631: ldc.i4.1
-			IL_0632: newarr [System.Runtime]System.Object
-			IL_0637: dup
-			IL_0638: ldc.i4.0
-			IL_0639: ldarg.0
-			IL_063a: stelem.ref
-			IL_063b: stloc.s 11
-			IL_063d: volatile.
-			IL_063f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_0644: brfalse IL_0659
+			IL_055d: stloc.s 9
+			IL_055f: ldnull
+			IL_0560: ldloc.s 9
+			IL_0562: ldstr "requiredFiles"
+			IL_0567: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+			IL_056c: pop
+			IL_056d: volatile.
+			IL_056f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_0574: brfalse IL_0589
 
-			IL_0649: ldarg.2
-			IL_064a: ldstr "requiredFiles"
-			IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0654: br IL_066e
+			IL_0579: ldarg.2
+			IL_057a: ldstr "requiredDirectories"
+			IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0584: br IL_059e
 
-			IL_0659: ldarg.2
-			IL_065a: ldstr "requiredFiles"
-			IL_065f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:155"
-			IL_0664: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0589: ldarg.2
+			IL_058a: ldstr "requiredDirectories"
+			IL_058f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:149"
+			IL_0594: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_066e: stloc.s 9
-			IL_0670: ldloc.s 12
-			IL_0672: ldloc.s 11
-			IL_0674: ldloc.s 9
-			IL_0676: ldstr "requiredFiles"
-			IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0680: pop
-			IL_0681: ldarg.0
-			IL_0682: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_0687: stloc.s 9
-			IL_0689: ldc.i4.1
-			IL_068a: newarr [System.Runtime]System.Object
-			IL_068f: dup
-			IL_0690: ldc.i4.0
-			IL_0691: ldarg.0
-			IL_0692: stelem.ref
-			IL_0693: stloc.s 11
-			IL_0695: volatile.
-			IL_0697: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_069c: brfalse IL_06b1
+			IL_059e: stloc.s 9
+			IL_05a0: ldnull
+			IL_05a1: ldloc.s 9
+			IL_05a3: ldstr "requiredDirectories"
+			IL_05a8: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+			IL_05ad: pop
+			IL_05ae: volatile.
+			IL_05b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_05b5: brfalse IL_05ca
 
-			IL_06a1: ldarg.2
-			IL_06a2: ldstr "requiredDirectories"
-			IL_06a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06ac: br IL_06c6
+			IL_05ba: ldarg.2
+			IL_05bb: ldstr "defaultHarnessFiles"
+			IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05c5: br IL_05df
 
-			IL_06b1: ldarg.2
-			IL_06b2: ldstr "requiredDirectories"
-			IL_06b7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:163"
-			IL_06bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_05ca: ldarg.2
+			IL_05cb: ldstr "defaultHarnessFiles"
+			IL_05d0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:156"
+			IL_05d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_05da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06c6: stloc.s 12
-			IL_06c8: ldloc.s 9
-			IL_06ca: ldloc.s 11
-			IL_06cc: ldloc.s 12
-			IL_06ce: ldstr "requiredDirectories"
-			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06d8: pop
-			IL_06d9: ldarg.0
-			IL_06da: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_06df: stloc.s 12
-			IL_06e1: ldc.i4.1
-			IL_06e2: newarr [System.Runtime]System.Object
-			IL_06e7: dup
-			IL_06e8: ldc.i4.0
-			IL_06e9: ldarg.0
-			IL_06ea: stelem.ref
-			IL_06eb: stloc.s 11
-			IL_06ed: volatile.
-			IL_06ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_06f4: brfalse IL_0709
+			IL_05df: stloc.s 9
+			IL_05e1: ldnull
+			IL_05e2: ldloc.s 9
+			IL_05e4: ldstr "defaultHarnessFiles"
+			IL_05e9: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+			IL_05ee: pop
+			IL_05ef: volatile.
+			IL_05f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_05f6: brfalse IL_060b
 
-			IL_06f9: ldarg.2
-			IL_06fa: ldstr "defaultHarnessFiles"
-			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0704: br IL_071e
+			IL_05fb: ldarg.2
+			IL_05fc: ldstr "excludedFromMvp"
+			IL_0601: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0606: br IL_0620
 
-			IL_0709: ldarg.2
-			IL_070a: ldstr "defaultHarnessFiles"
-			IL_070f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:171"
-			IL_0714: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_060b: ldarg.2
+			IL_060c: ldstr "excludedFromMvp"
+			IL_0611: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:163"
+			IL_0616: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_061b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_071e: stloc.s 9
-			IL_0720: ldloc.s 12
-			IL_0722: ldloc.s 11
-			IL_0724: ldloc.s 9
-			IL_0726: ldstr "defaultHarnessFiles"
-			IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0730: pop
-			IL_0731: ldarg.0
-			IL_0732: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateExcludedFromMvp
-			IL_0737: stloc.s 9
-			IL_0739: ldc.i4.1
-			IL_073a: newarr [System.Runtime]System.Object
-			IL_073f: dup
-			IL_0740: ldc.i4.0
-			IL_0741: ldarg.0
-			IL_0742: stelem.ref
-			IL_0743: stloc.s 11
-			IL_0745: volatile.
-			IL_0747: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_074c: brfalse IL_0761
+			IL_0620: stloc.s 9
+			IL_0622: ldarg.0
+			IL_0623: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0628: ldnull
+			IL_0629: ldloc.s 9
+			IL_062b: call object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0630: pop
+			IL_0631: volatile.
+			IL_0633: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_0638: brfalse IL_064d
 
-			IL_0751: ldarg.2
-			IL_0752: ldstr "excludedFromMvp"
-			IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_075c: br IL_0776
+			IL_063d: ldarg.2
+			IL_063e: ldstr "attributionFiles"
+			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0648: br IL_0662
 
-			IL_0761: ldarg.2
-			IL_0762: ldstr "excludedFromMvp"
-			IL_0767: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:179"
-			IL_076c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_064d: ldarg.2
+			IL_064e: ldstr "attributionFiles"
+			IL_0653: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:169"
+			IL_0658: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0776: stloc.s 12
-			IL_0778: ldloc.s 9
-			IL_077a: ldloc.s 11
-			IL_077c: ldloc.s 12
-			IL_077e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0783: pop
-			IL_0784: ldarg.0
-			IL_0785: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
-			IL_078a: stloc.s 12
-			IL_078c: ldc.i4.1
-			IL_078d: newarr [System.Runtime]System.Object
-			IL_0792: dup
-			IL_0793: ldc.i4.0
-			IL_0794: ldarg.0
-			IL_0795: stelem.ref
-			IL_0796: stloc.s 11
-			IL_0798: volatile.
-			IL_079a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_079f: brfalse IL_07b4
+			IL_0662: stloc.s 9
+			IL_0664: ldnull
+			IL_0665: ldloc.s 9
+			IL_0667: ldstr "attributionFiles"
+			IL_066c: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+			IL_0671: pop
+			IL_0672: ldstr "^[0-9a-f]{40}$"
+			IL_0677: ldstr "i"
+			IL_067c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0681: stloc.s 11
+			IL_0683: volatile.
+			IL_0685: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_068a: brfalse IL_069f
 
-			IL_07a4: ldarg.2
-			IL_07a5: ldstr "attributionFiles"
-			IL_07aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07af: br IL_07c9
+			IL_068f: ldarg.2
+			IL_0690: ldstr "upstream"
+			IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_069a: br IL_06b4
 
-			IL_07b4: ldarg.2
-			IL_07b5: ldstr "attributionFiles"
-			IL_07ba: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:186"
-			IL_07bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_069f: ldarg.2
+			IL_06a0: ldstr "upstream"
+			IL_06a5: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:179"
+			IL_06aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07c9: stloc.s 9
-			IL_07cb: ldloc.s 12
-			IL_07cd: ldloc.s 11
-			IL_07cf: ldloc.s 9
-			IL_07d1: ldstr "attributionFiles"
-			IL_07d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07db: pop
-			IL_07dc: ldstr "^[0-9a-f]{40}$"
-			IL_07e1: ldstr "i"
-			IL_07e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_07eb: stloc.s 13
-			IL_07ed: volatile.
-			IL_07ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_07f4: brfalse IL_0809
+			IL_06b4: stloc.s 9
+			IL_06b6: volatile.
+			IL_06b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_06bd: brfalse IL_06d3
 
-			IL_07f9: ldarg.2
-			IL_07fa: ldstr "upstream"
-			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0804: br IL_081e
+			IL_06c2: ldloc.s 9
+			IL_06c4: ldstr "commit"
+			IL_06c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06ce: br IL_06e9
 
-			IL_0809: ldarg.2
-			IL_080a: ldstr "upstream"
-			IL_080f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:195"
-			IL_0814: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_0819: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06d3: ldloc.s 9
+			IL_06d5: ldstr "commit"
+			IL_06da: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:181"
+			IL_06df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_081e: stloc.s 9
-			IL_0820: volatile.
-			IL_0822: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_0827: brfalse IL_083d
+			IL_06e9: stloc.s 9
+			IL_06eb: ldloc.s 11
+			IL_06ed: ldloc.s 9
+			IL_06ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_06f4: stloc.s 9
+			IL_06f6: ldloc.s 9
+			IL_06f8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06fd: ldc.i4.0
+			IL_06fe: ceq
+			IL_0700: stloc.3
+			IL_0701: ldloc.3
+			IL_0702: brfalse IL_0727
 
-			IL_082c: ldloc.s 9
-			IL_082e: ldstr "commit"
-			IL_0833: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0838: br IL_0853
+			IL_0707: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
+			IL_070c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0711: stloc.2
+			IL_0712: ldloc.2
+			IL_0713: isinst [System.Runtime]System.Exception
+			IL_0718: dup
+			IL_0719: brtrue IL_0726
 
-			IL_083d: ldloc.s 9
-			IL_083f: ldstr "commit"
-			IL_0844: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M36>:__js_call__:197"
-			IL_0849: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_071e: pop
+			IL_071f: ldloc.2
+			IL_0720: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0725: throw
 
-			IL_0853: stloc.s 9
-			IL_0855: ldloc.s 13
-			IL_0857: ldloc.s 9
-			IL_0859: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_085e: stloc.s 9
-			IL_0860: ldloc.s 9
-			IL_0862: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0867: ldc.i4.0
-			IL_0868: ceq
-			IL_086a: stloc.3
-			IL_086b: ldloc.3
-			IL_086c: brfalse IL_0891
+			IL_0726: throw
 
-			IL_0871: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
-			IL_0876: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_087b: stloc.2
-			IL_087c: ldloc.2
-			IL_087d: isinst [System.Runtime]System.Exception
-			IL_0882: dup
-			IL_0883: brtrue IL_0890
-
-			IL_0888: pop
-			IL_0889: ldloc.2
-			IL_088a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_088f: throw
-
-			IL_0890: throw
-
-			IL_0891: ldnull
-			IL_0892: ret
+			IL_0727: ldnull
+			IL_0728: ret
 		} // end of method validatePin::__js_call__
 
 	} // end of class validatePin
@@ -4305,13 +4107,12 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 94 (0x5e)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
-				[3] object
+				[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule
 			)
 
 			IL_0000: ldarg.0
@@ -4348,20 +4149,13 @@
 			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
 			IL_004d: stloc.1
 			IL_004e: ldarg.0
-			IL_004f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
-			IL_0054: stloc.3
-			IL_0055: ldloc.3
-			IL_0056: ldc.i4.1
-			IL_0057: newarr [System.Runtime]System.Object
-			IL_005c: dup
-			IL_005d: ldc.i4.0
-			IL_005e: ldarg.0
-			IL_005f: stelem.ref
-			IL_0060: ldloc.1
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0066: pop
-			IL_0067: ldloc.1
-			IL_0068: ret
+			IL_004f: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0054: ldnull
+			IL_0055: ldloc.1
+			IL_0056: call object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_005b: pop
+			IL_005c: ldloc.1
+			IL_005d: ret
 		} // end of method loadPin::__js_call__
 
 	} // end of class loadPin
@@ -4790,14 +4584,14 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 273 (0x111)
+			// Code size: 256 (0x100)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
 				[1] object,
-				[2] object[],
+				[2] object,
 				[3] object,
-				[4] object
+				[4] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -4821,88 +4615,81 @@
 			IL_002f: ldloc.1
 			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0035: stloc.1
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-			IL_003c: ldc.i4.1
-			IL_003d: newarr [System.Runtime]System.Object
-			IL_0042: dup
-			IL_0043: ldc.i4.0
-			IL_0044: ldarg.0
-			IL_0045: stelem.ref
-			IL_0046: stloc.2
-			IL_0047: volatile.
-			IL_0049: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_004e: brfalse IL_0063
+			IL_0036: volatile.
+			IL_0038: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_003d: brfalse IL_0052
 
-			IL_0053: ldarg.2
-			IL_0054: ldstr "managedRoot"
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005e: br IL_0078
+			IL_0042: ldarg.2
+			IL_0043: ldstr "managedRoot"
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004d: br IL_0067
 
-			IL_0063: ldarg.2
-			IL_0064: ldstr "managedRoot"
-			IL_0069: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:8"
-			IL_006e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0052: ldarg.2
+			IL_0053: ldstr "managedRoot"
+			IL_0058: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:6"
+			IL_005d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0078: stloc.3
-			IL_0079: ldloc.2
-			IL_007a: ldloc.3
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0080: stloc.3
-			IL_0081: volatile.
-			IL_0083: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_0088: brfalse IL_009d
+			IL_0067: stloc.2
+			IL_0068: ldarg.0
+			IL_0069: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_006e: ldnull
+			IL_006f: ldloc.2
+			IL_0070: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0075: stloc.2
+			IL_0076: volatile.
+			IL_0078: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_007d: brfalse IL_0092
 
-			IL_008d: ldarg.2
-			IL_008e: ldstr "upstream"
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0098: br IL_00b2
+			IL_0082: ldarg.2
+			IL_0083: ldstr "upstream"
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008d: br IL_00a7
 
-			IL_009d: ldarg.2
-			IL_009e: ldstr "upstream"
-			IL_00a3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:12"
-			IL_00a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0092: ldarg.2
+			IL_0093: ldstr "upstream"
+			IL_0098: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:11"
+			IL_009d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00b2: stloc.s 4
-			IL_00b4: volatile.
-			IL_00b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-			IL_00bb: brfalse IL_00d1
+			IL_00a7: stloc.3
+			IL_00a8: volatile.
+			IL_00aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_00af: brfalse IL_00c4
 
-			IL_00c0: ldloc.s 4
-			IL_00c2: ldstr "commit"
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00cc: br IL_00e7
+			IL_00b4: ldloc.3
+			IL_00b5: ldstr "commit"
+			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bf: br IL_00d9
 
-			IL_00d1: ldloc.s 4
-			IL_00d3: ldstr "commit"
-			IL_00d8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:14"
-			IL_00dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00c4: ldloc.3
+			IL_00c5: ldstr "commit"
+			IL_00ca: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M39>:__js_call__:13"
+			IL_00cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00e7: stloc.s 4
-			IL_00e9: ldloc.1
-			IL_00ea: ldstr "join"
-			IL_00ef: ldloc.3
-			IL_00f0: ldloc.s 4
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00f7: stloc.s 4
-			IL_00f9: ldc.i4.1
-			IL_00fa: newarr [System.Runtime]System.Object
-			IL_00ff: dup
-			IL_0100: ldc.i4.0
-			IL_0101: ldarg.0
-			IL_0102: stelem.ref
-			IL_0103: stloc.2
-			IL_0104: ldnull
-			IL_0105: ldloc.s 4
-			IL_0107: tail.
-			IL_0109: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_010e: ret
+			IL_00d9: stloc.3
+			IL_00da: ldloc.1
+			IL_00db: ldstr "join"
+			IL_00e0: ldloc.2
+			IL_00e1: ldloc.3
+			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00e7: stloc.3
+			IL_00e8: ldc.i4.1
+			IL_00e9: newarr [System.Runtime]System.Object
+			IL_00ee: dup
+			IL_00ef: ldc.i4.0
+			IL_00f0: ldarg.0
+			IL_00f1: stelem.ref
+			IL_00f2: stloc.s 4
+			IL_00f4: ldnull
+			IL_00f5: ldloc.3
+			IL_00f6: tail.
+			IL_00f8: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_00fd: ret
 
-			IL_010f: ldnull
-			IL_0110: ret
+			IL_00fe: ldnull
+			IL_00ff: ret
 		} // end of method resolveManagedCheckoutLabel::__js_call__
 
 	} // end of class resolveManagedCheckoutLabel
@@ -5080,7 +4867,7 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 431 (0x1af)
+			// Code size: 422 (0x1a6)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5230,28 +5017,23 @@
 			IL_0175: stloc.1
 
 			IL_0176: ldarg.0
-			IL_0177: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
-			IL_017c: ldc.i4.1
-			IL_017d: newarr [System.Runtime]System.Object
-			IL_0182: dup
-			IL_0183: ldc.i4.0
-			IL_0184: ldarg.0
-			IL_0185: stelem.ref
-			IL_0186: ldloc.0
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_018c: stloc.2
-			IL_018d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0192: dup
-			IL_0193: ldstr "source"
-			IL_0198: ldloc.1
-			IL_0199: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_019e: dup
-			IL_019f: ldstr "rootPath"
-			IL_01a4: ldloc.2
-			IL_01a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01aa: stloc.s 9
-			IL_01ac: ldloc.s 9
-			IL_01ae: ret
+			IL_0177: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_017c: ldnull
+			IL_017d: ldloc.0
+			IL_017e: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0183: stloc.2
+			IL_0184: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0189: dup
+			IL_018a: ldstr "source"
+			IL_018f: ldloc.1
+			IL_0190: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0195: dup
+			IL_0196: ldstr "rootPath"
+			IL_019b: ldloc.2
+			IL_019c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01a1: stloc.s 9
+			IL_01a3: ldloc.s 9
+			IL_01a5: ret
 		} // end of method resolveOverrideRoot::__js_call__
 
 	} // end of class resolveOverrideRoot
@@ -5429,7 +5211,7 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2154 (0x86a)
+			// Code size: 2103 (0x837)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5440,7 +5222,7 @@
 				[5] string,
 				[6] string,
 				[7] string,
-				[8] object[],
+				[8] string,
 				[9] string,
 				[10] string,
 				[11] string,
@@ -5451,8 +5233,7 @@
 				[16] string,
 				[17] string,
 				[18] string,
-				[19] string,
-				[20] string
+				[19] string
 			)
 
 			IL_0000: ldarg.3
@@ -5592,554 +5373,529 @@
 			IL_01a5: ldloc.s 7
 			IL_01a7: call string [System.Runtime]System.String::Concat(string, string)
 			IL_01ac: stloc.s 7
-			IL_01ae: ldarg.0
-			IL_01af: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
-			IL_01b4: ldc.i4.1
-			IL_01b5: newarr [System.Runtime]System.Object
-			IL_01ba: dup
-			IL_01bb: ldc.i4.0
-			IL_01bc: ldarg.0
-			IL_01bd: stelem.ref
-			IL_01be: stloc.s 8
-			IL_01c0: volatile.
-			IL_01c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
-			IL_01c7: brfalse IL_01dc
+			IL_01ae: volatile.
+			IL_01b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+			IL_01b5: brfalse IL_01ca
 
-			IL_01cc: ldarg.2
-			IL_01cd: ldstr "managedRoot"
-			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d7: br IL_01f1
+			IL_01ba: ldarg.2
+			IL_01bb: ldstr "managedRoot"
+			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01c5: br IL_01df
 
-			IL_01dc: ldarg.2
-			IL_01dd: ldstr "managedRoot"
-			IL_01e2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:43"
-			IL_01e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01ca: ldarg.2
+			IL_01cb: ldstr "managedRoot"
+			IL_01d0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:41"
+			IL_01d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01f1: stloc.s 4
-			IL_01f3: ldloc.s 8
-			IL_01f5: ldloc.s 4
-			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01fc: stloc.s 4
-			IL_01fe: ldloc.s 4
-			IL_0200: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0205: stloc.s 9
-			IL_0207: ldstr "managedRoot "
-			IL_020c: ldloc.s 9
-			IL_020e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0213: stloc.s 9
-			IL_0215: ldarg.0
-			IL_0216: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
-			IL_021b: ldc.i4.1
-			IL_021c: newarr [System.Runtime]System.Object
-			IL_0221: dup
-			IL_0222: ldc.i4.0
-			IL_0223: ldarg.0
-			IL_0224: stelem.ref
-			IL_0225: stloc.s 8
-			IL_0227: ldloc.s 8
-			IL_0229: ldarg.2
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_022f: stloc.s 4
-			IL_0231: ldloc.s 4
-			IL_0233: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0238: stloc.s 10
-			IL_023a: ldstr "checkoutDir "
-			IL_023f: ldloc.s 10
-			IL_0241: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0246: stloc.s 10
-			IL_0248: volatile.
-			IL_024a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-			IL_024f: brfalse IL_0264
+			IL_01df: stloc.s 4
+			IL_01e1: ldnull
+			IL_01e2: ldloc.s 4
+			IL_01e4: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_01e9: stloc.s 4
+			IL_01eb: ldloc.s 4
+			IL_01ed: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01f2: stloc.s 8
+			IL_01f4: ldstr "managedRoot "
+			IL_01f9: ldloc.s 8
+			IL_01fb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0200: stloc.s 8
+			IL_0202: ldarg.0
+			IL_0203: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0208: ldnull
+			IL_0209: ldarg.2
+			IL_020a: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_020f: stloc.s 4
+			IL_0211: ldloc.s 4
+			IL_0213: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0218: stloc.s 9
+			IL_021a: ldstr "checkoutDir "
+			IL_021f: ldloc.s 9
+			IL_0221: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0226: stloc.s 9
+			IL_0228: volatile.
+			IL_022a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+			IL_022f: brfalse IL_0244
 
-			IL_0254: ldarg.2
-			IL_0255: ldstr "localOverrideEnvVar"
-			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025f: br IL_0279
+			IL_0234: ldarg.2
+			IL_0235: ldstr "localOverrideEnvVar"
+			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023f: br IL_0259
 
-			IL_0264: ldarg.2
-			IL_0265: ldstr "localOverrideEnvVar"
-			IL_026a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:57"
-			IL_026f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0244: ldarg.2
+			IL_0245: ldstr "localOverrideEnvVar"
+			IL_024a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:55"
+			IL_024f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0279: stloc.s 4
-			IL_027b: ldloc.s 4
-			IL_027d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0282: stloc.s 11
-			IL_0284: ldstr "overrideEnv "
-			IL_0289: ldloc.s 11
-			IL_028b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0290: stloc.s 11
-			IL_0292: volatile.
-			IL_0294: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-			IL_0299: brfalse IL_02ae
+			IL_0259: stloc.s 4
+			IL_025b: ldloc.s 4
+			IL_025d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0262: stloc.s 10
+			IL_0264: ldstr "overrideEnv "
+			IL_0269: ldloc.s 10
+			IL_026b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0270: stloc.s 10
+			IL_0272: volatile.
+			IL_0274: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
+			IL_0279: brfalse IL_028e
 
-			IL_029e: ldarg.2
-			IL_029f: ldstr "lineEndings"
-			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a9: br IL_02c3
+			IL_027e: ldarg.2
+			IL_027f: ldstr "lineEndings"
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0289: br IL_02a3
 
-			IL_02ae: ldarg.2
-			IL_02af: ldstr "lineEndings"
-			IL_02b4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:63"
-			IL_02b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_028e: ldarg.2
+			IL_028f: ldstr "lineEndings"
+			IL_0294: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:61"
+			IL_0299: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
+			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02c3: stloc.s 4
-			IL_02c5: ldloc.s 4
-			IL_02c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02cc: stloc.s 12
-			IL_02ce: ldstr "lineEndings "
-			IL_02d3: ldloc.s 12
-			IL_02d5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02da: stloc.s 12
-			IL_02dc: volatile.
-			IL_02de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-			IL_02e3: brfalse IL_02f8
+			IL_02a3: stloc.s 4
+			IL_02a5: ldloc.s 4
+			IL_02a7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02ac: stloc.s 11
+			IL_02ae: ldstr "lineEndings "
+			IL_02b3: ldloc.s 11
+			IL_02b5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02ba: stloc.s 11
+			IL_02bc: volatile.
+			IL_02be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
+			IL_02c3: brfalse IL_02d8
 
-			IL_02e8: ldarg.2
-			IL_02e9: ldstr "updateStrategy"
-			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f3: br IL_030d
+			IL_02c8: ldarg.2
+			IL_02c9: ldstr "updateStrategy"
+			IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d3: br IL_02ed
 
-			IL_02f8: ldarg.2
-			IL_02f9: ldstr "updateStrategy"
-			IL_02fe: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:69"
-			IL_0303: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-			IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02d8: ldarg.2
+			IL_02d9: ldstr "updateStrategy"
+			IL_02de: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:67"
+			IL_02e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
+			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_030d: stloc.s 4
-			IL_030f: ldloc.s 4
-			IL_0311: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0316: stloc.s 13
-			IL_0318: ldstr "updateStrategy "
-			IL_031d: ldloc.s 13
-			IL_031f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0324: stloc.s 13
-			IL_0326: volatile.
-			IL_0328: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-			IL_032d: brfalse IL_0342
+			IL_02ed: stloc.s 4
+			IL_02ef: ldloc.s 4
+			IL_02f1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02f6: stloc.s 12
+			IL_02f8: ldstr "updateStrategy "
+			IL_02fd: ldloc.s 12
+			IL_02ff: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0304: stloc.s 12
+			IL_0306: volatile.
+			IL_0308: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+			IL_030d: brfalse IL_0322
 
-			IL_0332: ldarg.2
-			IL_0333: ldstr "includeFiles"
-			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_033d: br IL_0357
+			IL_0312: ldarg.2
+			IL_0313: ldstr "includeFiles"
+			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_031d: br IL_0337
 
-			IL_0342: ldarg.2
-			IL_0343: ldstr "includeFiles"
-			IL_0348: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:75"
-			IL_034d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0322: ldarg.2
+			IL_0323: ldstr "includeFiles"
+			IL_0328: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:73"
+			IL_032d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0357: stloc.s 4
-			IL_0359: ldloc.s 4
-			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0360: volatile.
-			IL_0362: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-			IL_0367: brfalse IL_0380
+			IL_0337: stloc.s 4
+			IL_0339: ldloc.s 4
+			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0340: volatile.
+			IL_0342: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+			IL_0347: brfalse IL_0360
 
-			IL_036c: ldstr "join"
-			IL_0371: ldstr ", "
-			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_037b: br IL_0399
+			IL_034c: ldstr "join"
+			IL_0351: ldstr ", "
+			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_035b: br IL_0379
 
-			IL_0380: ldstr "join"
-			IL_0385: ldstr ", "
-			IL_038a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:78"
-			IL_038f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-			IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0360: ldstr "join"
+			IL_0365: ldstr ", "
+			IL_036a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:76"
+			IL_036f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0399: stloc.s 4
-			IL_039b: ldloc.s 4
-			IL_039d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03a2: stloc.s 14
-			IL_03a4: ldstr "includeFiles "
-			IL_03a9: ldloc.s 14
-			IL_03ab: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03b0: stloc.s 14
-			IL_03b2: volatile.
-			IL_03b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-			IL_03b9: brfalse IL_03ce
+			IL_0379: stloc.s 4
+			IL_037b: ldloc.s 4
+			IL_037d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0382: stloc.s 13
+			IL_0384: ldstr "includeFiles "
+			IL_0389: ldloc.s 13
+			IL_038b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0390: stloc.s 13
+			IL_0392: volatile.
+			IL_0394: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+			IL_0399: brfalse IL_03ae
 
-			IL_03be: ldarg.2
-			IL_03bf: ldstr "includeDirectories"
-			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c9: br IL_03e3
+			IL_039e: ldarg.2
+			IL_039f: ldstr "includeDirectories"
+			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a9: br IL_03c3
 
-			IL_03ce: ldarg.2
-			IL_03cf: ldstr "includeDirectories"
-			IL_03d4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:84"
-			IL_03d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03ae: ldarg.2
+			IL_03af: ldstr "includeDirectories"
+			IL_03b4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:82"
+			IL_03b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03e3: stloc.s 4
-			IL_03e5: ldloc.s 4
-			IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ec: volatile.
-			IL_03ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-			IL_03f3: brfalse IL_040c
+			IL_03c3: stloc.s 4
+			IL_03c5: ldloc.s 4
+			IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03cc: volatile.
+			IL_03ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+			IL_03d3: brfalse IL_03ec
 
-			IL_03f8: ldstr "join"
-			IL_03fd: ldstr ", "
-			IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0407: br IL_0425
+			IL_03d8: ldstr "join"
+			IL_03dd: ldstr ", "
+			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03e7: br IL_0405
 
-			IL_040c: ldstr "join"
-			IL_0411: ldstr ", "
-			IL_0416: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:87"
-			IL_041b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_03ec: ldstr "join"
+			IL_03f1: ldstr ", "
+			IL_03f6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:85"
+			IL_03fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0425: stloc.s 4
-			IL_0427: ldloc.s 4
-			IL_0429: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_042e: stloc.s 15
-			IL_0430: ldstr "includeDirectories "
-			IL_0435: ldloc.s 15
-			IL_0437: call string [System.Runtime]System.String::Concat(string, string)
-			IL_043c: stloc.s 15
-			IL_043e: volatile.
-			IL_0440: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-			IL_0445: brfalse IL_045a
+			IL_0405: stloc.s 4
+			IL_0407: ldloc.s 4
+			IL_0409: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_040e: stloc.s 14
+			IL_0410: ldstr "includeDirectories "
+			IL_0415: ldloc.s 14
+			IL_0417: call string [System.Runtime]System.String::Concat(string, string)
+			IL_041c: stloc.s 14
+			IL_041e: volatile.
+			IL_0420: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+			IL_0425: brfalse IL_043a
 
-			IL_044a: ldarg.2
-			IL_044b: ldstr "requiredFiles"
-			IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0455: br IL_046f
+			IL_042a: ldarg.2
+			IL_042b: ldstr "requiredFiles"
+			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0435: br IL_044f
 
-			IL_045a: ldarg.2
-			IL_045b: ldstr "requiredFiles"
-			IL_0460: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:93"
-			IL_0465: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_043a: ldarg.2
+			IL_043b: ldstr "requiredFiles"
+			IL_0440: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:91"
+			IL_0445: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+			IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_046f: stloc.s 4
-			IL_0471: ldloc.s 4
-			IL_0473: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0478: volatile.
-			IL_047a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
-			IL_047f: brfalse IL_0498
+			IL_044f: stloc.s 4
+			IL_0451: ldloc.s 4
+			IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0458: volatile.
+			IL_045a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_045f: brfalse IL_0478
 
-			IL_0484: ldstr "join"
-			IL_0489: ldstr ", "
-			IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0493: br IL_04b1
+			IL_0464: ldstr "join"
+			IL_0469: ldstr ", "
+			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0473: br IL_0491
 
-			IL_0498: ldstr "join"
-			IL_049d: ldstr ", "
-			IL_04a2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:96"
-			IL_04a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
-			IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0478: ldstr "join"
+			IL_047d: ldstr ", "
+			IL_0482: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:94"
+			IL_0487: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_04b1: stloc.s 4
-			IL_04b3: ldloc.s 4
-			IL_04b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04ba: stloc.s 16
-			IL_04bc: ldstr "requiredFiles "
-			IL_04c1: ldloc.s 16
-			IL_04c3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04c8: stloc.s 16
-			IL_04ca: volatile.
-			IL_04cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
-			IL_04d1: brfalse IL_04e6
+			IL_0491: stloc.s 4
+			IL_0493: ldloc.s 4
+			IL_0495: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_049a: stloc.s 15
+			IL_049c: ldstr "requiredFiles "
+			IL_04a1: ldloc.s 15
+			IL_04a3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04a8: stloc.s 15
+			IL_04aa: volatile.
+			IL_04ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_04b1: brfalse IL_04c6
 
-			IL_04d6: ldarg.2
-			IL_04d7: ldstr "requiredDirectories"
-			IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04e1: br IL_04fb
+			IL_04b6: ldarg.2
+			IL_04b7: ldstr "requiredDirectories"
+			IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04c1: br IL_04db
 
-			IL_04e6: ldarg.2
-			IL_04e7: ldstr "requiredDirectories"
-			IL_04ec: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:102"
-			IL_04f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
-			IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04c6: ldarg.2
+			IL_04c7: ldstr "requiredDirectories"
+			IL_04cc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:100"
+			IL_04d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04fb: stloc.s 4
-			IL_04fd: ldloc.s 4
-			IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0504: volatile.
-			IL_0506: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
-			IL_050b: brfalse IL_0524
+			IL_04db: stloc.s 4
+			IL_04dd: ldloc.s 4
+			IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04e4: volatile.
+			IL_04e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_04eb: brfalse IL_0504
 
-			IL_0510: ldstr "join"
-			IL_0515: ldstr ", "
-			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_051f: br IL_053d
+			IL_04f0: ldstr "join"
+			IL_04f5: ldstr ", "
+			IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04ff: br IL_051d
 
-			IL_0524: ldstr "join"
-			IL_0529: ldstr ", "
-			IL_052e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:105"
-			IL_0533: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
-			IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0504: ldstr "join"
+			IL_0509: ldstr ", "
+			IL_050e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:103"
+			IL_0513: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_053d: stloc.s 4
-			IL_053f: ldloc.s 4
-			IL_0541: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0546: stloc.s 17
-			IL_0548: ldstr "requiredDirectories "
-			IL_054d: ldloc.s 17
-			IL_054f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0554: stloc.s 17
-			IL_0556: volatile.
-			IL_0558: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
-			IL_055d: brfalse IL_0572
+			IL_051d: stloc.s 4
+			IL_051f: ldloc.s 4
+			IL_0521: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0526: stloc.s 16
+			IL_0528: ldstr "requiredDirectories "
+			IL_052d: ldloc.s 16
+			IL_052f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0534: stloc.s 16
+			IL_0536: volatile.
+			IL_0538: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+			IL_053d: brfalse IL_0552
 
-			IL_0562: ldarg.2
-			IL_0563: ldstr "defaultHarnessFiles"
-			IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_056d: br IL_0587
+			IL_0542: ldarg.2
+			IL_0543: ldstr "defaultHarnessFiles"
+			IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_054d: br IL_0567
 
-			IL_0572: ldarg.2
-			IL_0573: ldstr "defaultHarnessFiles"
-			IL_0578: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:111"
-			IL_057d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
-			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0552: ldarg.2
+			IL_0553: ldstr "defaultHarnessFiles"
+			IL_0558: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:109"
+			IL_055d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+			IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0587: stloc.s 4
-			IL_0589: ldloc.s 4
-			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0590: volatile.
-			IL_0592: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
-			IL_0597: brfalse IL_05b0
+			IL_0567: stloc.s 4
+			IL_0569: ldloc.s 4
+			IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0570: volatile.
+			IL_0572: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
+			IL_0577: brfalse IL_0590
 
-			IL_059c: ldstr "join"
-			IL_05a1: ldstr ", "
-			IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05ab: br IL_05c9
+			IL_057c: ldstr "join"
+			IL_0581: ldstr ", "
+			IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_058b: br IL_05a9
 
-			IL_05b0: ldstr "join"
-			IL_05b5: ldstr ", "
-			IL_05ba: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:114"
-			IL_05bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
-			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0590: ldstr "join"
+			IL_0595: ldstr ", "
+			IL_059a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:112"
+			IL_059f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
+			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_05c9: stloc.s 4
-			IL_05cb: ldloc.s 4
-			IL_05cd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05d2: stloc.s 18
-			IL_05d4: ldstr "defaultHarnessFiles "
-			IL_05d9: ldloc.s 18
-			IL_05db: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05e0: stloc.s 18
-			IL_05e2: volatile.
-			IL_05e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
-			IL_05e9: brfalse IL_05fe
+			IL_05a9: stloc.s 4
+			IL_05ab: ldloc.s 4
+			IL_05ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05b2: stloc.s 17
+			IL_05b4: ldstr "defaultHarnessFiles "
+			IL_05b9: ldloc.s 17
+			IL_05bb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05c0: stloc.s 17
+			IL_05c2: volatile.
+			IL_05c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
+			IL_05c9: brfalse IL_05de
 
-			IL_05ee: ldarg.2
-			IL_05ef: ldstr "excludedFromMvp"
-			IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05f9: br IL_0613
+			IL_05ce: ldarg.2
+			IL_05cf: ldstr "excludedFromMvp"
+			IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05d9: br IL_05f3
 
-			IL_05fe: ldarg.2
-			IL_05ff: ldstr "excludedFromMvp"
-			IL_0604: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:120"
-			IL_0609: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
-			IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_05de: ldarg.2
+			IL_05df: ldstr "excludedFromMvp"
+			IL_05e4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:118"
+			IL_05e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
+			IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0613: stloc.s 4
-			IL_0615: ldloc.s 4
-			IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_061c: volatile.
-			IL_061e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
-			IL_0623: brfalse IL_063c
+			IL_05f3: stloc.s 4
+			IL_05f5: ldloc.s 4
+			IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05fc: volatile.
+			IL_05fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
+			IL_0603: brfalse IL_061c
 
-			IL_0628: ldstr "join"
-			IL_062d: ldstr "; "
-			IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0637: br IL_0655
+			IL_0608: ldstr "join"
+			IL_060d: ldstr "; "
+			IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0617: br IL_0635
 
-			IL_063c: ldstr "join"
-			IL_0641: ldstr "; "
-			IL_0646: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:123"
-			IL_064b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
-			IL_0650: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_061c: ldstr "join"
+			IL_0621: ldstr "; "
+			IL_0626: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:121"
+			IL_062b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
+			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0655: stloc.s 4
-			IL_0657: ldloc.s 4
-			IL_0659: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_065e: stloc.s 19
-			IL_0660: ldstr "excludedFromMvp "
-			IL_0665: ldloc.s 19
-			IL_0667: call string [System.Runtime]System.String::Concat(string, string)
-			IL_066c: stloc.s 19
-			IL_066e: volatile.
-			IL_0670: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
-			IL_0675: brfalse IL_068a
+			IL_0635: stloc.s 4
+			IL_0637: ldloc.s 4
+			IL_0639: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_063e: stloc.s 18
+			IL_0640: ldstr "excludedFromMvp "
+			IL_0645: ldloc.s 18
+			IL_0647: call string [System.Runtime]System.String::Concat(string, string)
+			IL_064c: stloc.s 18
+			IL_064e: volatile.
+			IL_0650: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
+			IL_0655: brfalse IL_066a
 
-			IL_067a: ldarg.2
-			IL_067b: ldstr "attributionFiles"
-			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0685: br IL_069f
+			IL_065a: ldarg.2
+			IL_065b: ldstr "attributionFiles"
+			IL_0660: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0665: br IL_067f
 
-			IL_068a: ldarg.2
-			IL_068b: ldstr "attributionFiles"
-			IL_0690: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:129"
-			IL_0695: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
-			IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_066a: ldarg.2
+			IL_066b: ldstr "attributionFiles"
+			IL_0670: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:127"
+			IL_0675: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
+			IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_069f: stloc.s 4
-			IL_06a1: ldloc.s 4
-			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06a8: volatile.
-			IL_06aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
-			IL_06af: brfalse IL_06c8
+			IL_067f: stloc.s 4
+			IL_0681: ldloc.s 4
+			IL_0683: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0688: volatile.
+			IL_068a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
+			IL_068f: brfalse IL_06a8
 
-			IL_06b4: ldstr "join"
-			IL_06b9: ldstr ", "
-			IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06c3: br IL_06e1
+			IL_0694: ldstr "join"
+			IL_0699: ldstr ", "
+			IL_069e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06a3: br IL_06c1
 
-			IL_06c8: ldstr "join"
-			IL_06cd: ldstr ", "
-			IL_06d2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:132"
-			IL_06d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
-			IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_06a8: ldstr "join"
+			IL_06ad: ldstr ", "
+			IL_06b2: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:130"
+			IL_06b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
+			IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_06e1: stloc.s 4
-			IL_06e3: ldloc.s 4
-			IL_06e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06ea: stloc.s 20
-			IL_06ec: ldstr "attributionFiles "
-			IL_06f1: ldloc.s 20
-			IL_06f3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06f8: stloc.s 20
-			IL_06fa: ldc.i4.s 16
-			IL_06fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0701: dup
-			IL_0702: ldloc.3
+			IL_06c1: stloc.s 4
+			IL_06c3: ldloc.s 4
+			IL_06c5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06ca: stloc.s 19
+			IL_06cc: ldstr "attributionFiles "
+			IL_06d1: ldloc.s 19
+			IL_06d3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06d8: stloc.s 19
+			IL_06da: ldc.i4.s 16
+			IL_06dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_06e1: dup
+			IL_06e2: ldloc.3
+			IL_06e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_06e8: dup
+			IL_06e9: ldloc.s 5
+			IL_06eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_06f0: dup
+			IL_06f1: ldloc.s 6
+			IL_06f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_06f8: dup
+			IL_06f9: ldloc.s 7
+			IL_06fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0700: dup
+			IL_0701: ldloc.s 8
 			IL_0703: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0708: dup
-			IL_0709: ldloc.s 5
+			IL_0709: ldloc.s 9
 			IL_070b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0710: dup
-			IL_0711: ldloc.s 6
+			IL_0711: ldloc.s 10
 			IL_0713: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0718: dup
-			IL_0719: ldloc.s 7
+			IL_0719: ldloc.s 11
 			IL_071b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0720: dup
-			IL_0721: ldloc.s 9
+			IL_0721: ldloc.s 12
 			IL_0723: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0728: dup
-			IL_0729: ldloc.s 10
+			IL_0729: ldloc.s 13
 			IL_072b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0730: dup
-			IL_0731: ldloc.s 11
+			IL_0731: ldloc.s 14
 			IL_0733: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0738: dup
-			IL_0739: ldloc.s 12
+			IL_0739: ldloc.s 15
 			IL_073b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0740: dup
-			IL_0741: ldloc.s 13
+			IL_0741: ldloc.s 16
 			IL_0743: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0748: dup
-			IL_0749: ldloc.s 14
+			IL_0749: ldloc.s 17
 			IL_074b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0750: dup
-			IL_0751: ldloc.s 15
+			IL_0751: ldloc.s 18
 			IL_0753: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0758: dup
-			IL_0759: ldloc.s 16
+			IL_0759: ldloc.s 19
 			IL_075b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0760: dup
-			IL_0761: ldloc.s 17
-			IL_0763: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0768: dup
-			IL_0769: ldloc.s 18
-			IL_076b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0770: dup
-			IL_0771: ldloc.s 19
-			IL_0773: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0778: dup
-			IL_0779: ldloc.s 20
-			IL_077b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0780: stloc.1
-			IL_0781: ldarg.3
-			IL_0782: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0787: stloc.2
-			IL_0788: ldloc.2
-			IL_0789: brfalse IL_0851
+			IL_0760: stloc.1
+			IL_0761: ldarg.3
+			IL_0762: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0767: stloc.2
+			IL_0768: ldloc.2
+			IL_0769: brfalse IL_081e
 
-			IL_078e: volatile.
-			IL_0790: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
-			IL_0795: brfalse IL_07aa
+			IL_076e: volatile.
+			IL_0770: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
+			IL_0775: brfalse IL_078a
 
-			IL_079a: ldarg.3
-			IL_079b: ldstr "source"
-			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a5: br IL_07bf
+			IL_077a: ldarg.3
+			IL_077b: ldstr "source"
+			IL_0780: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0785: br IL_079f
 
-			IL_07aa: ldarg.3
-			IL_07ab: ldstr "source"
-			IL_07b0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:145"
-			IL_07b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
-			IL_07ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_078a: ldarg.3
+			IL_078b: ldstr "source"
+			IL_0790: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:143"
+			IL_0795: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
+			IL_079a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07bf: stloc.s 4
-			IL_07c1: ldloc.s 4
-			IL_07c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_07c8: stloc.s 20
-			IL_07ca: ldstr "overrideSource "
-			IL_07cf: ldloc.s 20
-			IL_07d1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07d6: stloc.s 20
-			IL_07d8: ldloc.1
-			IL_07d9: ldloc.s 20
-			IL_07db: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_07e0: pop
-			IL_07e1: ldarg.0
-			IL_07e2: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
-			IL_07e7: ldc.i4.1
-			IL_07e8: newarr [System.Runtime]System.Object
-			IL_07ed: dup
-			IL_07ee: ldc.i4.0
-			IL_07ef: ldarg.0
-			IL_07f0: stelem.ref
-			IL_07f1: stloc.s 8
-			IL_07f3: volatile.
-			IL_07f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
-			IL_07fa: brfalse IL_080f
+			IL_079f: stloc.s 4
+			IL_07a1: ldloc.s 4
+			IL_07a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07a8: stloc.s 19
+			IL_07aa: ldstr "overrideSource "
+			IL_07af: ldloc.s 19
+			IL_07b1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07b6: stloc.s 19
+			IL_07b8: ldloc.1
+			IL_07b9: ldloc.s 19
+			IL_07bb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_07c0: pop
+			IL_07c1: volatile.
+			IL_07c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
+			IL_07c8: brfalse IL_07dd
 
-			IL_07ff: ldarg.3
-			IL_0800: ldstr "rootPath"
-			IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_080a: br IL_0824
+			IL_07cd: ldarg.3
+			IL_07ce: ldstr "rootPath"
+			IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d8: br IL_07f2
 
-			IL_080f: ldarg.3
-			IL_0810: ldstr "rootPath"
-			IL_0815: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:155"
-			IL_081a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
-			IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07dd: ldarg.3
+			IL_07de: ldstr "rootPath"
+			IL_07e3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M41>:__js_call__:151"
+			IL_07e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
+			IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0824: stloc.s 4
-			IL_0826: ldloc.s 8
-			IL_0828: ldloc.s 4
-			IL_082a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_082f: stloc.s 4
-			IL_0831: ldloc.s 4
-			IL_0833: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0838: stloc.s 20
-			IL_083a: ldstr "overrideRoot "
-			IL_083f: ldloc.s 20
-			IL_0841: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0846: stloc.s 20
-			IL_0848: ldloc.1
-			IL_0849: ldloc.s 20
-			IL_084b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0850: pop
+			IL_07f2: stloc.s 4
+			IL_07f4: ldnull
+			IL_07f5: ldloc.s 4
+			IL_07f7: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_07fc: stloc.s 4
+			IL_07fe: ldloc.s 4
+			IL_0800: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0805: stloc.s 19
+			IL_0807: ldstr "overrideRoot "
+			IL_080c: ldloc.s 19
+			IL_080e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0813: stloc.s 19
+			IL_0815: ldloc.1
+			IL_0816: ldloc.s 19
+			IL_0818: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_081d: pop
 
-			IL_0851: ldloc.1
-			IL_0852: ldc.i4.1
-			IL_0853: newarr [System.Runtime]System.Object
-			IL_0858: dup
-			IL_0859: ldc.i4.0
-			IL_085a: ldstr "\n"
-			IL_085f: stelem.ref
-			IL_0860: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0865: stloc.s 20
-			IL_0867: ldloc.s 20
-			IL_0869: ret
+			IL_081e: ldloc.1
+			IL_081f: ldc.i4.1
+			IL_0820: newarr [System.Runtime]System.Object
+			IL_0825: dup
+			IL_0826: ldc.i4.0
+			IL_0827: ldstr "\n"
+			IL_082c: stelem.ref
+			IL_082d: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0832: stloc.s 19
+			IL_0834: ldloc.s 19
+			IL_0836: ret
 		} // end of method describePlan::__js_call__
 
 	} // end of class describePlan
@@ -7389,7 +7145,7 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 483 (0x1e3)
+			// Code size: 465 (0x1d1)
 			.maxstack 12
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -7445,7 +7201,7 @@
 					IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_0057: stloc.s 11
 					IL_0059: ldloc.s 11
-					IL_005b: brtrue IL_00ba
+					IL_005b: brtrue IL_00b1
 
 					IL_0060: ldloc.s 10
 					IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -7455,162 +7211,152 @@
 					IL_006b: ldloc.s 10
 					IL_006d: stloc.s 4
 					IL_006f: ldarg.0
-					IL_0070: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_0075: ldc.i4.1
-					IL_0076: newarr [System.Runtime]System.Object
-					IL_007b: dup
-					IL_007c: ldc.i4.0
-					IL_007d: ldarg.0
-					IL_007e: stelem.ref
-					IL_007f: ldloc.s 4
-					IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0086: stloc.s 10
-					IL_0088: ldloc.s 10
-					IL_008a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_008f: stloc.s 12
-					IL_0091: ldstr "/"
-					IL_0096: ldloc.s 12
-					IL_0098: call string [System.Runtime]System.String::Concat(string, string)
-					IL_009d: stloc.s 12
-					IL_009f: ldloc.0
-					IL_00a0: ldloc.s 12
-					IL_00a2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_00a7: pop
-					IL_00a8: br IL_0046
+					IL_0070: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_0075: ldnull
+					IL_0076: ldloc.s 4
+					IL_0078: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_007d: stloc.s 10
+					IL_007f: ldloc.s 10
+					IL_0081: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0086: stloc.s 12
+					IL_0088: ldstr "/"
+					IL_008d: ldloc.s 12
+					IL_008f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0094: stloc.s 12
+					IL_0096: ldloc.0
+					IL_0097: ldloc.s 12
+					IL_0099: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_009e: pop
+					IL_009f: br IL_0046
 				// end loop
-				IL_00ad: ldloc.1
-				IL_00ae: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_00b3: ldc.i4.1
-				IL_00b4: stloc.3
-				IL_00b5: leave IL_00d4
+				IL_00a4: ldloc.1
+				IL_00a5: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_00aa: ldc.i4.1
+				IL_00ab: stloc.3
+				IL_00ac: leave IL_00cb
 
-				IL_00ba: ldc.i4.1
-				IL_00bb: stloc.2
-				IL_00bc: leave IL_00d4
+				IL_00b1: ldc.i4.1
+				IL_00b2: stloc.2
+				IL_00b3: leave IL_00cb
 			} // end .try
 			finally
 			{
-				IL_00c1: ldloc.2
-				IL_00c2: brtrue IL_00d3
+				IL_00b8: ldloc.2
+				IL_00b9: brtrue IL_00ca
 
-				IL_00c7: ldloc.3
-				IL_00c8: brtrue IL_00d3
+				IL_00be: ldloc.3
+				IL_00bf: brtrue IL_00ca
 
-				IL_00cd: ldloc.1
-				IL_00ce: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_00c4: ldloc.1
+				IL_00c5: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_00d3: endfinally
+				IL_00ca: endfinally
 			} // end handler
 
-			IL_00d4: volatile.
-			IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
-			IL_00db: brfalse IL_00f0
+			IL_00cb: volatile.
+			IL_00cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
+			IL_00d2: brfalse IL_00e7
 
-			IL_00e0: ldarg.2
-			IL_00e1: ldstr "includeDirectories"
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00eb: br IL_0105
+			IL_00d7: ldarg.2
+			IL_00d8: ldstr "includeDirectories"
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e2: br IL_00fc
 
-			IL_00f0: ldarg.2
-			IL_00f1: ldstr "includeDirectories"
-			IL_00f6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:51"
-			IL_00fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
-			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00e7: ldarg.2
+			IL_00e8: ldstr "includeDirectories"
+			IL_00ed: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M45>:__js_call__:50"
+			IL_00f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0105: stloc.s 10
-			IL_0107: ldloc.s 10
-			IL_0109: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_010e: stloc.s 5
-			IL_0110: ldc.i4.0
-			IL_0111: stloc.s 6
-			IL_0113: ldc.i4.0
-			IL_0114: stloc.s 7
+			IL_00fc: stloc.s 10
+			IL_00fe: ldloc.s 10
+			IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0105: stloc.s 5
+			IL_0107: ldc.i4.0
+			IL_0108: stloc.s 6
+			IL_010a: ldc.i4.0
+			IL_010b: stloc.s 7
 			.try
 			{
-				// loop start (head: IL_0116)
-					IL_0116: ldc.i4.1
-					IL_0117: stloc.s 6
-					IL_0119: ldloc.s 5
-					IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_0120: stloc.s 10
-					IL_0122: ldloc.s 10
-					IL_0124: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_0129: stloc.s 11
-					IL_012b: ldloc.s 11
-					IL_012d: brtrue IL_01c3
+				// loop start (head: IL_010d)
+					IL_010d: ldc.i4.1
+					IL_010e: stloc.s 6
+					IL_0110: ldloc.s 5
+					IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_0117: stloc.s 10
+					IL_0119: ldloc.s 10
+					IL_011b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_0120: stloc.s 11
+					IL_0122: ldloc.s 11
+					IL_0124: brtrue IL_01b1
 
-					IL_0132: ldloc.s 10
-					IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_0139: stloc.s 10
-					IL_013b: ldc.i4.0
-					IL_013c: stloc.s 6
-					IL_013e: ldloc.s 10
-					IL_0140: stloc.s 8
-					IL_0142: ldarg.0
-					IL_0143: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_0148: ldc.i4.1
-					IL_0149: newarr [System.Runtime]System.Object
-					IL_014e: dup
-					IL_014f: ldc.i4.0
-					IL_0150: ldarg.0
-					IL_0151: stelem.ref
-					IL_0152: ldloc.s 8
-					IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0159: stloc.s 9
-					IL_015b: ldloc.s 9
-					IL_015d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0162: stloc.s 12
-					IL_0164: ldstr "/"
-					IL_0169: ldloc.s 12
-					IL_016b: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0170: ldstr "/"
-					IL_0175: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0129: ldloc.s 10
+					IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_0130: stloc.s 10
+					IL_0132: ldc.i4.0
+					IL_0133: stloc.s 6
+					IL_0135: ldloc.s 10
+					IL_0137: stloc.s 8
+					IL_0139: ldarg.0
+					IL_013a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_013f: ldnull
+					IL_0140: ldloc.s 8
+					IL_0142: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_0147: stloc.s 9
+					IL_0149: ldloc.s 9
+					IL_014b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0150: stloc.s 12
+					IL_0152: ldstr "/"
+					IL_0157: ldloc.s 12
+					IL_0159: call string [System.Runtime]System.String::Concat(string, string)
+					IL_015e: ldstr "/"
+					IL_0163: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0168: stloc.s 12
+					IL_016a: ldloc.0
+					IL_016b: ldloc.s 12
+					IL_016d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0172: pop
+					IL_0173: ldloc.s 9
+					IL_0175: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 					IL_017a: stloc.s 12
-					IL_017c: ldloc.0
-					IL_017d: ldloc.s 12
-					IL_017f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0184: pop
-					IL_0185: ldloc.s 9
-					IL_0187: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_018c: stloc.s 12
-					IL_018e: ldstr "/"
-					IL_0193: ldloc.s 12
-					IL_0195: call string [System.Runtime]System.String::Concat(string, string)
-					IL_019a: ldstr "/**"
-					IL_019f: call string [System.Runtime]System.String::Concat(string, string)
-					IL_01a4: stloc.s 12
-					IL_01a6: ldloc.0
-					IL_01a7: ldloc.s 12
-					IL_01a9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01ae: pop
-					IL_01af: br IL_0116
+					IL_017c: ldstr "/"
+					IL_0181: ldloc.s 12
+					IL_0183: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0188: ldstr "/**"
+					IL_018d: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0192: stloc.s 12
+					IL_0194: ldloc.0
+					IL_0195: ldloc.s 12
+					IL_0197: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_019c: pop
+					IL_019d: br IL_010d
 				// end loop
-				IL_01b4: ldloc.s 5
-				IL_01b6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_01bb: ldc.i4.1
-				IL_01bc: stloc.s 7
-				IL_01be: leave IL_01e1
+				IL_01a2: ldloc.s 5
+				IL_01a4: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_01a9: ldc.i4.1
+				IL_01aa: stloc.s 7
+				IL_01ac: leave IL_01cf
 
-				IL_01c3: ldc.i4.1
-				IL_01c4: stloc.s 6
-				IL_01c6: leave IL_01e1
+				IL_01b1: ldc.i4.1
+				IL_01b2: stloc.s 6
+				IL_01b4: leave IL_01cf
 			} // end .try
 			finally
 			{
-				IL_01cb: ldloc.s 6
-				IL_01cd: brtrue IL_01e0
+				IL_01b9: ldloc.s 6
+				IL_01bb: brtrue IL_01ce
 
-				IL_01d2: ldloc.s 7
-				IL_01d4: brtrue IL_01e0
+				IL_01c0: ldloc.s 7
+				IL_01c2: brtrue IL_01ce
 
-				IL_01d9: ldloc.s 5
-				IL_01db: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_01c7: ldloc.s 5
+				IL_01c9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_01e0: endfinally
+				IL_01ce: endfinally
 			} // end handler
 
-			IL_01e1: ldloc.0
-			IL_01e2: ret
+			IL_01cf: ldloc.0
+			IL_01d0: ret
 		} // end of method buildSparsePatterns::__js_call__
 
 	} // end of class buildSparsePatterns
@@ -7969,7 +7715,7 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2351 (0x92f)
+			// Code size: 2333 (0x91d)
 			.maxstack 12
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -8049,7 +7795,7 @@
 					IL_005a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_005f: stloc.s 17
 					IL_0061: ldloc.s 17
-					IL_0063: brtrue IL_0248
+					IL_0063: brtrue IL_023f
 
 					IL_0068: ldloc.s 16
 					IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -8071,803 +7817,793 @@
 					IL_0090: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 					IL_0095: stloc.s 19
 					IL_0097: ldarg.0
-					IL_0098: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_009d: ldc.i4.1
-					IL_009e: newarr [System.Runtime]System.Object
-					IL_00a3: dup
-					IL_00a4: ldc.i4.0
-					IL_00a5: ldarg.0
-					IL_00a6: stelem.ref
-					IL_00a7: ldloc.s 5
-					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_00ae: stloc.s 16
-					IL_00b0: ldloc.s 16
-					IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00b7: volatile.
-					IL_00b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
-					IL_00be: brfalse IL_00d7
+					IL_0098: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_009d: ldnull
+					IL_009e: ldloc.s 5
+					IL_00a0: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_00a5: stloc.s 16
+					IL_00a7: ldloc.s 16
+					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00ae: volatile.
+					IL_00b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
+					IL_00b5: brfalse IL_00ce
 
-					IL_00c3: ldstr "split"
-					IL_00c8: ldstr "/"
-					IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_00d2: br IL_00f0
+					IL_00ba: ldstr "split"
+					IL_00bf: ldstr "/"
+					IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_00c9: br IL_00e7
 
-					IL_00d7: ldstr "split"
-					IL_00dc: ldstr "/"
-					IL_00e1: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:35"
-					IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
-					IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+					IL_00ce: ldstr "split"
+					IL_00d3: ldstr "/"
+					IL_00d8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:34"
+					IL_00dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
+					IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-					IL_00f0: stloc.s 16
+					IL_00e7: stloc.s 16
+					IL_00e9: ldloc.s 19
+					IL_00eb: ldloc.s 16
+					IL_00ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
 					IL_00f2: ldloc.s 19
-					IL_00f4: ldloc.s 16
-					IL_00f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_00fb: ldloc.s 19
-					IL_00fd: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_0102: stloc.s 20
-					IL_0104: ldloc.s 18
-					IL_0106: ldstr "join"
-					IL_010b: ldloc.s 20
-					IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-					IL_0112: stloc.s 6
-					IL_0114: ldarg.0
-					IL_0115: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_011a: stloc.s 21
-					IL_011c: ldloc.s 21
-					IL_011e: ldstr "existsSync"
-					IL_0123: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_0128: brtrue IL_0142
+					IL_00f4: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_00f9: stloc.s 20
+					IL_00fb: ldloc.s 18
+					IL_00fd: ldstr "join"
+					IL_0102: ldloc.s 20
+					IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+					IL_0109: stloc.s 6
+					IL_010b: ldarg.0
+					IL_010c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0111: stloc.s 21
+					IL_0113: ldloc.s 21
+					IL_0115: ldstr "existsSync"
+					IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_011f: brtrue IL_0139
 
-					IL_012d: ldloc.s 21
-					IL_012f: ldloc.s 6
-					IL_0131: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_0136: box [System.Runtime]System.Boolean
-					IL_013b: stloc.s 16
-					IL_013d: br IL_015b
+					IL_0124: ldloc.s 21
+					IL_0126: ldloc.s 6
+					IL_0128: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_012d: box [System.Runtime]System.Boolean
+					IL_0132: stloc.s 16
+					IL_0134: br IL_0152
 
-					IL_0142: ldloc.s 21
-					IL_0144: ldstr "existsSync"
-					IL_0149: ldc.i4.1
-					IL_014a: newarr [System.Runtime]System.Object
-					IL_014f: dup
-					IL_0150: ldc.i4.0
-					IL_0151: ldloc.s 6
-					IL_0153: stelem.ref
-					IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_0159: stloc.s 16
+					IL_0139: ldloc.s 21
+					IL_013b: ldstr "existsSync"
+					IL_0140: ldc.i4.1
+					IL_0141: newarr [System.Runtime]System.Object
+					IL_0146: dup
+					IL_0147: ldc.i4.0
+					IL_0148: ldloc.s 6
+					IL_014a: stelem.ref
+					IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_0150: stloc.s 16
 
-					IL_015b: ldloc.s 16
-					IL_015d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0162: ldc.i4.0
-					IL_0163: ceq
-					IL_0165: stloc.s 17
-					IL_0167: ldloc.s 17
-					IL_0169: box [System.Runtime]System.Boolean
-					IL_016e: stloc.s 22
-					IL_0170: ldloc.s 22
-					IL_0172: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0177: stloc.s 17
-					IL_0179: ldloc.s 17
-					IL_017b: brtrue IL_0218
+					IL_0152: ldloc.s 16
+					IL_0154: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0159: ldc.i4.0
+					IL_015a: ceq
+					IL_015c: stloc.s 17
+					IL_015e: ldloc.s 17
+					IL_0160: box [System.Runtime]System.Boolean
+					IL_0165: stloc.s 22
+					IL_0167: ldloc.s 22
+					IL_0169: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_016e: stloc.s 17
+					IL_0170: ldloc.s 17
+					IL_0172: brtrue IL_020f
 
-					IL_0180: ldarg.0
-					IL_0181: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0186: stloc.s 21
-					IL_0188: ldloc.s 21
-					IL_018a: ldstr "statSync"
-					IL_018f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_0194: brtrue IL_01a9
+					IL_0177: ldarg.0
+					IL_0178: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_017d: stloc.s 21
+					IL_017f: ldloc.s 21
+					IL_0181: ldstr "statSync"
+					IL_0186: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_018b: brtrue IL_01a0
 
-					IL_0199: ldloc.s 21
-					IL_019b: ldloc.s 6
-					IL_019d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
-					IL_01a2: stloc.s 16
-					IL_01a4: br IL_01c2
+					IL_0190: ldloc.s 21
+					IL_0192: ldloc.s 6
+					IL_0194: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_0199: stloc.s 16
+					IL_019b: br IL_01b9
 
-					IL_01a9: ldloc.s 21
-					IL_01ab: ldstr "statSync"
-					IL_01b0: ldc.i4.1
-					IL_01b1: newarr [System.Runtime]System.Object
-					IL_01b6: dup
-					IL_01b7: ldc.i4.0
-					IL_01b8: ldloc.s 6
-					IL_01ba: stelem.ref
-					IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_01c0: stloc.s 16
+					IL_01a0: ldloc.s 21
+					IL_01a2: ldstr "statSync"
+					IL_01a7: ldc.i4.1
+					IL_01a8: newarr [System.Runtime]System.Object
+					IL_01ad: dup
+					IL_01ae: ldc.i4.0
+					IL_01af: ldloc.s 6
+					IL_01b1: stelem.ref
+					IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_01b7: stloc.s 16
 
-					IL_01c2: ldloc.s 16
-					IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01c9: volatile.
-					IL_01cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
-					IL_01d0: brfalse IL_01e4
+					IL_01b9: ldloc.s 16
+					IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01c0: volatile.
+					IL_01c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
+					IL_01c7: brfalse IL_01db
 
-					IL_01d5: ldstr "isFile"
-					IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_01df: br IL_01f8
+					IL_01cc: ldstr "isFile"
+					IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_01d6: br IL_01ef
 
-					IL_01e4: ldstr "isFile"
-					IL_01e9: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:50"
-					IL_01ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
-					IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+					IL_01db: ldstr "isFile"
+					IL_01e0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:49"
+					IL_01e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
+					IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-					IL_01f8: stloc.s 16
-					IL_01fa: ldloc.s 16
-					IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0201: ldc.i4.0
-					IL_0202: ceq
-					IL_0204: stloc.s 17
-					IL_0206: ldloc.s 17
-					IL_0208: box [System.Runtime]System.Boolean
-					IL_020d: stloc.s 23
-					IL_020f: ldloc.s 23
+					IL_01ef: stloc.s 16
+					IL_01f1: ldloc.s 16
+					IL_01f3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_01f8: ldc.i4.0
+					IL_01f9: ceq
+					IL_01fb: stloc.s 17
+					IL_01fd: ldloc.s 17
+					IL_01ff: box [System.Runtime]System.Boolean
+					IL_0204: stloc.s 23
+					IL_0206: ldloc.s 23
+					IL_0208: stloc.s 25
+					IL_020a: br IL_0213
+
+					IL_020f: ldloc.s 22
 					IL_0211: stloc.s 25
-					IL_0213: br IL_021c
 
-					IL_0218: ldloc.s 22
-					IL_021a: stloc.s 25
+					IL_0213: ldloc.s 25
+					IL_0215: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_021a: stloc.s 17
+					IL_021c: ldloc.s 17
+					IL_021e: brfalse IL_022c
 
-					IL_021c: ldloc.s 25
-					IL_021e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0223: stloc.s 17
-					IL_0225: ldloc.s 17
-					IL_0227: brfalse IL_0235
+					IL_0223: ldloc.0
+					IL_0224: ldloc.s 5
+					IL_0226: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_022b: pop
 
-					IL_022c: ldloc.0
-					IL_022d: ldloc.s 5
-					IL_022f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0234: pop
-
-					IL_0235: br IL_004e
+					IL_022c: br IL_004e
 				// end loop
-				IL_023a: ldloc.2
-				IL_023b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0240: ldc.i4.1
-				IL_0241: stloc.s 4
-				IL_0243: leave IL_0263
+				IL_0231: ldloc.2
+				IL_0232: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0237: ldc.i4.1
+				IL_0238: stloc.s 4
+				IL_023a: leave IL_025a
 
-				IL_0248: ldc.i4.1
-				IL_0249: stloc.3
-				IL_024a: leave IL_0263
+				IL_023f: ldc.i4.1
+				IL_0240: stloc.3
+				IL_0241: leave IL_025a
 			} // end .try
 			finally
 			{
-				IL_024f: ldloc.3
-				IL_0250: brtrue IL_0262
+				IL_0246: ldloc.3
+				IL_0247: brtrue IL_0259
 
-				IL_0255: ldloc.s 4
-				IL_0257: brtrue IL_0262
+				IL_024c: ldloc.s 4
+				IL_024e: brtrue IL_0259
 
-				IL_025c: ldloc.2
-				IL_025d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_0253: ldloc.2
+				IL_0254: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0262: endfinally
+				IL_0259: endfinally
 			} // end handler
 
-			IL_0263: volatile.
-			IL_0265: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
-			IL_026a: brfalse IL_027f
+			IL_025a: volatile.
+			IL_025c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
+			IL_0261: brfalse IL_0276
 
-			IL_026f: ldarg.3
-			IL_0270: ldstr "requiredDirectories"
-			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027a: br IL_0294
+			IL_0266: ldarg.3
+			IL_0267: ldstr "requiredDirectories"
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0271: br IL_028b
 
-			IL_027f: ldarg.3
-			IL_0280: ldstr "requiredDirectories"
-			IL_0285: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:84"
-			IL_028a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
-			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0276: ldarg.3
+			IL_0277: ldstr "requiredDirectories"
+			IL_027c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:83"
+			IL_0281: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
+			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0294: stloc.s 16
-			IL_0296: ldloc.s 16
-			IL_0298: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_029d: stloc.s 7
-			IL_029f: ldc.i4.0
-			IL_02a0: stloc.s 8
-			IL_02a2: ldc.i4.0
-			IL_02a3: stloc.s 9
+			IL_028b: stloc.s 16
+			IL_028d: ldloc.s 16
+			IL_028f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0294: stloc.s 7
+			IL_0296: ldc.i4.0
+			IL_0297: stloc.s 8
+			IL_0299: ldc.i4.0
+			IL_029a: stloc.s 9
 			.try
 			{
-				// loop start (head: IL_02a5)
-					IL_02a5: ldc.i4.1
-					IL_02a6: stloc.s 8
-					IL_02a8: ldloc.s 7
-					IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_02af: stloc.s 16
-					IL_02b1: ldloc.s 16
-					IL_02b3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_02b8: stloc.s 17
-					IL_02ba: ldloc.s 17
-					IL_02bc: brtrue IL_04a3
+				// loop start (head: IL_029c)
+					IL_029c: ldc.i4.1
+					IL_029d: stloc.s 8
+					IL_029f: ldloc.s 7
+					IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_02a6: stloc.s 16
+					IL_02a8: ldloc.s 16
+					IL_02aa: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_02af: stloc.s 17
+					IL_02b1: ldloc.s 17
+					IL_02b3: brtrue IL_0491
 
-					IL_02c1: ldloc.s 16
-					IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_02c8: stloc.s 16
-					IL_02ca: ldc.i4.0
-					IL_02cb: stloc.s 8
-					IL_02cd: ldloc.s 16
-					IL_02cf: stloc.s 10
-					IL_02d1: ldarg.0
-					IL_02d2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_02b8: ldloc.s 16
+					IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_02bf: stloc.s 16
+					IL_02c1: ldc.i4.0
+					IL_02c2: stloc.s 8
+					IL_02c4: ldloc.s 16
+					IL_02c6: stloc.s 10
+					IL_02c8: ldarg.0
+					IL_02c9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_02ce: stloc.s 18
+					IL_02d0: ldloc.s 18
+					IL_02d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(!!0)
 					IL_02d7: stloc.s 18
-					IL_02d9: ldloc.s 18
-					IL_02db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule>(!!0)
-					IL_02e0: stloc.s 18
-					IL_02e2: ldc.i4.1
-					IL_02e3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_02e8: dup
-					IL_02e9: ldarg.2
-					IL_02ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_02ef: stloc.s 19
-					IL_02f1: ldarg.0
-					IL_02f2: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
-					IL_02f7: ldc.i4.1
-					IL_02f8: newarr [System.Runtime]System.Object
-					IL_02fd: dup
-					IL_02fe: ldc.i4.0
-					IL_02ff: ldarg.0
-					IL_0300: stelem.ref
-					IL_0301: ldloc.s 10
-					IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0308: stloc.s 16
-					IL_030a: ldloc.s 16
-					IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0311: volatile.
-					IL_0313: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
-					IL_0318: brfalse IL_0331
+					IL_02d9: ldc.i4.1
+					IL_02da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_02df: dup
+					IL_02e0: ldarg.2
+					IL_02e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_02e6: stloc.s 19
+					IL_02e8: ldarg.0
+					IL_02e9: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_02ee: ldnull
+					IL_02ef: ldloc.s 10
+					IL_02f1: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_02f6: stloc.s 16
+					IL_02f8: ldloc.s 16
+					IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02ff: volatile.
+					IL_0301: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
+					IL_0306: brfalse IL_031f
 
-					IL_031d: ldstr "split"
-					IL_0322: ldstr "/"
-					IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_032c: br IL_034a
+					IL_030b: ldstr "split"
+					IL_0310: ldstr "/"
+					IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_031a: br IL_0338
 
-					IL_0331: ldstr "split"
-					IL_0336: ldstr "/"
-					IL_033b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:110"
-					IL_0340: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
-					IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+					IL_031f: ldstr "split"
+					IL_0324: ldstr "/"
+					IL_0329: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:108"
+					IL_032e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
+					IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-					IL_034a: stloc.s 16
-					IL_034c: ldloc.s 19
-					IL_034e: ldloc.s 16
-					IL_0350: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_0355: ldloc.s 19
-					IL_0357: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_035c: stloc.s 20
-					IL_035e: ldloc.s 18
-					IL_0360: ldstr "join"
-					IL_0365: ldloc.s 20
-					IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
-					IL_036c: stloc.s 11
-					IL_036e: ldarg.0
-					IL_036f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0374: stloc.s 21
-					IL_0376: ldloc.s 21
-					IL_0378: ldstr "existsSync"
-					IL_037d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_0382: brtrue IL_039c
+					IL_0338: stloc.s 16
+					IL_033a: ldloc.s 19
+					IL_033c: ldloc.s 16
+					IL_033e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_0343: ldloc.s 19
+					IL_0345: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_034a: stloc.s 20
+					IL_034c: ldloc.s 18
+					IL_034e: ldstr "join"
+					IL_0353: ldloc.s 20
+					IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+					IL_035a: stloc.s 11
+					IL_035c: ldarg.0
+					IL_035d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0362: stloc.s 21
+					IL_0364: ldloc.s 21
+					IL_0366: ldstr "existsSync"
+					IL_036b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_0370: brtrue IL_038a
 
-					IL_0387: ldloc.s 21
-					IL_0389: ldloc.s 11
-					IL_038b: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-					IL_0390: box [System.Runtime]System.Boolean
-					IL_0395: stloc.s 16
-					IL_0397: br IL_03b5
+					IL_0375: ldloc.s 21
+					IL_0377: ldloc.s 11
+					IL_0379: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+					IL_037e: box [System.Runtime]System.Boolean
+					IL_0383: stloc.s 16
+					IL_0385: br IL_03a3
 
-					IL_039c: ldloc.s 21
-					IL_039e: ldstr "existsSync"
-					IL_03a3: ldc.i4.1
-					IL_03a4: newarr [System.Runtime]System.Object
-					IL_03a9: dup
+					IL_038a: ldloc.s 21
+					IL_038c: ldstr "existsSync"
+					IL_0391: ldc.i4.1
+					IL_0392: newarr [System.Runtime]System.Object
+					IL_0397: dup
+					IL_0398: ldc.i4.0
+					IL_0399: ldloc.s 11
+					IL_039b: stelem.ref
+					IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_03a1: stloc.s 16
+
+					IL_03a3: ldloc.s 16
+					IL_03a5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 					IL_03aa: ldc.i4.0
-					IL_03ab: ldloc.s 11
-					IL_03ad: stelem.ref
-					IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_03b3: stloc.s 16
-
-					IL_03b5: ldloc.s 16
-					IL_03b7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_03bc: ldc.i4.0
-					IL_03bd: ceq
+					IL_03ab: ceq
+					IL_03ad: stloc.s 17
+					IL_03af: ldloc.s 17
+					IL_03b1: box [System.Runtime]System.Boolean
+					IL_03b6: stloc.s 22
+					IL_03b8: ldloc.s 22
+					IL_03ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_03bf: stloc.s 17
 					IL_03c1: ldloc.s 17
-					IL_03c3: box [System.Runtime]System.Boolean
-					IL_03c8: stloc.s 22
-					IL_03ca: ldloc.s 22
-					IL_03cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_03d1: stloc.s 17
-					IL_03d3: ldloc.s 17
-					IL_03d5: brtrue IL_0472
+					IL_03c3: brtrue IL_0460
 
-					IL_03da: ldarg.0
-					IL_03db: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_03e0: stloc.s 21
-					IL_03e2: ldloc.s 21
-					IL_03e4: ldstr "statSync"
-					IL_03e9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-					IL_03ee: brtrue IL_0403
+					IL_03c8: ldarg.0
+					IL_03c9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_03ce: stloc.s 21
+					IL_03d0: ldloc.s 21
+					IL_03d2: ldstr "statSync"
+					IL_03d7: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+					IL_03dc: brtrue IL_03f1
 
-					IL_03f3: ldloc.s 21
-					IL_03f5: ldloc.s 11
-					IL_03f7: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
-					IL_03fc: stloc.s 16
-					IL_03fe: br IL_041c
+					IL_03e1: ldloc.s 21
+					IL_03e3: ldloc.s 11
+					IL_03e5: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::statSync(object)
+					IL_03ea: stloc.s 16
+					IL_03ec: br IL_040a
 
-					IL_0403: ldloc.s 21
-					IL_0405: ldstr "statSync"
-					IL_040a: ldc.i4.1
-					IL_040b: newarr [System.Runtime]System.Object
-					IL_0410: dup
-					IL_0411: ldc.i4.0
-					IL_0412: ldloc.s 11
-					IL_0414: stelem.ref
-					IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-					IL_041a: stloc.s 16
+					IL_03f1: ldloc.s 21
+					IL_03f3: ldstr "statSync"
+					IL_03f8: ldc.i4.1
+					IL_03f9: newarr [System.Runtime]System.Object
+					IL_03fe: dup
+					IL_03ff: ldc.i4.0
+					IL_0400: ldloc.s 11
+					IL_0402: stelem.ref
+					IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+					IL_0408: stloc.s 16
 
-					IL_041c: ldloc.s 16
-					IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0423: volatile.
-					IL_0425: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
-					IL_042a: brfalse IL_043e
+					IL_040a: ldloc.s 16
+					IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0411: volatile.
+					IL_0413: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
+					IL_0418: brfalse IL_042c
 
-					IL_042f: ldstr "isDirectory"
-					IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_0439: br IL_0452
+					IL_041d: ldstr "isDirectory"
+					IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_0427: br IL_0440
 
-					IL_043e: ldstr "isDirectory"
-					IL_0443: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:125"
-					IL_0448: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
-					IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+					IL_042c: ldstr "isDirectory"
+					IL_0431: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:123"
+					IL_0436: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
+					IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-					IL_0452: stloc.s 16
-					IL_0454: ldloc.s 16
-					IL_0456: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_045b: ldc.i4.0
-					IL_045c: ceq
-					IL_045e: stloc.s 17
-					IL_0460: ldloc.s 17
-					IL_0462: box [System.Runtime]System.Boolean
-					IL_0467: stloc.s 23
-					IL_0469: ldloc.s 23
-					IL_046b: stloc.s 26
-					IL_046d: br IL_0476
+					IL_0440: stloc.s 16
+					IL_0442: ldloc.s 16
+					IL_0444: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0449: ldc.i4.0
+					IL_044a: ceq
+					IL_044c: stloc.s 17
+					IL_044e: ldloc.s 17
+					IL_0450: box [System.Runtime]System.Boolean
+					IL_0455: stloc.s 23
+					IL_0457: ldloc.s 23
+					IL_0459: stloc.s 26
+					IL_045b: br IL_0464
 
-					IL_0472: ldloc.s 22
-					IL_0474: stloc.s 26
+					IL_0460: ldloc.s 22
+					IL_0462: stloc.s 26
 
-					IL_0476: ldloc.s 26
-					IL_0478: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_047d: stloc.s 17
-					IL_047f: ldloc.s 17
-					IL_0481: brfalse IL_048f
+					IL_0464: ldloc.s 26
+					IL_0466: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_046b: stloc.s 17
+					IL_046d: ldloc.s 17
+					IL_046f: brfalse IL_047d
 
-					IL_0486: ldloc.1
-					IL_0487: ldloc.s 10
-					IL_0489: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_048e: pop
+					IL_0474: ldloc.1
+					IL_0475: ldloc.s 10
+					IL_0477: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_047c: pop
 
-					IL_048f: br IL_02a5
+					IL_047d: br IL_029c
 				// end loop
-				IL_0494: ldloc.s 7
-				IL_0496: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_049b: ldc.i4.1
-				IL_049c: stloc.s 9
-				IL_049e: leave IL_04c1
+				IL_0482: ldloc.s 7
+				IL_0484: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0489: ldc.i4.1
+				IL_048a: stloc.s 9
+				IL_048c: leave IL_04af
 
-				IL_04a3: ldc.i4.1
-				IL_04a4: stloc.s 8
-				IL_04a6: leave IL_04c1
+				IL_0491: ldc.i4.1
+				IL_0492: stloc.s 8
+				IL_0494: leave IL_04af
 			} // end .try
 			finally
 			{
-				IL_04ab: ldloc.s 8
-				IL_04ad: brtrue IL_04c0
+				IL_0499: ldloc.s 8
+				IL_049b: brtrue IL_04ae
 
-				IL_04b2: ldloc.s 9
-				IL_04b4: brtrue IL_04c0
+				IL_04a0: ldloc.s 9
+				IL_04a2: brtrue IL_04ae
 
-				IL_04b9: ldloc.s 7
-				IL_04bb: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_04a7: ldloc.s 7
+				IL_04a9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_04c0: endfinally
+				IL_04ae: endfinally
 			} // end handler
 
-			IL_04c1: ldloc.0
-			IL_04c2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_04c7: ldc.r8 0.0
-			IL_04d0: cgt
+			IL_04af: ldloc.0
+			IL_04b0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_04b5: ldc.r8 0.0
+			IL_04be: cgt
+			IL_04c0: stloc.s 17
+			IL_04c2: ldloc.s 17
+			IL_04c4: box [System.Runtime]System.Boolean
+			IL_04c9: stloc.s 22
+			IL_04cb: ldloc.s 22
+			IL_04cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_04d2: stloc.s 17
 			IL_04d4: ldloc.s 17
-			IL_04d6: box [System.Runtime]System.Boolean
-			IL_04db: stloc.s 22
-			IL_04dd: ldloc.s 22
-			IL_04df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04e4: stloc.s 17
-			IL_04e6: ldloc.s 17
-			IL_04e8: brtrue IL_0512
+			IL_04d6: brtrue IL_0500
 
-			IL_04ed: ldloc.1
-			IL_04ee: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_04f3: ldc.r8 0.0
-			IL_04fc: cgt
-			IL_04fe: stloc.s 17
-			IL_0500: ldloc.s 17
-			IL_0502: box [System.Runtime]System.Boolean
-			IL_0507: stloc.s 23
-			IL_0509: ldloc.s 23
-			IL_050b: stloc.s 27
-			IL_050d: br IL_0516
+			IL_04db: ldloc.1
+			IL_04dc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_04e1: ldc.r8 0.0
+			IL_04ea: cgt
+			IL_04ec: stloc.s 17
+			IL_04ee: ldloc.s 17
+			IL_04f0: box [System.Runtime]System.Boolean
+			IL_04f5: stloc.s 23
+			IL_04f7: ldloc.s 23
+			IL_04f9: stloc.s 27
+			IL_04fb: br IL_0504
 
-			IL_0512: ldloc.s 22
-			IL_0514: stloc.s 27
+			IL_0500: ldloc.s 22
+			IL_0502: stloc.s 27
 
-			IL_0516: ldloc.s 27
-			IL_0518: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_051d: stloc.s 17
-			IL_051f: ldloc.s 17
-			IL_0521: brfalse IL_0602
+			IL_0504: ldloc.s 27
+			IL_0506: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_050b: stloc.s 17
+			IL_050d: ldloc.s 17
+			IL_050f: brfalse IL_05f0
 
-			IL_0526: ldc.i4.0
-			IL_0527: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_052c: stloc.s 12
-			IL_052e: ldloc.0
-			IL_052f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0534: ldc.r8 0.0
-			IL_053d: cgt
-			IL_053f: brfalse IL_057b
+			IL_0514: ldc.i4.0
+			IL_0515: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_051a: stloc.s 12
+			IL_051c: ldloc.0
+			IL_051d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_0522: ldc.r8 0.0
+			IL_052b: cgt
+			IL_052d: brfalse IL_0569
 
-			IL_0544: ldloc.0
-			IL_0545: ldc.i4.1
-			IL_0546: newarr [System.Runtime]System.Object
-			IL_054b: dup
-			IL_054c: ldc.i4.0
-			IL_054d: ldstr ", "
-			IL_0552: stelem.ref
-			IL_0553: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0558: stloc.s 28
-			IL_055a: ldloc.s 28
-			IL_055c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0561: stloc.s 28
-			IL_0563: ldstr "missing files: "
-			IL_0568: ldloc.s 28
-			IL_056a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_056f: stloc.s 28
-			IL_0571: ldloc.s 12
-			IL_0573: ldloc.s 28
-			IL_0575: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_057a: pop
+			IL_0532: ldloc.0
+			IL_0533: ldc.i4.1
+			IL_0534: newarr [System.Runtime]System.Object
+			IL_0539: dup
+			IL_053a: ldc.i4.0
+			IL_053b: ldstr ", "
+			IL_0540: stelem.ref
+			IL_0541: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0546: stloc.s 28
+			IL_0548: ldloc.s 28
+			IL_054a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_054f: stloc.s 28
+			IL_0551: ldstr "missing files: "
+			IL_0556: ldloc.s 28
+			IL_0558: call string [System.Runtime]System.String::Concat(string, string)
+			IL_055d: stloc.s 28
+			IL_055f: ldloc.s 12
+			IL_0561: ldloc.s 28
+			IL_0563: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0568: pop
 
-			IL_057b: ldloc.1
-			IL_057c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0581: ldc.r8 0.0
-			IL_058a: cgt
-			IL_058c: brfalse IL_05c8
+			IL_0569: ldloc.1
+			IL_056a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_056f: ldc.r8 0.0
+			IL_0578: cgt
+			IL_057a: brfalse IL_05b6
 
-			IL_0591: ldloc.1
-			IL_0592: ldc.i4.1
-			IL_0593: newarr [System.Runtime]System.Object
-			IL_0598: dup
-			IL_0599: ldc.i4.0
-			IL_059a: ldstr ", "
-			IL_059f: stelem.ref
-			IL_05a0: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_05a5: stloc.s 28
-			IL_05a7: ldloc.s 28
-			IL_05a9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05ae: stloc.s 28
-			IL_05b0: ldstr "missing directories: "
-			IL_05b5: ldloc.s 28
-			IL_05b7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05bc: stloc.s 28
-			IL_05be: ldloc.s 12
-			IL_05c0: ldloc.s 28
-			IL_05c2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_05c7: pop
+			IL_057f: ldloc.1
+			IL_0580: ldc.i4.1
+			IL_0581: newarr [System.Runtime]System.Object
+			IL_0586: dup
+			IL_0587: ldc.i4.0
+			IL_0588: ldstr ", "
+			IL_058d: stelem.ref
+			IL_058e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0593: stloc.s 28
+			IL_0595: ldloc.s 28
+			IL_0597: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_059c: stloc.s 28
+			IL_059e: ldstr "missing directories: "
+			IL_05a3: ldloc.s 28
+			IL_05a5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05aa: stloc.s 28
+			IL_05ac: ldloc.s 12
+			IL_05ae: ldloc.s 28
+			IL_05b0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_05b5: pop
 
-			IL_05c8: ldloc.s 12
-			IL_05ca: ldc.i4.1
-			IL_05cb: newarr [System.Runtime]System.Object
-			IL_05d0: dup
-			IL_05d1: ldc.i4.0
-			IL_05d2: ldstr "; "
-			IL_05d7: stelem.ref
-			IL_05d8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_05dd: stloc.s 28
-			IL_05df: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05e4: dup
-			IL_05e5: ldstr "ok"
-			IL_05ea: ldc.i4.0
-			IL_05eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05f0: dup
-			IL_05f1: ldstr "message"
-			IL_05f6: ldloc.s 28
-			IL_05f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05fd: stloc.s 29
-			IL_05ff: ldloc.s 29
-			IL_0601: ret
+			IL_05b6: ldloc.s 12
+			IL_05b8: ldc.i4.1
+			IL_05b9: newarr [System.Runtime]System.Object
+			IL_05be: dup
+			IL_05bf: ldc.i4.0
+			IL_05c0: ldstr "; "
+			IL_05c5: stelem.ref
+			IL_05c6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_05cb: stloc.s 28
+			IL_05cd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05d2: dup
+			IL_05d3: ldstr "ok"
+			IL_05d8: ldc.i4.0
+			IL_05d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05de: dup
+			IL_05df: ldstr "message"
+			IL_05e4: ldloc.s 28
+			IL_05e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05eb: stloc.s 29
+			IL_05ed: ldloc.s 29
+			IL_05ef: ret
 
-			IL_0602: ldarg.0
-			IL_0603: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0608: stloc.s 18
-			IL_060a: ldloc.s 18
-			IL_060c: ldstr "join"
-			IL_0611: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0616: brtrue IL_063b
+			IL_05f0: ldarg.0
+			IL_05f1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_05f6: stloc.s 18
+			IL_05f8: ldloc.s 18
+			IL_05fa: ldstr "join"
+			IL_05ff: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0604: brtrue IL_0629
 
-			IL_061b: ldloc.s 18
-			IL_061d: ldc.i4.2
-			IL_061e: newarr [System.Runtime]System.Object
-			IL_0623: dup
-			IL_0624: ldc.i4.0
-			IL_0625: ldarg.2
-			IL_0626: stelem.ref
-			IL_0627: dup
-			IL_0628: ldc.i4.1
-			IL_0629: ldstr "package.json"
-			IL_062e: stelem.ref
-			IL_062f: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0634: stloc.s 13
-			IL_0636: br IL_065b
+			IL_0609: ldloc.s 18
+			IL_060b: ldc.i4.2
+			IL_060c: newarr [System.Runtime]System.Object
+			IL_0611: dup
+			IL_0612: ldc.i4.0
+			IL_0613: ldarg.2
+			IL_0614: stelem.ref
+			IL_0615: dup
+			IL_0616: ldc.i4.1
+			IL_0617: ldstr "package.json"
+			IL_061c: stelem.ref
+			IL_061d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0622: stloc.s 13
+			IL_0624: br IL_0649
 
-			IL_063b: ldloc.s 18
-			IL_063d: ldstr "join"
-			IL_0642: ldc.i4.2
-			IL_0643: newarr [System.Runtime]System.Object
-			IL_0648: dup
-			IL_0649: ldc.i4.0
-			IL_064a: ldarg.2
-			IL_064b: stelem.ref
-			IL_064c: dup
-			IL_064d: ldc.i4.1
-			IL_064e: ldstr "package.json"
-			IL_0653: stelem.ref
-			IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_0659: stloc.s 13
+			IL_0629: ldloc.s 18
+			IL_062b: ldstr "join"
+			IL_0630: ldc.i4.2
+			IL_0631: newarr [System.Runtime]System.Object
+			IL_0636: dup
+			IL_0637: ldc.i4.0
+			IL_0638: ldarg.2
+			IL_0639: stelem.ref
+			IL_063a: dup
+			IL_063b: ldc.i4.1
+			IL_063c: ldstr "package.json"
+			IL_0641: stelem.ref
+			IL_0642: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0647: stloc.s 13
 
-			IL_065b: ldarg.0
-			IL_065c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_0661: stloc.s 21
-			IL_0663: ldloc.s 21
-			IL_0665: ldstr "readFileSync"
-			IL_066a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_066f: brtrue IL_0689
+			IL_0649: ldarg.0
+			IL_064a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_064f: stloc.s 21
+			IL_0651: ldloc.s 21
+			IL_0653: ldstr "readFileSync"
+			IL_0658: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_065d: brtrue IL_0677
 
-			IL_0674: ldloc.s 21
-			IL_0676: ldloc.s 13
-			IL_0678: ldstr "utf8"
-			IL_067d: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0682: stloc.s 16
-			IL_0684: br IL_06aa
+			IL_0662: ldloc.s 21
+			IL_0664: ldloc.s 13
+			IL_0666: ldstr "utf8"
+			IL_066b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0670: stloc.s 16
+			IL_0672: br IL_0698
 
-			IL_0689: ldloc.s 21
-			IL_068b: ldstr "readFileSync"
-			IL_0690: ldc.i4.2
-			IL_0691: newarr [System.Runtime]System.Object
-			IL_0696: dup
-			IL_0697: ldc.i4.0
-			IL_0698: ldloc.s 13
-			IL_069a: stelem.ref
-			IL_069b: dup
-			IL_069c: ldc.i4.1
-			IL_069d: ldstr "utf8"
-			IL_06a2: stelem.ref
-			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_06a8: stloc.s 16
+			IL_0677: ldloc.s 21
+			IL_0679: ldstr "readFileSync"
+			IL_067e: ldc.i4.2
+			IL_067f: newarr [System.Runtime]System.Object
+			IL_0684: dup
+			IL_0685: ldc.i4.0
+			IL_0686: ldloc.s 13
+			IL_0688: stelem.ref
+			IL_0689: dup
+			IL_068a: ldc.i4.1
+			IL_068b: ldstr "utf8"
+			IL_0690: stelem.ref
+			IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0696: stloc.s 16
 
-			IL_06aa: ldloc.s 16
-			IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_06b1: stloc.s 14
-			IL_06b3: ldloc.s 14
-			IL_06b5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_06ba: ldc.i4.0
-			IL_06bb: ceq
+			IL_0698: ldloc.s 16
+			IL_069a: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_069f: stloc.s 14
+			IL_06a1: ldloc.s 14
+			IL_06a3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06a8: ldc.i4.0
+			IL_06a9: ceq
+			IL_06ab: stloc.s 17
+			IL_06ad: ldloc.s 17
+			IL_06af: box [System.Runtime]System.Boolean
+			IL_06b4: stloc.s 22
+			IL_06b6: ldloc.s 22
+			IL_06b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_06bd: stloc.s 17
 			IL_06bf: ldloc.s 17
-			IL_06c1: box [System.Runtime]System.Boolean
-			IL_06c6: stloc.s 22
-			IL_06c8: ldloc.s 22
-			IL_06ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06cf: stloc.s 17
-			IL_06d1: ldloc.s 17
-			IL_06d3: brtrue IL_0792
+			IL_06c1: brtrue IL_0780
 
-			IL_06d8: volatile.
-			IL_06da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
-			IL_06df: brfalse IL_06f5
+			IL_06c6: volatile.
+			IL_06c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
+			IL_06cd: brfalse IL_06e3
 
-			IL_06e4: ldloc.s 14
-			IL_06e6: ldstr "version"
-			IL_06eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06f0: br IL_070b
+			IL_06d2: ldloc.s 14
+			IL_06d4: ldstr "version"
+			IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06de: br IL_06f9
 
-			IL_06f5: ldloc.s 14
-			IL_06f7: ldstr "version"
-			IL_06fc: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:228"
-			IL_0701: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
-			IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06e3: ldloc.s 14
+			IL_06e5: ldstr "version"
+			IL_06ea: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:226"
+			IL_06ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
+			IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_070b: stloc.s 16
-			IL_070d: volatile.
-			IL_070f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
-			IL_0714: brfalse IL_0729
+			IL_06f9: stloc.s 16
+			IL_06fb: volatile.
+			IL_06fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
+			IL_0702: brfalse IL_0717
 
-			IL_0719: ldarg.3
-			IL_071a: ldstr "upstream"
-			IL_071f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0724: br IL_073e
+			IL_0707: ldarg.3
+			IL_0708: ldstr "upstream"
+			IL_070d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0712: br IL_072c
 
-			IL_0729: ldarg.3
-			IL_072a: ldstr "upstream"
-			IL_072f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:231"
-			IL_0734: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
-			IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0717: ldarg.3
+			IL_0718: ldstr "upstream"
+			IL_071d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:229"
+			IL_0722: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
+			IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_073e: stloc.s 30
-			IL_0740: volatile.
-			IL_0742: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
-			IL_0747: brfalse IL_075d
+			IL_072c: stloc.s 30
+			IL_072e: volatile.
+			IL_0730: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
+			IL_0735: brfalse IL_074b
 
-			IL_074c: ldloc.s 30
-			IL_074e: ldstr "packageVersion"
-			IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0758: br IL_0773
+			IL_073a: ldloc.s 30
+			IL_073c: ldstr "packageVersion"
+			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0746: br IL_0761
 
-			IL_075d: ldloc.s 30
-			IL_075f: ldstr "packageVersion"
-			IL_0764: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:233"
-			IL_0769: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
-			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_074b: ldloc.s 30
+			IL_074d: ldstr "packageVersion"
+			IL_0752: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:231"
+			IL_0757: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
+			IL_075c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0773: stloc.s 30
-			IL_0775: ldloc.s 16
-			IL_0777: ldloc.s 30
-			IL_0779: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_077e: stloc.s 17
-			IL_0780: ldloc.s 17
-			IL_0782: box [System.Runtime]System.Boolean
-			IL_0787: stloc.s 23
-			IL_0789: ldloc.s 23
-			IL_078b: stloc.s 31
-			IL_078d: br IL_0796
+			IL_0761: stloc.s 30
+			IL_0763: ldloc.s 16
+			IL_0765: ldloc.s 30
+			IL_0767: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_076c: stloc.s 17
+			IL_076e: ldloc.s 17
+			IL_0770: box [System.Runtime]System.Boolean
+			IL_0775: stloc.s 23
+			IL_0777: ldloc.s 23
+			IL_0779: stloc.s 31
+			IL_077b: br IL_0784
 
-			IL_0792: ldloc.s 22
-			IL_0794: stloc.s 31
+			IL_0780: ldloc.s 22
+			IL_0782: stloc.s 31
 
-			IL_0796: ldloc.s 31
-			IL_0798: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_079d: stloc.s 17
-			IL_079f: ldloc.s 17
-			IL_07a1: brfalse IL_090d
+			IL_0784: ldloc.s 31
+			IL_0786: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_078b: stloc.s 17
+			IL_078d: ldloc.s 17
+			IL_078f: brfalse IL_08fb
 
-			IL_07a6: volatile.
-			IL_07a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
-			IL_07ad: brfalse IL_07c2
+			IL_0794: volatile.
+			IL_0796: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
+			IL_079b: brfalse IL_07b0
 
-			IL_07b2: ldarg.3
-			IL_07b3: ldstr "upstream"
-			IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07bd: br IL_07d7
+			IL_07a0: ldarg.3
+			IL_07a1: ldstr "upstream"
+			IL_07a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07ab: br IL_07c5
 
-			IL_07c2: ldarg.3
-			IL_07c3: ldstr "upstream"
-			IL_07c8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:248"
-			IL_07cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
-			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07b0: ldarg.3
+			IL_07b1: ldstr "upstream"
+			IL_07b6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:246"
+			IL_07bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
+			IL_07c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07d7: stloc.s 30
-			IL_07d9: volatile.
-			IL_07db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
-			IL_07e0: brfalse IL_07f6
+			IL_07c5: stloc.s 30
+			IL_07c7: volatile.
+			IL_07c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
+			IL_07ce: brfalse IL_07e4
 
-			IL_07e5: ldloc.s 30
-			IL_07e7: ldstr "packageVersion"
-			IL_07ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07f1: br IL_080c
+			IL_07d3: ldloc.s 30
+			IL_07d5: ldstr "packageVersion"
+			IL_07da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07df: br IL_07fa
 
-			IL_07f6: ldloc.s 30
-			IL_07f8: ldstr "packageVersion"
-			IL_07fd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:250"
-			IL_0802: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
-			IL_0807: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07e4: ldloc.s 30
+			IL_07e6: ldstr "packageVersion"
+			IL_07eb: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:248"
+			IL_07f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
+			IL_07f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_080c: stloc.s 30
-			IL_080e: ldloc.s 30
-			IL_0810: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0815: stloc.s 28
-			IL_0817: ldstr "package.json version mismatch: expected "
-			IL_081c: ldloc.s 28
-			IL_081e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0823: ldstr ", got "
-			IL_0828: call string [System.Runtime]System.String::Concat(string, string)
-			IL_082d: stloc.s 28
-			IL_082f: ldloc.s 14
-			IL_0831: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0836: stloc.s 17
-			IL_0838: ldloc.s 17
-			IL_083a: brfalse IL_087d
+			IL_07fa: stloc.s 30
+			IL_07fc: ldloc.s 30
+			IL_07fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0803: stloc.s 28
+			IL_0805: ldstr "package.json version mismatch: expected "
+			IL_080a: ldloc.s 28
+			IL_080c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0811: ldstr ", got "
+			IL_0816: call string [System.Runtime]System.String::Concat(string, string)
+			IL_081b: stloc.s 28
+			IL_081d: ldloc.s 14
+			IL_081f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0824: stloc.s 17
+			IL_0826: ldloc.s 17
+			IL_0828: brfalse IL_086b
 
-			IL_083f: volatile.
-			IL_0841: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
-			IL_0846: brfalse IL_085c
+			IL_082d: volatile.
+			IL_082f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
+			IL_0834: brfalse IL_084a
 
-			IL_084b: ldloc.s 14
-			IL_084d: ldstr "version"
-			IL_0852: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0857: br IL_0872
+			IL_0839: ldloc.s 14
+			IL_083b: ldstr "version"
+			IL_0840: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0845: br IL_0860
 
-			IL_085c: ldloc.s 14
-			IL_085e: ldstr "version"
-			IL_0863: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:258"
-			IL_0868: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
-			IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_084a: ldloc.s 14
+			IL_084c: ldstr "version"
+			IL_0851: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:256"
+			IL_0856: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
+			IL_085b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0872: stloc.s 30
-			IL_0874: ldloc.s 30
-			IL_0876: stloc.s 32
-			IL_0878: br IL_0881
+			IL_0860: stloc.s 30
+			IL_0862: ldloc.s 30
+			IL_0864: stloc.s 32
+			IL_0866: br IL_086f
 
-			IL_087d: ldloc.s 14
-			IL_087f: stloc.s 32
+			IL_086b: ldloc.s 14
+			IL_086d: stloc.s 32
 
-			IL_0881: ldloc.s 32
-			IL_0883: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0888: stloc.s 17
-			IL_088a: ldloc.s 17
-			IL_088c: brfalse IL_08cf
+			IL_086f: ldloc.s 32
+			IL_0871: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0876: stloc.s 17
+			IL_0878: ldloc.s 17
+			IL_087a: brfalse IL_08bd
 
-			IL_0891: volatile.
-			IL_0893: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
-			IL_0898: brfalse IL_08ae
+			IL_087f: volatile.
+			IL_0881: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
+			IL_0886: brfalse IL_089c
 
-			IL_089d: ldloc.s 14
-			IL_089f: ldstr "version"
-			IL_08a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a9: br IL_08c4
+			IL_088b: ldloc.s 14
+			IL_088d: ldstr "version"
+			IL_0892: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0897: br IL_08b2
 
-			IL_08ae: ldloc.s 14
-			IL_08b0: ldstr "version"
-			IL_08b5: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:267"
-			IL_08ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
-			IL_08bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_089c: ldloc.s 14
+			IL_089e: ldstr "version"
+			IL_08a3: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M46>:__js_call__:265"
+			IL_08a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
+			IL_08ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08c4: stloc.s 30
-			IL_08c6: ldloc.s 30
-			IL_08c8: stloc.s 15
-			IL_08ca: br IL_08d6
+			IL_08b2: stloc.s 30
+			IL_08b4: ldloc.s 30
+			IL_08b6: stloc.s 15
+			IL_08b8: br IL_08c4
 
-			IL_08cf: ldstr "<missing>"
-			IL_08d4: stloc.s 15
+			IL_08bd: ldstr "<missing>"
+			IL_08c2: stloc.s 15
 
-			IL_08d6: ldloc.s 15
-			IL_08d8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08dd: stloc.s 33
-			IL_08df: ldloc.s 28
-			IL_08e1: ldloc.s 33
-			IL_08e3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08e8: stloc.s 33
-			IL_08ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_08ef: dup
-			IL_08f0: ldstr "ok"
-			IL_08f5: ldc.i4.0
-			IL_08f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_08fb: dup
-			IL_08fc: ldstr "message"
-			IL_0901: ldloc.s 33
-			IL_0903: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0908: stloc.s 29
-			IL_090a: ldloc.s 29
-			IL_090c: ret
+			IL_08c4: ldloc.s 15
+			IL_08c6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08cb: stloc.s 33
+			IL_08cd: ldloc.s 28
+			IL_08cf: ldloc.s 33
+			IL_08d1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08d6: stloc.s 33
+			IL_08d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_08dd: dup
+			IL_08de: ldstr "ok"
+			IL_08e3: ldc.i4.0
+			IL_08e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_08e9: dup
+			IL_08ea: ldstr "message"
+			IL_08ef: ldloc.s 33
+			IL_08f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_08f6: stloc.s 29
+			IL_08f8: ldloc.s 29
+			IL_08fa: ret
 
-			IL_090d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0912: dup
-			IL_0913: ldstr "ok"
-			IL_0918: ldc.i4.1
-			IL_0919: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_091e: dup
-			IL_091f: ldstr "message"
-			IL_0924: ldstr ""
-			IL_0929: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_092e: ret
+			IL_08fb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0900: dup
+			IL_0901: ldstr "ok"
+			IL_0906: ldc.i4.1
+			IL_0907: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_090c: dup
+			IL_090d: ldstr "message"
+			IL_0912: ldstr ""
+			IL_0917: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_091c: ret
 		} // end of method validateResolvedRoot::__js_call__
 
 	} // end of class validateResolvedRoot
@@ -9092,19 +8828,17 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1316 (0x524)
+			// Code size: 1107 (0x453)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Error,
 				[3] bool,
-				[4] object[],
-				[5] object,
+				[4] object,
+				[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[7] object,
-				[8] object[],
-				[9] string
+				[7] string
 			)
 
 			IL_0000: ldarg.s force
@@ -9113,492 +8847,381 @@
 			IL_0008: ceq
 			IL_000a: stloc.3
 			IL_000b: ldloc.3
-			IL_000c: brfalse IL_009c
+			IL_000c: brfalse IL_008f
 
 			IL_0011: ldarg.0
-			IL_0012: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-			IL_0017: ldc.i4.1
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: stelem.ref
-			IL_0021: stloc.s 4
-			IL_0023: ldloc.s 4
-			IL_0025: ldarg.2
-			IL_0026: ldarg.3
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_002c: stloc.0
-			IL_002d: volatile.
-			IL_002f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
-			IL_0034: brfalse IL_0049
+			IL_0012: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0017: ldnull
+			IL_0018: ldarg.2
+			IL_0019: ldarg.3
+			IL_001a: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_001f: stloc.0
+			IL_0020: volatile.
+			IL_0022: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
+			IL_0027: brfalse IL_003c
 
-			IL_0039: ldloc.0
-			IL_003a: ldstr "ok"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0044: br IL_005e
+			IL_002c: ldloc.0
+			IL_002d: ldstr "ok"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: br IL_0051
 
-			IL_0049: ldloc.0
-			IL_004a: ldstr "ok"
-			IL_004f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:13"
-			IL_0054: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_003c: ldloc.0
+			IL_003d: ldstr "ok"
+			IL_0042: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:12"
+			IL_0047: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_142
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_005e: stloc.s 5
-			IL_0060: ldloc.s 5
-			IL_0062: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0067: stloc.3
-			IL_0068: ldloc.3
-			IL_0069: brfalse IL_009c
+			IL_0051: stloc.s 4
+			IL_0053: ldloc.s 4
+			IL_0055: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005a: stloc.3
+			IL_005b: ldloc.3
+			IL_005c: brfalse IL_008f
 
-			IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0073: dup
-			IL_0074: ldstr "source"
-			IL_0079: ldstr "managed-cache"
-			IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0083: dup
-			IL_0084: ldstr "rootPath"
-			IL_0089: ldarg.2
-			IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_008f: dup
-			IL_0090: ldstr "reused"
-			IL_0095: ldc.i4.1
-			IL_0096: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_009b: ret
+			IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0066: dup
+			IL_0067: ldstr "source"
+			IL_006c: ldstr "managed-cache"
+			IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0076: dup
+			IL_0077: ldstr "rootPath"
+			IL_007c: ldarg.2
+			IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0082: dup
+			IL_0083: ldstr "reused"
+			IL_0088: ldc.i4.1
+			IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_008e: ret
 
-			IL_009c: ldarg.0
-			IL_009d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
-			IL_00a2: stloc.s 5
-			IL_00a4: ldc.i4.1
-			IL_00a5: newarr [System.Runtime]System.Object
-			IL_00aa: dup
-			IL_00ab: ldc.i4.0
-			IL_00ac: ldarg.0
-			IL_00ad: stelem.ref
-			IL_00ae: stloc.s 4
-			IL_00b0: ldloc.s 5
-			IL_00b2: ldloc.s 4
-			IL_00b4: ldarg.2
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00ba: pop
-			IL_00bb: ldarg.0
-			IL_00bc: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
-			IL_00c1: stloc.s 5
-			IL_00c3: ldc.i4.1
-			IL_00c4: newarr [System.Runtime]System.Object
-			IL_00c9: dup
-			IL_00ca: ldc.i4.0
-			IL_00cb: ldarg.0
-			IL_00cc: stelem.ref
-			IL_00cd: stloc.s 4
-			IL_00cf: ldloc.s 5
-			IL_00d1: ldloc.s 4
-			IL_00d3: ldarg.2
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00d9: pop
-			IL_00da: ldarg.0
-			IL_00db: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_00e0: stloc.s 5
-			IL_00e2: ldc.i4.1
-			IL_00e3: newarr [System.Runtime]System.Object
-			IL_00e8: dup
-			IL_00e9: ldc.i4.0
-			IL_00ea: ldarg.0
-			IL_00eb: stelem.ref
-			IL_00ec: stloc.s 4
-			IL_00ee: ldc.i4.1
-			IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00f4: dup
-			IL_00f5: ldstr "init"
-			IL_00fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00ff: stloc.s 6
-			IL_0101: ldloc.s 5
-			IL_0103: ldloc.s 4
-			IL_0105: ldloc.s 6
-			IL_0107: ldarg.2
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_010d: pop
-			IL_010e: ldarg.0
-			IL_010f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_0114: stloc.s 5
-			IL_0116: ldc.i4.1
-			IL_0117: newarr [System.Runtime]System.Object
-			IL_011c: dup
-			IL_011d: ldc.i4.0
-			IL_011e: ldarg.0
-			IL_011f: stelem.ref
-			IL_0120: stloc.s 4
-			IL_0122: ldc.i4.3
-			IL_0123: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0128: dup
-			IL_0129: ldstr "config"
-			IL_012e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0133: dup
-			IL_0134: ldstr "core.autocrlf"
-			IL_0139: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_013e: dup
-			IL_013f: ldstr "false"
-			IL_0144: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0149: stloc.s 6
-			IL_014b: ldloc.s 5
-			IL_014d: ldloc.s 4
-			IL_014f: ldloc.s 6
-			IL_0151: ldarg.2
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0157: pop
-			IL_0158: ldarg.0
-			IL_0159: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_015e: stloc.s 5
-			IL_0160: ldc.i4.1
-			IL_0161: newarr [System.Runtime]System.Object
-			IL_0166: dup
-			IL_0167: ldc.i4.0
-			IL_0168: ldarg.0
-			IL_0169: stelem.ref
-			IL_016a: stloc.s 4
-			IL_016c: ldc.i4.3
-			IL_016d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0172: dup
-			IL_0173: ldstr "config"
-			IL_0178: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_017d: dup
-			IL_017e: ldstr "core.eol"
-			IL_0183: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0188: dup
-			IL_0189: ldstr "lf"
-			IL_018e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0193: stloc.s 6
-			IL_0195: ldloc.s 5
-			IL_0197: ldloc.s 4
-			IL_0199: ldloc.s 6
-			IL_019b: ldarg.2
-			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01a1: pop
-			IL_01a2: ldarg.0
-			IL_01a3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_01a8: stloc.s 5
-			IL_01aa: ldc.i4.1
-			IL_01ab: newarr [System.Runtime]System.Object
-			IL_01b0: dup
-			IL_01b1: ldc.i4.0
-			IL_01b2: ldarg.0
-			IL_01b3: stelem.ref
-			IL_01b4: stloc.s 4
-			IL_01b6: volatile.
-			IL_01b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
-			IL_01bd: brfalse IL_01d2
+			IL_008f: ldarg.0
+			IL_0090: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0095: ldnull
+			IL_0096: ldarg.2
+			IL_0097: call object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_009c: pop
+			IL_009d: ldarg.0
+			IL_009e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00a3: ldnull
+			IL_00a4: ldarg.2
+			IL_00a5: call object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00aa: pop
+			IL_00ab: ldc.i4.1
+			IL_00ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00b1: dup
+			IL_00b2: ldstr "init"
+			IL_00b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00bc: stloc.s 5
+			IL_00be: ldarg.0
+			IL_00bf: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00c4: ldnull
+			IL_00c5: ldloc.s 5
+			IL_00c7: ldarg.2
+			IL_00c8: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_00cd: pop
+			IL_00ce: ldc.i4.3
+			IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00d4: dup
+			IL_00d5: ldstr "config"
+			IL_00da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00df: dup
+			IL_00e0: ldstr "core.autocrlf"
+			IL_00e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00ea: dup
+			IL_00eb: ldstr "false"
+			IL_00f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00f5: stloc.s 5
+			IL_00f7: ldarg.0
+			IL_00f8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00fd: ldnull
+			IL_00fe: ldloc.s 5
+			IL_0100: ldarg.2
+			IL_0101: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0106: pop
+			IL_0107: ldc.i4.3
+			IL_0108: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_010d: dup
+			IL_010e: ldstr "config"
+			IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0118: dup
+			IL_0119: ldstr "core.eol"
+			IL_011e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0123: dup
+			IL_0124: ldstr "lf"
+			IL_0129: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012e: stloc.s 5
+			IL_0130: ldarg.0
+			IL_0131: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0136: ldnull
+			IL_0137: ldloc.s 5
+			IL_0139: ldarg.2
+			IL_013a: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_013f: pop
+			IL_0140: volatile.
+			IL_0142: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
+			IL_0147: brfalse IL_015c
 
-			IL_01c2: ldarg.3
-			IL_01c3: ldstr "upstream"
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01cd: br IL_01e7
+			IL_014c: ldarg.3
+			IL_014d: ldstr "upstream"
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0157: br IL_0171
 
-			IL_01d2: ldarg.3
-			IL_01d3: ldstr "upstream"
-			IL_01d8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:67"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_015c: ldarg.3
+			IL_015d: ldstr "upstream"
+			IL_0162: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:59"
+			IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_143
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01e7: stloc.s 7
-			IL_01e9: volatile.
-			IL_01eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
-			IL_01f0: brfalse IL_0206
+			IL_0171: stloc.s 4
+			IL_0173: volatile.
+			IL_0175: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
+			IL_017a: brfalse IL_0190
 
-			IL_01f5: ldloc.s 7
-			IL_01f7: ldstr "cloneUrl"
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0201: br IL_021c
+			IL_017f: ldloc.s 4
+			IL_0181: ldstr "cloneUrl"
+			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_018b: br IL_01a6
 
-			IL_0206: ldloc.s 7
-			IL_0208: ldstr "cloneUrl"
-			IL_020d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:69"
-			IL_0212: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
-			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0190: ldloc.s 4
+			IL_0192: ldstr "cloneUrl"
+			IL_0197: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:61"
+			IL_019c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_144
+			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_021c: stloc.s 7
-			IL_021e: ldc.i4.4
-			IL_021f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0224: dup
-			IL_0225: ldstr "remote"
-			IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_022f: dup
-			IL_0230: ldstr "add"
-			IL_0235: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_023a: dup
-			IL_023b: ldstr "origin"
-			IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0245: dup
-			IL_0246: ldloc.s 7
-			IL_0248: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_024d: stloc.s 6
-			IL_024f: ldloc.s 5
-			IL_0251: ldloc.s 4
-			IL_0253: ldloc.s 6
-			IL_0255: ldarg.2
-			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_025b: pop
-			IL_025c: ldarg.0
-			IL_025d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_0262: stloc.s 5
-			IL_0264: ldc.i4.1
-			IL_0265: newarr [System.Runtime]System.Object
-			IL_026a: dup
-			IL_026b: ldc.i4.0
-			IL_026c: ldarg.0
-			IL_026d: stelem.ref
-			IL_026e: stloc.s 4
-			IL_0270: ldc.i4.3
-			IL_0271: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0276: dup
-			IL_0277: ldstr "sparse-checkout"
-			IL_027c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0281: dup
-			IL_0282: ldstr "init"
-			IL_0287: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_028c: dup
-			IL_028d: ldstr "--no-cone"
-			IL_0292: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0297: stloc.s 6
-			IL_0299: ldloc.s 5
-			IL_029b: ldloc.s 4
-			IL_029d: ldloc.s 6
-			IL_029f: ldarg.2
-			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02a5: pop
-			IL_02a6: ldarg.0
-			IL_02a7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_02ac: stloc.s 5
-			IL_02ae: ldc.i4.1
-			IL_02af: newarr [System.Runtime]System.Object
-			IL_02b4: dup
-			IL_02b5: ldc.i4.0
-			IL_02b6: ldarg.0
-			IL_02b7: stelem.ref
-			IL_02b8: stloc.s 4
-			IL_02ba: ldc.i4.3
-			IL_02bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02c0: dup
-			IL_02c1: ldstr "sparse-checkout"
-			IL_02c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02cb: dup
-			IL_02cc: ldstr "set"
-			IL_02d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02d6: dup
-			IL_02d7: ldstr "--no-cone"
-			IL_02dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02e1: stloc.s 6
-			IL_02e3: ldarg.0
-			IL_02e4: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
-			IL_02e9: ldc.i4.1
-			IL_02ea: newarr [System.Runtime]System.Object
-			IL_02ef: dup
-			IL_02f0: ldc.i4.0
-			IL_02f1: ldarg.0
-			IL_02f2: stelem.ref
-			IL_02f3: stloc.s 8
-			IL_02f5: ldloc.s 8
-			IL_02f7: ldarg.3
-			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_02fd: stloc.s 7
-			IL_02ff: ldloc.s 6
-			IL_0301: ldc.i4.1
-			IL_0302: newarr [System.Runtime]System.Object
-			IL_0307: dup
-			IL_0308: ldc.i4.0
-			IL_0309: ldloc.s 7
-			IL_030b: stelem.ref
-			IL_030c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
-			IL_0311: stloc.s 7
-			IL_0313: ldloc.s 5
-			IL_0315: ldloc.s 4
-			IL_0317: ldloc.s 7
-			IL_0319: ldarg.2
-			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_031f: pop
-			IL_0320: ldarg.0
-			IL_0321: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_0326: stloc.s 7
-			IL_0328: ldc.i4.1
-			IL_0329: newarr [System.Runtime]System.Object
-			IL_032e: dup
-			IL_032f: ldc.i4.0
-			IL_0330: ldarg.0
-			IL_0331: stelem.ref
-			IL_0332: stloc.s 4
-			IL_0334: volatile.
-			IL_0336: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
-			IL_033b: brfalse IL_0350
+			IL_01a6: stloc.s 4
+			IL_01a8: ldc.i4.4
+			IL_01a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01ae: dup
+			IL_01af: ldstr "remote"
+			IL_01b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b9: dup
+			IL_01ba: ldstr "add"
+			IL_01bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01c4: dup
+			IL_01c5: ldstr "origin"
+			IL_01ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01cf: dup
+			IL_01d0: ldloc.s 4
+			IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01d7: stloc.s 5
+			IL_01d9: ldarg.0
+			IL_01da: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_01df: ldnull
+			IL_01e0: ldloc.s 5
+			IL_01e2: ldarg.2
+			IL_01e3: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_01e8: pop
+			IL_01e9: ldc.i4.3
+			IL_01ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01ef: dup
+			IL_01f0: ldstr "sparse-checkout"
+			IL_01f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01fa: dup
+			IL_01fb: ldstr "init"
+			IL_0200: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0205: dup
+			IL_0206: ldstr "--no-cone"
+			IL_020b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0210: stloc.s 5
+			IL_0212: ldarg.0
+			IL_0213: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0218: ldnull
+			IL_0219: ldloc.s 5
+			IL_021b: ldarg.2
+			IL_021c: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0221: pop
+			IL_0222: ldc.i4.3
+			IL_0223: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0228: dup
+			IL_0229: ldstr "sparse-checkout"
+			IL_022e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0233: dup
+			IL_0234: ldstr "set"
+			IL_0239: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_023e: dup
+			IL_023f: ldstr "--no-cone"
+			IL_0244: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0249: stloc.s 5
+			IL_024b: ldarg.0
+			IL_024c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0251: ldnull
+			IL_0252: ldarg.3
+			IL_0253: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0258: stloc.s 6
+			IL_025a: ldloc.s 5
+			IL_025c: ldc.i4.1
+			IL_025d: newarr [System.Runtime]System.Object
+			IL_0262: dup
+			IL_0263: ldc.i4.0
+			IL_0264: ldloc.s 6
+			IL_0266: stelem.ref
+			IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
+			IL_026c: stloc.s 4
+			IL_026e: ldarg.0
+			IL_026f: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0274: ldnull
+			IL_0275: ldloc.s 4
+			IL_0277: ldarg.2
+			IL_0278: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_027d: pop
+			IL_027e: volatile.
+			IL_0280: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
+			IL_0285: brfalse IL_029a
 
-			IL_0340: ldarg.3
-			IL_0341: ldstr "upstream"
-			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_034b: br IL_0365
+			IL_028a: ldarg.3
+			IL_028b: ldstr "upstream"
+			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0295: br IL_02af
 
-			IL_0350: ldarg.3
-			IL_0351: ldstr "upstream"
-			IL_0356: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:105"
-			IL_035b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_029a: ldarg.3
+			IL_029b: ldstr "upstream"
+			IL_02a0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:93"
+			IL_02a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_145
+			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0365: stloc.s 5
-			IL_0367: volatile.
-			IL_0369: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
-			IL_036e: brfalse IL_0384
+			IL_02af: stloc.s 4
+			IL_02b1: volatile.
+			IL_02b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
+			IL_02b8: brfalse IL_02ce
 
-			IL_0373: ldloc.s 5
-			IL_0375: ldstr "commit"
-			IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_037f: br IL_039a
+			IL_02bd: ldloc.s 4
+			IL_02bf: ldstr "commit"
+			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c9: br IL_02e4
 
-			IL_0384: ldloc.s 5
-			IL_0386: ldstr "commit"
-			IL_038b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:107"
-			IL_0390: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
-			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02ce: ldloc.s 4
+			IL_02d0: ldstr "commit"
+			IL_02d5: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:95"
+			IL_02da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_146
+			IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_039a: stloc.s 5
-			IL_039c: ldc.i4.5
-			IL_039d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03a2: dup
-			IL_03a3: ldstr "fetch"
-			IL_03a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03ad: dup
-			IL_03ae: ldstr "--depth"
-			IL_03b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03b8: dup
-			IL_03b9: ldstr "1"
-			IL_03be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03c3: dup
-			IL_03c4: ldstr "origin"
-			IL_03c9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03ce: dup
-			IL_03cf: ldloc.s 5
-			IL_03d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03d6: stloc.s 6
-			IL_03d8: ldloc.s 7
-			IL_03da: ldloc.s 4
-			IL_03dc: ldloc.s 6
-			IL_03de: ldarg.2
-			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03e4: pop
-			IL_03e5: ldarg.0
-			IL_03e6: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
-			IL_03eb: stloc.s 7
-			IL_03ed: ldc.i4.1
-			IL_03ee: newarr [System.Runtime]System.Object
-			IL_03f3: dup
-			IL_03f4: ldc.i4.0
-			IL_03f5: ldarg.0
-			IL_03f6: stelem.ref
-			IL_03f7: stloc.s 4
-			IL_03f9: ldc.i4.3
-			IL_03fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03ff: dup
-			IL_0400: ldstr "checkout"
-			IL_0405: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_040a: dup
-			IL_040b: ldstr "--detach"
-			IL_0410: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0415: dup
-			IL_0416: ldstr "FETCH_HEAD"
-			IL_041b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0420: stloc.s 6
-			IL_0422: ldloc.s 7
-			IL_0424: ldloc.s 4
-			IL_0426: ldloc.s 6
-			IL_0428: ldarg.2
-			IL_0429: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_042e: pop
-			IL_042f: ldarg.0
-			IL_0430: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-			IL_0435: ldc.i4.1
-			IL_0436: newarr [System.Runtime]System.Object
-			IL_043b: dup
-			IL_043c: ldc.i4.0
-			IL_043d: ldarg.0
-			IL_043e: stelem.ref
-			IL_043f: stloc.s 4
-			IL_0441: ldloc.s 4
-			IL_0443: ldarg.2
-			IL_0444: ldarg.3
-			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_044a: stloc.1
-			IL_044b: volatile.
-			IL_044d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
-			IL_0452: brfalse IL_0467
+			IL_02e4: stloc.s 4
+			IL_02e6: ldc.i4.5
+			IL_02e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02ec: dup
+			IL_02ed: ldstr "fetch"
+			IL_02f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02f7: dup
+			IL_02f8: ldstr "--depth"
+			IL_02fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0302: dup
+			IL_0303: ldstr "1"
+			IL_0308: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_030d: dup
+			IL_030e: ldstr "origin"
+			IL_0313: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0318: dup
+			IL_0319: ldloc.s 4
+			IL_031b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0320: stloc.s 6
+			IL_0322: ldarg.0
+			IL_0323: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0328: ldnull
+			IL_0329: ldloc.s 6
+			IL_032b: ldarg.2
+			IL_032c: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0331: pop
+			IL_0332: ldc.i4.3
+			IL_0333: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0338: dup
+			IL_0339: ldstr "checkout"
+			IL_033e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0343: dup
+			IL_0344: ldstr "--detach"
+			IL_0349: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_034e: dup
+			IL_034f: ldstr "FETCH_HEAD"
+			IL_0354: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0359: stloc.s 6
+			IL_035b: ldarg.0
+			IL_035c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0361: ldnull
+			IL_0362: ldloc.s 6
+			IL_0364: ldarg.2
+			IL_0365: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_036a: pop
+			IL_036b: ldarg.0
+			IL_036c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0371: ldnull
+			IL_0372: ldarg.2
+			IL_0373: ldarg.3
+			IL_0374: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0379: stloc.1
+			IL_037a: volatile.
+			IL_037c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
+			IL_0381: brfalse IL_0396
 
-			IL_0457: ldloc.1
-			IL_0458: ldstr "ok"
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0462: br IL_047c
+			IL_0386: ldloc.1
+			IL_0387: ldstr "ok"
+			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0391: br IL_03ab
 
-			IL_0467: ldloc.1
-			IL_0468: ldstr "ok"
-			IL_046d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:129"
-			IL_0472: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
-			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0396: ldloc.1
+			IL_0397: ldstr "ok"
+			IL_039c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:116"
+			IL_03a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_147
+			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_047c: stloc.s 7
-			IL_047e: ldloc.s 7
-			IL_0480: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0485: ldc.i4.0
-			IL_0486: ceq
-			IL_0488: stloc.3
-			IL_0489: ldloc.3
-			IL_048a: brfalse IL_04f6
+			IL_03ab: stloc.s 4
+			IL_03ad: ldloc.s 4
+			IL_03af: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03b4: ldc.i4.0
+			IL_03b5: ceq
+			IL_03b7: stloc.3
+			IL_03b8: ldloc.3
+			IL_03b9: brfalse IL_0425
 
-			IL_048f: volatile.
-			IL_0491: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
-			IL_0496: brfalse IL_04ab
+			IL_03be: volatile.
+			IL_03c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
+			IL_03c5: brfalse IL_03da
 
-			IL_049b: ldloc.1
-			IL_049c: ldstr "message"
-			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04a6: br IL_04c0
+			IL_03ca: ldloc.1
+			IL_03cb: ldstr "message"
+			IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d5: br IL_03ef
 
-			IL_04ab: ldloc.1
-			IL_04ac: ldstr "message"
-			IL_04b1: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:135"
-			IL_04b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
-			IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03da: ldloc.1
+			IL_03db: ldstr "message"
+			IL_03e0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M47>:__js_call__:122"
+			IL_03e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_148
+			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04c0: stloc.s 7
-			IL_04c2: ldloc.s 7
-			IL_04c4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04c9: stloc.s 9
-			IL_04cb: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
-			IL_04d0: ldloc.s 9
-			IL_04d2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04d7: stloc.s 9
-			IL_04d9: ldloc.s 9
-			IL_04db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_04e0: stloc.2
-			IL_04e1: ldloc.2
-			IL_04e2: isinst [System.Runtime]System.Exception
-			IL_04e7: dup
-			IL_04e8: brtrue IL_04f5
+			IL_03ef: stloc.s 4
+			IL_03f1: ldloc.s 4
+			IL_03f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03f8: stloc.s 7
+			IL_03fa: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
+			IL_03ff: ldloc.s 7
+			IL_0401: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0406: stloc.s 7
+			IL_0408: ldloc.s 7
+			IL_040a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_040f: stloc.2
+			IL_0410: ldloc.2
+			IL_0411: isinst [System.Runtime]System.Exception
+			IL_0416: dup
+			IL_0417: brtrue IL_0424
 
-			IL_04ed: pop
-			IL_04ee: ldloc.2
-			IL_04ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_04f4: throw
+			IL_041c: pop
+			IL_041d: ldloc.2
+			IL_041e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0423: throw
 
-			IL_04f5: throw
+			IL_0424: throw
 
-			IL_04f6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04fb: dup
-			IL_04fc: ldstr "source"
-			IL_0501: ldstr "managed-cache"
-			IL_0506: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_050b: dup
-			IL_050c: ldstr "rootPath"
-			IL_0511: ldarg.2
-			IL_0512: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0517: dup
-			IL_0518: ldstr "reused"
-			IL_051d: ldc.i4.0
-			IL_051e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0523: ret
+			IL_0425: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_042a: dup
+			IL_042b: ldstr "source"
+			IL_0430: ldstr "managed-cache"
+			IL_0435: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_043a: dup
+			IL_043b: ldstr "rootPath"
+			IL_0440: ldarg.2
+			IL_0441: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0446: dup
+			IL_0447: ldstr "reused"
+			IL_044c: ldc.i4.0
+			IL_044d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0452: ret
 		} // end of method ensureManagedCheckout::__js_call__
 
 	} // end of class ensureManagedCheckout
@@ -9804,255 +9427,234 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 635 (0x27b)
+			// Code size: 600 (0x258)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.Error,
-				[3] object[],
-				[4] bool,
-				[5] object,
-				[6] string,
-				[7] object,
-				[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[3] bool,
+				[4] object,
+				[5] string,
+				[6] object,
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[8] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.3
-			IL_0011: ldloc.3
-			IL_0012: ldarg.s args
-			IL_0014: ldarg.3
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_001a: stloc.0
-			IL_001b: ldloc.0
-			IL_001c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0021: stloc.s 4
-			IL_0023: ldloc.s 4
-			IL_0025: brfalse IL_0208
+			IL_0001: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0006: ldnull
+			IL_0007: ldarg.s args
+			IL_0009: ldarg.3
+			IL_000a: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_000f: stloc.0
+			IL_0010: ldloc.0
+			IL_0011: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0016: stloc.3
+			IL_0017: ldloc.3
+			IL_0018: brfalse IL_01ee
 
-			IL_002a: ldarg.0
-			IL_002b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
-			IL_0030: ldc.i4.1
-			IL_0031: newarr [System.Runtime]System.Object
-			IL_0036: dup
-			IL_0037: ldc.i4.0
-			IL_0038: ldarg.0
-			IL_0039: stelem.ref
-			IL_003a: stloc.3
-			IL_003b: volatile.
-			IL_003d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
-			IL_0042: brfalse IL_0057
+			IL_001d: volatile.
+			IL_001f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
+			IL_0024: brfalse IL_0039
 
-			IL_0047: ldloc.0
-			IL_0048: ldstr "rootPath"
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0052: br IL_006c
+			IL_0029: ldloc.0
+			IL_002a: ldstr "rootPath"
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0034: br IL_004e
 
-			IL_0057: ldloc.0
-			IL_0058: ldstr "rootPath"
-			IL_005d: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:14"
-			IL_0062: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0039: ldloc.0
+			IL_003a: ldstr "rootPath"
+			IL_003f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:11"
+			IL_0044: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_149
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_006c: stloc.s 5
-			IL_006e: ldloc.3
-			IL_006f: ldloc.s 5
-			IL_0071: ldarg.3
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0077: stloc.1
-			IL_0078: volatile.
-			IL_007a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
-			IL_007f: brfalse IL_0094
+			IL_004e: stloc.s 4
+			IL_0050: ldarg.0
+			IL_0051: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0056: ldnull
+			IL_0057: ldloc.s 4
+			IL_0059: ldarg.3
+			IL_005a: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_005f: stloc.1
+			IL_0060: volatile.
+			IL_0062: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
+			IL_0067: brfalse IL_007c
 
-			IL_0084: ldloc.1
-			IL_0085: ldstr "ok"
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008f: br IL_00a9
+			IL_006c: ldloc.1
+			IL_006d: ldstr "ok"
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0077: br IL_0091
 
-			IL_0094: ldloc.1
-			IL_0095: ldstr "ok"
-			IL_009a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:20"
-			IL_009f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_007c: ldloc.1
+			IL_007d: ldstr "ok"
+			IL_0082: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:18"
+			IL_0087: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_150
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00a9: stloc.s 5
-			IL_00ab: ldloc.s 5
-			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00b2: ldc.i4.0
-			IL_00b3: ceq
-			IL_00b5: stloc.s 4
-			IL_00b7: ldloc.s 4
-			IL_00b9: brfalse IL_0172
+			IL_0091: stloc.s 4
+			IL_0093: ldloc.s 4
+			IL_0095: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_009a: ldc.i4.0
+			IL_009b: ceq
+			IL_009d: stloc.3
+			IL_009e: ldloc.3
+			IL_009f: brfalse IL_0158
 
-			IL_00be: volatile.
-			IL_00c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
-			IL_00c5: brfalse IL_00da
+			IL_00a4: volatile.
+			IL_00a6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
+			IL_00ab: brfalse IL_00c0
 
-			IL_00ca: ldloc.0
-			IL_00cb: ldstr "rootPath"
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d5: br IL_00ef
+			IL_00b0: ldloc.0
+			IL_00b1: ldstr "rootPath"
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bb: br IL_00d5
 
-			IL_00da: ldloc.0
-			IL_00db: ldstr "rootPath"
-			IL_00e0: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:26"
-			IL_00e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00c0: ldloc.0
+			IL_00c1: ldstr "rootPath"
+			IL_00c6: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:24"
+			IL_00cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_151
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00ef: stloc.s 5
-			IL_00f1: ldloc.s 5
-			IL_00f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00f8: stloc.s 6
-			IL_00fa: ldstr "Override test262 root '"
-			IL_00ff: ldloc.s 6
-			IL_0101: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0106: ldstr "' is invalid: "
-			IL_010b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0110: volatile.
-			IL_0112: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
-			IL_0117: brfalse IL_012c
+			IL_00d5: stloc.s 4
+			IL_00d7: ldloc.s 4
+			IL_00d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00de: stloc.s 5
+			IL_00e0: ldstr "Override test262 root '"
+			IL_00e5: ldloc.s 5
+			IL_00e7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ec: ldstr "' is invalid: "
+			IL_00f1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00f6: volatile.
+			IL_00f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
+			IL_00fd: brfalse IL_0112
 
-			IL_011c: ldloc.1
-			IL_011d: ldstr "message"
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0127: br IL_0141
+			IL_0102: ldloc.1
+			IL_0103: ldstr "message"
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_010d: br IL_0127
 
-			IL_012c: ldloc.1
-			IL_012d: ldstr "message"
-			IL_0132: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:32"
-			IL_0137: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
-			IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0112: ldloc.1
+			IL_0113: ldstr "message"
+			IL_0118: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:30"
+			IL_011d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0141: stloc.s 5
-			IL_0143: ldloc.s 5
-			IL_0145: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_014a: stloc.s 6
-			IL_014c: ldloc.s 6
-			IL_014e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0153: stloc.s 6
-			IL_0155: ldloc.s 6
-			IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_015c: stloc.2
-			IL_015d: ldloc.2
-			IL_015e: isinst [System.Runtime]System.Exception
-			IL_0163: dup
-			IL_0164: brtrue IL_0171
+			IL_0127: stloc.s 4
+			IL_0129: ldloc.s 4
+			IL_012b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0130: stloc.s 5
+			IL_0132: ldloc.s 5
+			IL_0134: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0139: stloc.s 5
+			IL_013b: ldloc.s 5
+			IL_013d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0142: stloc.2
+			IL_0143: ldloc.2
+			IL_0144: isinst [System.Runtime]System.Exception
+			IL_0149: dup
+			IL_014a: brtrue IL_0157
 
-			IL_0169: pop
-			IL_016a: ldloc.2
-			IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0170: throw
+			IL_014f: pop
+			IL_0150: ldloc.2
+			IL_0151: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0156: throw
 
-			IL_0171: throw
+			IL_0157: throw
 
-			IL_0172: volatile.
-			IL_0174: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
-			IL_0179: brfalse IL_018e
+			IL_0158: volatile.
+			IL_015a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
+			IL_015f: brfalse IL_0174
 
-			IL_017e: ldloc.0
-			IL_017f: ldstr "source"
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0189: br IL_01a3
+			IL_0164: ldloc.0
+			IL_0165: ldstr "source"
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016f: br IL_0189
 
-			IL_018e: ldloc.0
-			IL_018f: ldstr "source"
-			IL_0194: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:41"
-			IL_0199: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
-			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0174: ldloc.0
+			IL_0175: ldstr "source"
+			IL_017a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:39"
+			IL_017f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_153
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01a3: stloc.s 5
-			IL_01a5: volatile.
-			IL_01a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
-			IL_01ac: brfalse IL_01c1
+			IL_0189: stloc.s 4
+			IL_018b: volatile.
+			IL_018d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
+			IL_0192: brfalse IL_01a7
 
-			IL_01b1: ldloc.0
-			IL_01b2: ldstr "rootPath"
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01bc: br IL_01d6
+			IL_0197: ldloc.0
+			IL_0198: ldstr "rootPath"
+			IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01a2: br IL_01bc
 
-			IL_01c1: ldloc.0
-			IL_01c2: ldstr "rootPath"
-			IL_01c7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:43"
-			IL_01cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01a7: ldloc.0
+			IL_01a8: ldstr "rootPath"
+			IL_01ad: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:41"
+			IL_01b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01d6: stloc.s 7
-			IL_01d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01bc: stloc.s 6
+			IL_01be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01c3: dup
+			IL_01c4: ldstr "source"
+			IL_01c9: ldloc.s 4
+			IL_01cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01d0: dup
+			IL_01d1: ldstr "rootPath"
+			IL_01d6: ldloc.s 6
+			IL_01d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_01dd: dup
-			IL_01de: ldstr "source"
-			IL_01e3: ldloc.s 5
-			IL_01e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01ea: dup
-			IL_01eb: ldstr "rootPath"
-			IL_01f0: ldloc.s 7
-			IL_01f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01f7: dup
-			IL_01f8: ldstr "reused"
-			IL_01fd: ldc.i4.1
-			IL_01fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0203: stloc.s 8
-			IL_0205: ldloc.s 8
-			IL_0207: ret
+			IL_01de: ldstr "reused"
+			IL_01e3: ldc.i4.1
+			IL_01e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_01e9: stloc.s 7
+			IL_01eb: ldloc.s 7
+			IL_01ed: ret
 
-			IL_0208: ldarg.0
-			IL_0209: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
-			IL_020e: ldc.i4.1
-			IL_020f: newarr [System.Runtime]System.Object
-			IL_0214: dup
-			IL_0215: ldc.i4.0
-			IL_0216: ldarg.0
-			IL_0217: stelem.ref
-			IL_0218: stloc.3
-			IL_0219: ldloc.3
-			IL_021a: ldarg.2
-			IL_021b: ldarg.3
-			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0221: stloc.s 7
-			IL_0223: volatile.
-			IL_0225: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
-			IL_022a: brfalse IL_0240
+			IL_01ee: ldarg.0
+			IL_01ef: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_01f4: ldnull
+			IL_01f5: ldarg.2
+			IL_01f6: ldarg.3
+			IL_01f7: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_01fc: stloc.s 6
+			IL_01fe: volatile.
+			IL_0200: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
+			IL_0205: brfalse IL_021b
 
-			IL_022f: ldarg.s args
-			IL_0231: ldstr "force"
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023b: br IL_0256
+			IL_020a: ldarg.s args
+			IL_020c: ldstr "force"
+			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0216: br IL_0231
 
-			IL_0240: ldarg.s args
-			IL_0242: ldstr "force"
-			IL_0247: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:57"
-			IL_024c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
-			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_021b: ldarg.s args
+			IL_021d: ldstr "force"
+			IL_0222: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M48>:__js_call__:54"
+			IL_0227: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_155
+			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0256: stloc.s 5
-			IL_0258: ldc.i4.1
-			IL_0259: newarr [System.Runtime]System.Object
-			IL_025e: dup
-			IL_025f: ldc.i4.0
-			IL_0260: ldarg.0
-			IL_0261: stelem.ref
-			IL_0262: stloc.3
-			IL_0263: ldloc.3
-			IL_0264: ldc.i4.0
-			IL_0265: ldelem.ref
-			IL_0266: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_026b: ldnull
-			IL_026c: ldloc.s 7
-			IL_026e: ldarg.3
-			IL_026f: ldloc.s 5
-			IL_0271: tail.
-			IL_0273: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_0278: ret
+			IL_0231: stloc.s 4
+			IL_0233: ldc.i4.1
+			IL_0234: newarr [System.Runtime]System.Object
+			IL_0239: dup
+			IL_023a: ldc.i4.0
+			IL_023b: ldarg.0
+			IL_023c: stelem.ref
+			IL_023d: stloc.s 8
+			IL_023f: ldloc.s 8
+			IL_0241: ldc.i4.0
+			IL_0242: ldelem.ref
+			IL_0243: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0248: ldnull
+			IL_0249: ldloc.s 6
+			IL_024b: ldarg.3
+			IL_024c: ldloc.s 4
+			IL_024e: tail.
+			IL_0250: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_0255: ret
 
-			IL_0279: ldnull
-			IL_027a: ret
+			IL_0256: ldnull
+			IL_0257: ret
 		} // end of method resolveBootstrapRoot::__js_call__
 
 	} // end of class resolveBootstrapRoot
@@ -10237,7 +9839,7 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 707 (0x2c3)
+			// Code size: 688 (0x2b0)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -10246,12 +9848,11 @@
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[4] object,
 				[5] string,
-				[6] object[],
+				[6] string,
 				[7] string,
 				[8] string,
 				[9] string,
-				[10] string,
-				[11] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[10] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.s printRootOnly
@@ -10341,160 +9942,151 @@
 			IL_00ed: ldloc.s 5
 			IL_00ef: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00f4: stloc.s 5
-			IL_00f6: ldarg.0
-			IL_00f7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
-			IL_00fc: ldc.i4.1
-			IL_00fd: newarr [System.Runtime]System.Object
-			IL_0102: dup
-			IL_0103: ldc.i4.0
-			IL_0104: ldarg.0
-			IL_0105: stelem.ref
-			IL_0106: stloc.s 6
-			IL_0108: volatile.
-			IL_010a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
-			IL_010f: brfalse IL_0124
+			IL_00f6: volatile.
+			IL_00f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
+			IL_00fd: brfalse IL_0112
 
-			IL_0114: ldarg.2
-			IL_0115: ldstr "rootPath"
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_011f: br IL_0139
+			IL_0102: ldarg.2
+			IL_0103: ldstr "rootPath"
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_010d: br IL_0127
 
-			IL_0124: ldarg.2
-			IL_0125: ldstr "rootPath"
-			IL_012a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:41"
-			IL_012f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0112: ldarg.2
+			IL_0113: ldstr "rootPath"
+			IL_0118: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:39"
+			IL_011d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_159
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0139: stloc.s 4
-			IL_013b: ldloc.s 6
-			IL_013d: ldloc.s 4
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0144: stloc.s 4
-			IL_0146: ldloc.s 4
-			IL_0148: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_014d: stloc.s 7
-			IL_014f: ldstr "root "
-			IL_0154: ldloc.s 7
-			IL_0156: call string [System.Runtime]System.String::Concat(string, string)
-			IL_015b: stloc.s 7
-			IL_015d: volatile.
-			IL_015f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
-			IL_0164: brfalse IL_0179
+			IL_0127: stloc.s 4
+			IL_0129: ldnull
+			IL_012a: ldloc.s 4
+			IL_012c: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_0131: stloc.s 4
+			IL_0133: ldloc.s 4
+			IL_0135: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_013a: stloc.s 6
+			IL_013c: ldstr "root "
+			IL_0141: ldloc.s 6
+			IL_0143: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0148: stloc.s 6
+			IL_014a: volatile.
+			IL_014c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
+			IL_0151: brfalse IL_0166
 
-			IL_0169: ldarg.3
-			IL_016a: ldstr "upstream"
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0174: br IL_018e
+			IL_0156: ldarg.3
+			IL_0157: ldstr "upstream"
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0161: br IL_017b
 
-			IL_0179: ldarg.3
-			IL_017a: ldstr "upstream"
-			IL_017f: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:48"
-			IL_0184: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
-			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0166: ldarg.3
+			IL_0167: ldstr "upstream"
+			IL_016c: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:47"
+			IL_0171: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_018e: stloc.s 4
-			IL_0190: volatile.
-			IL_0192: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
-			IL_0197: brfalse IL_01ad
+			IL_017b: stloc.s 4
+			IL_017d: volatile.
+			IL_017f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
+			IL_0184: brfalse IL_019a
 
-			IL_019c: ldloc.s 4
-			IL_019e: ldstr "commit"
-			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a8: br IL_01c3
+			IL_0189: ldloc.s 4
+			IL_018b: ldstr "commit"
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0195: br IL_01b0
 
-			IL_01ad: ldloc.s 4
-			IL_01af: ldstr "commit"
-			IL_01b4: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:50"
-			IL_01b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
-			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_019a: ldloc.s 4
+			IL_019c: ldstr "commit"
+			IL_01a1: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:49"
+			IL_01a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_161
+			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01c3: stloc.s 4
-			IL_01c5: ldloc.s 4
-			IL_01c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01cc: stloc.s 8
-			IL_01ce: ldstr "commit "
-			IL_01d3: ldloc.s 8
-			IL_01d5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01da: stloc.s 8
-			IL_01dc: volatile.
-			IL_01de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
-			IL_01e3: brfalse IL_01f8
+			IL_01b0: stloc.s 4
+			IL_01b2: ldloc.s 4
+			IL_01b4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b9: stloc.s 7
+			IL_01bb: ldstr "commit "
+			IL_01c0: ldloc.s 7
+			IL_01c2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01c7: stloc.s 7
+			IL_01c9: volatile.
+			IL_01cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
+			IL_01d0: brfalse IL_01e5
 
-			IL_01e8: ldarg.3
-			IL_01e9: ldstr "upstream"
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f3: br IL_020d
+			IL_01d5: ldarg.3
+			IL_01d6: ldstr "upstream"
+			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01e0: br IL_01fa
 
-			IL_01f8: ldarg.3
-			IL_01f9: ldstr "upstream"
-			IL_01fe: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:56"
-			IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
-			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01e5: ldarg.3
+			IL_01e6: ldstr "upstream"
+			IL_01eb: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:55"
+			IL_01f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_020d: stloc.s 4
-			IL_020f: volatile.
-			IL_0211: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
-			IL_0216: brfalse IL_022c
+			IL_01fa: stloc.s 4
+			IL_01fc: volatile.
+			IL_01fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
+			IL_0203: brfalse IL_0219
 
-			IL_021b: ldloc.s 4
-			IL_021d: ldstr "packageVersion"
-			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0227: br IL_0242
+			IL_0208: ldloc.s 4
+			IL_020a: ldstr "packageVersion"
+			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0214: br IL_022f
 
-			IL_022c: ldloc.s 4
-			IL_022e: ldstr "packageVersion"
-			IL_0233: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:58"
-			IL_0238: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
-			IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0219: ldloc.s 4
+			IL_021b: ldstr "packageVersion"
+			IL_0220: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M49>:__js_call__:57"
+			IL_0225: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
+			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0242: stloc.s 4
-			IL_0244: ldloc.s 4
-			IL_0246: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_024b: stloc.s 9
-			IL_024d: ldstr "packageVersion "
-			IL_0252: ldloc.s 9
-			IL_0254: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0259: stloc.s 9
-			IL_025b: ldloc.1
-			IL_025c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0261: stloc.s 10
-			IL_0263: ldstr "status "
-			IL_0268: ldloc.s 10
-			IL_026a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_026f: stloc.s 10
-			IL_0271: ldc.i4.5
-			IL_0272: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0277: dup
-			IL_0278: ldloc.s 5
-			IL_027a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_027f: dup
-			IL_0280: ldloc.s 7
-			IL_0282: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0287: dup
-			IL_0288: ldloc.s 8
-			IL_028a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_028f: dup
-			IL_0290: ldloc.s 9
-			IL_0292: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0297: dup
-			IL_0298: ldloc.s 10
-			IL_029a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_029f: stloc.s 11
-			IL_02a1: ldloc.s 11
-			IL_02a3: ldc.i4.1
-			IL_02a4: newarr [System.Runtime]System.Object
-			IL_02a9: dup
-			IL_02aa: ldc.i4.0
-			IL_02ab: ldstr "\n"
-			IL_02b0: stelem.ref
-			IL_02b1: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_02b6: stloc.s 10
-			IL_02b8: ldloc.3
-			IL_02b9: ldloc.s 10
-			IL_02bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02c0: pop
-			IL_02c1: ldnull
-			IL_02c2: ret
+			IL_022f: stloc.s 4
+			IL_0231: ldloc.s 4
+			IL_0233: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0238: stloc.s 8
+			IL_023a: ldstr "packageVersion "
+			IL_023f: ldloc.s 8
+			IL_0241: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0246: stloc.s 8
+			IL_0248: ldloc.1
+			IL_0249: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_024e: stloc.s 9
+			IL_0250: ldstr "status "
+			IL_0255: ldloc.s 9
+			IL_0257: call string [System.Runtime]System.String::Concat(string, string)
+			IL_025c: stloc.s 9
+			IL_025e: ldc.i4.5
+			IL_025f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0264: dup
+			IL_0265: ldloc.s 5
+			IL_0267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_026c: dup
+			IL_026d: ldloc.s 6
+			IL_026f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0274: dup
+			IL_0275: ldloc.s 7
+			IL_0277: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_027c: dup
+			IL_027d: ldloc.s 8
+			IL_027f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0284: dup
+			IL_0285: ldloc.s 9
+			IL_0287: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_028c: stloc.s 10
+			IL_028e: ldloc.s 10
+			IL_0290: ldc.i4.1
+			IL_0291: newarr [System.Runtime]System.Object
+			IL_0296: dup
+			IL_0297: ldc.i4.0
+			IL_0298: ldstr "\n"
+			IL_029d: stelem.ref
+			IL_029e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_02a3: stloc.s 9
+			IL_02a5: ldloc.3
+			IL_02a6: ldloc.s 9
+			IL_02a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02ad: pop
+			IL_02ae: ldnull
+			IL_02af: ret
 		} // end of method printResolvedRoot::__js_call__
 
 	} // end of class printResolvedRoot
@@ -10677,7 +10269,7 @@
 				74 61 54 6f 6b 65 6e 28 00 00 02
 			)
 			// Header size: 12
-			// Code size: 700 (0x2bc)
+			// Code size: 585 (0x249)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -10686,285 +10278,222 @@
 				[3] object,
 				[4] object,
 				[5] object,
-				[6] object[],
+				[6] bool,
 				[7] object,
-				[8] bool,
+				[8] object,
 				[9] object,
-				[10] object,
-				[11] object,
-				[12] class [JavaScriptRuntime]JavaScriptRuntime.Console
+				[10] class [JavaScriptRuntime]JavaScriptRuntime.Console
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
-			IL_0006: stloc.s 5
-			IL_0008: ldc.i4.1
-			IL_0009: newarr [System.Runtime]System.Object
-			IL_000e: dup
-			IL_000f: ldc.i4.0
-			IL_0010: ldarg.0
-			IL_0011: stelem.ref
-			IL_0012: stloc.s 6
-			IL_0014: ldstr "process"
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_001e: volatile.
-			IL_0020: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
-			IL_0025: brfalse IL_0039
+			IL_0000: ldstr "process"
+			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_000a: volatile.
+			IL_000c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
+			IL_0011: brfalse IL_0025
 
-			IL_002a: ldstr "argv"
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0034: br IL_004d
+			IL_0016: ldstr "argv"
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0020: br IL_0039
 
-			IL_0039: ldstr "argv"
-			IL_003e: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:6"
-			IL_0043: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0025: ldstr "argv"
+			IL_002a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:4"
+			IL_002f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_004d: stloc.s 7
-			IL_004f: ldloc.s 7
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: stloc.s 7
-			IL_0058: ldc.i4.0
-			IL_0059: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_005e: brfalse IL_009e
+			IL_0039: stloc.s 5
+			IL_003b: ldloc.s 5
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0042: stloc.s 5
+			IL_0044: ldc.i4.0
+			IL_0045: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_004a: brfalse IL_008a
 
-			IL_0063: ldloc.s 7
-			IL_0065: isinst [System.Runtime]System.String
-			IL_006a: dup
-			IL_006b: brtrue IL_0083
+			IL_004f: ldloc.s 5
+			IL_0051: isinst [System.Runtime]System.String
+			IL_0056: dup
+			IL_0057: brtrue IL_006f
 
-			IL_0070: pop
-			IL_0071: ldloc.s 7
-			IL_0073: ldstr "slice"
-			IL_0078: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_007d: dup
-			IL_007e: brfalse IL_009d
+			IL_005c: pop
+			IL_005d: ldloc.s 5
+			IL_005f: ldstr "slice"
+			IL_0064: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0069: dup
+			IL_006a: brfalse IL_0089
 
-			IL_0083: ldc.r8 2
-			IL_008c: box [System.Runtime]System.Double
-			IL_0091: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
-			IL_0096: stloc.s 7
-			IL_0098: br IL_00ba
+			IL_006f: ldc.r8 2
+			IL_0078: box [System.Runtime]System.Double
+			IL_007d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_0082: stloc.s 5
+			IL_0084: br IL_00a6
 
-			IL_009d: pop
+			IL_0089: pop
 
-			IL_009e: ldloc.s 7
-			IL_00a0: ldstr "slice"
-			IL_00a5: ldc.r8 2
-			IL_00ae: box [System.Runtime]System.Double
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00b8: stloc.s 7
+			IL_008a: ldloc.s 5
+			IL_008c: ldstr "slice"
+			IL_0091: ldc.r8 2
+			IL_009a: box [System.Runtime]System.Double
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00a4: stloc.s 5
 
-			IL_00ba: ldloc.s 5
-			IL_00bc: ldloc.s 6
-			IL_00be: ldloc.s 7
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00c5: stloc.0
-			IL_00c6: volatile.
-			IL_00c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
-			IL_00cd: brfalse IL_00e2
+			IL_00a6: ldarg.0
+			IL_00a7: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00ac: ldnull
+			IL_00ad: ldloc.s 5
+			IL_00af: call object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00b4: stloc.0
+			IL_00b5: volatile.
+			IL_00b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
+			IL_00bc: brfalse IL_00d1
 
-			IL_00d2: ldloc.0
-			IL_00d3: ldstr "help"
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00dd: br IL_00f7
+			IL_00c1: ldloc.0
+			IL_00c2: ldstr "help"
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00cc: br IL_00e6
 
-			IL_00e2: ldloc.0
-			IL_00e3: ldstr "help"
-			IL_00e8: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:15"
-			IL_00ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00d1: ldloc.0
+			IL_00d2: ldstr "help"
+			IL_00d7: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:14"
+			IL_00dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00f7: stloc.s 7
-			IL_00f9: ldloc.s 7
-			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0100: stloc.s 8
-			IL_0102: ldloc.s 8
-			IL_0104: brfalse IL_0125
+			IL_00e6: stloc.s 5
+			IL_00e8: ldloc.s 5
+			IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00ef: stloc.s 6
+			IL_00f1: ldloc.s 6
+			IL_00f3: brfalse IL_0101
 
-			IL_0109: ldarg.0
-			IL_010a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
-			IL_010f: stloc.s 7
-			IL_0111: ldloc.s 7
-			IL_0113: ldc.i4.1
-			IL_0114: newarr [System.Runtime]System.Object
-			IL_0119: dup
-			IL_011a: ldc.i4.0
-			IL_011b: ldarg.0
-			IL_011c: stelem.ref
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0122: pop
-			IL_0123: ldnull
-			IL_0124: ret
+			IL_00f8: ldnull
+			IL_00f9: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
+			IL_00fe: pop
+			IL_00ff: ldnull
+			IL_0100: ret
 
-			IL_0125: ldarg.0
-			IL_0126: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
-			IL_012b: stloc.s 7
-			IL_012d: ldc.i4.1
-			IL_012e: newarr [System.Runtime]System.Object
-			IL_0133: dup
-			IL_0134: ldc.i4.0
-			IL_0135: ldarg.0
-			IL_0136: stelem.ref
-			IL_0137: stloc.s 6
-			IL_0139: volatile.
-			IL_013b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
-			IL_0140: brfalse IL_0155
+			IL_0101: volatile.
+			IL_0103: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
+			IL_0108: brfalse IL_011d
 
-			IL_0145: ldloc.0
-			IL_0146: ldstr "pin"
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0150: br IL_016a
+			IL_010d: ldloc.0
+			IL_010e: ldstr "pin"
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0118: br IL_0132
 
-			IL_0155: ldloc.0
-			IL_0156: ldstr "pin"
-			IL_015b: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:30"
-			IL_0160: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
-			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_011d: ldloc.0
+			IL_011e: ldstr "pin"
+			IL_0123: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:26"
+			IL_0128: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_016a: stloc.s 5
-			IL_016c: ldloc.s 5
-			IL_016e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0173: stloc.s 8
-			IL_0175: ldloc.s 8
-			IL_0177: brtrue IL_019c
+			IL_0132: stloc.s 5
+			IL_0134: ldloc.s 5
+			IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_013b: stloc.s 6
+			IL_013d: ldloc.s 6
+			IL_013f: brtrue IL_015b
 
+			IL_0144: ldarg.0
+			IL_0145: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_014a: ldnull
+			IL_014b: call object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+			IL_0150: stloc.s 7
+			IL_0152: ldloc.s 7
+			IL_0154: stloc.s 9
+			IL_0156: br IL_015f
+
+			IL_015b: ldloc.s 5
+			IL_015d: stloc.s 9
+
+			IL_015f: ldarg.0
+			IL_0160: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0165: ldnull
+			IL_0166: ldloc.s 9
+			IL_0168: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_016d: stloc.1
+			IL_016e: ldarg.0
+			IL_016f: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0174: ldnull
+			IL_0175: ldloc.1
+			IL_0176: call object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_017b: stloc.2
 			IL_017c: ldarg.0
-			IL_017d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
-			IL_0182: ldc.i4.1
-			IL_0183: newarr [System.Runtime]System.Object
-			IL_0188: dup
-			IL_0189: ldc.i4.0
-			IL_018a: ldarg.0
-			IL_018b: stelem.ref
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0191: stloc.s 9
-			IL_0193: ldloc.s 9
-			IL_0195: stloc.s 11
-			IL_0197: br IL_01a0
+			IL_017d: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0182: ldnull
+			IL_0183: ldloc.0
+			IL_0184: ldloc.2
+			IL_0185: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_018a: stloc.3
+			IL_018b: volatile.
+			IL_018d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
+			IL_0192: brfalse IL_01a7
 
-			IL_019c: ldloc.s 5
-			IL_019e: stloc.s 11
+			IL_0197: ldloc.0
+			IL_0198: ldstr "describe"
+			IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01a2: br IL_01bc
 
-			IL_01a0: ldloc.s 7
-			IL_01a2: ldloc.s 6
-			IL_01a4: ldloc.s 11
-			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01ab: stloc.1
-			IL_01ac: ldarg.0
-			IL_01ad: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
-			IL_01b2: ldc.i4.1
-			IL_01b3: newarr [System.Runtime]System.Object
-			IL_01b8: dup
-			IL_01b9: ldc.i4.0
-			IL_01ba: ldarg.0
-			IL_01bb: stelem.ref
-			IL_01bc: ldloc.1
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01c2: stloc.2
-			IL_01c3: ldarg.0
-			IL_01c4: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
-			IL_01c9: ldc.i4.1
-			IL_01ca: newarr [System.Runtime]System.Object
-			IL_01cf: dup
-			IL_01d0: ldc.i4.0
-			IL_01d1: ldarg.0
-			IL_01d2: stelem.ref
-			IL_01d3: ldloc.0
-			IL_01d4: ldloc.2
-			IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01da: stloc.3
-			IL_01db: volatile.
-			IL_01dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
-			IL_01e2: brfalse IL_01f7
+			IL_01a7: ldloc.0
+			IL_01a8: ldstr "describe"
+			IL_01ad: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:49"
+			IL_01b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01e7: ldloc.0
-			IL_01e8: ldstr "describe"
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f2: br IL_020c
+			IL_01bc: stloc.s 5
+			IL_01be: ldloc.s 5
+			IL_01c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01c5: stloc.s 6
+			IL_01c7: ldloc.s 6
+			IL_01c9: brfalse IL_01f1
 
-			IL_01f7: ldloc.0
-			IL_01f8: ldstr "describe"
-			IL_01fd: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:55"
-			IL_0202: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_167
-			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01d3: stloc.s 10
+			IL_01d5: ldarg.0
+			IL_01d6: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_01db: ldnull
+			IL_01dc: ldloc.2
+			IL_01dd: ldloc.3
+			IL_01de: call object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_01e3: stloc.s 5
+			IL_01e5: ldloc.s 10
+			IL_01e7: ldloc.s 5
+			IL_01e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01ee: pop
+			IL_01ef: ldnull
+			IL_01f0: ret
 
-			IL_020c: stloc.s 7
-			IL_020e: ldloc.s 7
-			IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0215: stloc.s 8
-			IL_0217: ldloc.s 8
-			IL_0219: brfalse IL_024a
+			IL_01f1: ldarg.0
+			IL_01f2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_01f7: ldnull
+			IL_01f8: ldloc.1
+			IL_01f9: ldloc.2
+			IL_01fa: ldloc.0
+			IL_01fb: call object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_0200: stloc.s 4
+			IL_0202: volatile.
+			IL_0204: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
+			IL_0209: brfalse IL_021e
 
-			IL_021e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0223: stloc.s 12
-			IL_0225: ldarg.0
-			IL_0226: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
-			IL_022b: ldc.i4.1
-			IL_022c: newarr [System.Runtime]System.Object
-			IL_0231: dup
-			IL_0232: ldc.i4.0
-			IL_0233: ldarg.0
-			IL_0234: stelem.ref
-			IL_0235: ldloc.2
-			IL_0236: ldloc.3
-			IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_023c: stloc.s 7
-			IL_023e: ldloc.s 12
-			IL_0240: ldloc.s 7
-			IL_0242: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0247: pop
-			IL_0248: ldnull
-			IL_0249: ret
+			IL_020e: ldloc.0
+			IL_020f: ldstr "printRoot"
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0219: br IL_0233
 
-			IL_024a: ldarg.0
-			IL_024b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
-			IL_0250: ldc.i4.1
-			IL_0251: newarr [System.Runtime]System.Object
-			IL_0256: dup
-			IL_0257: ldc.i4.0
-			IL_0258: ldarg.0
-			IL_0259: stelem.ref
-			IL_025a: ldloc.1
-			IL_025b: ldloc.2
-			IL_025c: ldloc.0
-			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0262: stloc.s 4
-			IL_0264: ldarg.0
-			IL_0265: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
-			IL_026a: stloc.s 7
-			IL_026c: ldc.i4.1
-			IL_026d: newarr [System.Runtime]System.Object
-			IL_0272: dup
-			IL_0273: ldc.i4.0
-			IL_0274: ldarg.0
-			IL_0275: stelem.ref
-			IL_0276: stloc.s 6
-			IL_0278: volatile.
-			IL_027a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
-			IL_027f: brfalse IL_0294
+			IL_021e: ldloc.0
+			IL_021f: ldstr "printRoot"
+			IL_0224: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:67"
+			IL_0229: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
+			IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0284: ldloc.0
-			IL_0285: ldstr "printRoot"
-			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028f: br IL_02a9
-
-			IL_0294: ldloc.0
-			IL_0295: ldstr "printRoot"
-			IL_029a: ldstr "Compile_Scripts_Test262Bootstrap:<TwoPhaseDummy_M50>:__js_call__:77"
-			IL_029f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
-			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_02a9: stloc.s 5
-			IL_02ab: ldloc.s 7
-			IL_02ad: ldloc.s 6
-			IL_02af: ldloc.s 4
-			IL_02b1: ldloc.2
-			IL_02b2: ldloc.s 5
-			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_02b9: pop
-			IL_02ba: ldnull
-			IL_02bb: ret
+			IL_0233: stloc.s 5
+			IL_0235: ldarg.0
+			IL_0236: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_023b: ldnull
+			IL_023c: ldloc.s 4
+			IL_023e: ldloc.2
+			IL_023f: ldloc.s 5
+			IL_0241: call object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_0246: pop
+			IL_0247: ldnull
+			IL_0248: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -11107,7 +10636,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1913 (0x779)
+		// Code size: 1914 (0x77a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262Bootstrap/Scope,
@@ -11823,136 +11352,137 @@
 		IL_0611: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_0616: stloc.s 46
 		IL_0618: ldloc.s 46
-		IL_061a: brfalse IL_0775
+		IL_061a: brfalse IL_0776
 		.try
 		{
 			IL_061f: nop
-			IL_0620: ldloc.1
-			IL_0621: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_062b: pop
-			IL_062c: leave IL_0775
+			IL_0620: ldloc.0
+			IL_0621: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0626: ldnull
+			IL_0627: call object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+			IL_062c: pop
+			IL_062d: leave IL_0776
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0631: stloc.2
-			IL_0632: ldloc.2
-			IL_0633: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0638: dup
-			IL_0639: brtrue IL_064e
+			IL_0632: stloc.2
+			IL_0633: ldloc.2
+			IL_0634: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0639: dup
+			IL_063a: brtrue IL_064f
 
-			IL_063e: pop
-			IL_063f: ldloc.2
-			IL_0640: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0645: dup
-			IL_0646: brtrue IL_0659
+			IL_063f: pop
+			IL_0640: ldloc.2
+			IL_0641: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0646: dup
+			IL_0647: brtrue IL_065a
 
-			IL_064b: pop
-			IL_064c: rethrow
+			IL_064c: pop
+			IL_064d: rethrow
 
-			IL_064e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0653: stloc.3
-			IL_0654: br IL_065a
+			IL_064f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0654: stloc.3
+			IL_0655: br IL_065b
 
-			IL_0659: stloc.3
+			IL_065a: stloc.3
 
-			IL_065a: ldloc.3
-			IL_065b: stloc.s 4
-			IL_065d: ldloc.s 4
-			IL_065f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0664: stloc.s 46
-			IL_0666: ldloc.s 46
-			IL_0668: brfalse IL_06ab
+			IL_065b: ldloc.3
+			IL_065c: stloc.s 4
+			IL_065e: ldloc.s 4
+			IL_0660: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0665: stloc.s 46
+			IL_0667: ldloc.s 46
+			IL_0669: brfalse IL_06ac
 
-			IL_066d: volatile.
-			IL_066f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-			IL_0674: brfalse IL_068a
+			IL_066e: volatile.
+			IL_0670: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_0675: brfalse IL_068b
 
-			IL_0679: ldloc.s 4
-			IL_067b: ldstr "message"
-			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0685: br IL_06a0
+			IL_067a: ldloc.s 4
+			IL_067c: ldstr "message"
+			IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0686: br IL_06a1
 
-			IL_068a: ldloc.s 4
-			IL_068c: ldstr "message"
-			IL_0691: ldstr "Compile_Scripts_Test262Bootstrap:Modules.Compile_Scripts_Test262Bootstrap:__js_module_init__:153"
-			IL_0696: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-			IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_068b: ldloc.s 4
+			IL_068d: ldstr "message"
+			IL_0692: ldstr "Compile_Scripts_Test262Bootstrap:Modules.Compile_Scripts_Test262Bootstrap:__js_module_init__:153"
+			IL_0697: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06a0: stloc.s 44
-			IL_06a2: ldloc.s 44
-			IL_06a4: stloc.s 48
-			IL_06a6: br IL_06af
+			IL_06a1: stloc.s 44
+			IL_06a3: ldloc.s 44
+			IL_06a5: stloc.s 48
+			IL_06a7: br IL_06b0
 
-			IL_06ab: ldloc.s 4
-			IL_06ad: stloc.s 48
+			IL_06ac: ldloc.s 4
+			IL_06ae: stloc.s 48
 
-			IL_06af: ldloc.s 48
-			IL_06b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_06b6: stloc.s 46
-			IL_06b8: ldloc.s 46
-			IL_06ba: brfalse IL_06fd
+			IL_06b0: ldloc.s 48
+			IL_06b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_06b7: stloc.s 46
+			IL_06b9: ldloc.s 46
+			IL_06bb: brfalse IL_06fe
 
-			IL_06bf: volatile.
-			IL_06c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-			IL_06c6: brfalse IL_06dc
+			IL_06c0: volatile.
+			IL_06c2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_06c7: brfalse IL_06dd
 
-			IL_06cb: ldloc.s 4
-			IL_06cd: ldstr "message"
-			IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06d7: br IL_06f2
+			IL_06cc: ldloc.s 4
+			IL_06ce: ldstr "message"
+			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06d8: br IL_06f3
 
-			IL_06dc: ldloc.s 4
-			IL_06de: ldstr "message"
-			IL_06e3: ldstr "Compile_Scripts_Test262Bootstrap:Modules.Compile_Scripts_Test262Bootstrap:__js_module_init__:162"
-			IL_06e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-			IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06dd: ldloc.s 4
+			IL_06df: ldstr "message"
+			IL_06e4: ldstr "Compile_Scripts_Test262Bootstrap:Modules.Compile_Scripts_Test262Bootstrap:__js_module_init__:162"
+			IL_06e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_06ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06f2: stloc.s 44
-			IL_06f4: ldloc.s 44
-			IL_06f6: stloc.s 5
-			IL_06f8: br IL_070a
+			IL_06f3: stloc.s 44
+			IL_06f5: ldloc.s 44
+			IL_06f7: stloc.s 5
+			IL_06f9: br IL_070b
 
-			IL_06fd: ldloc.s 4
-			IL_06ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0704: stloc.s 49
-			IL_0706: ldloc.s 49
-			IL_0708: stloc.s 5
+			IL_06fe: ldloc.s 4
+			IL_0700: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0705: stloc.s 49
+			IL_0707: ldloc.s 49
+			IL_0709: stloc.s 5
 
-			IL_070a: ldloc.s 5
-			IL_070c: stloc.s 6
-			IL_070e: ldstr "console"
-			IL_0713: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_071d: volatile.
-			IL_071f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-			IL_0724: brfalse IL_073a
+			IL_070b: ldloc.s 5
+			IL_070d: stloc.s 6
+			IL_070f: ldstr "console"
+			IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_071e: volatile.
+			IL_0720: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_0725: brfalse IL_073b
 
-			IL_0729: ldstr "error"
-			IL_072e: ldloc.s 6
-			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0735: br IL_0750
+			IL_072a: ldstr "error"
+			IL_072f: ldloc.s 6
+			IL_0731: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0736: br IL_0751
 
-			IL_073a: ldstr "error"
-			IL_073f: ldloc.s 6
-			IL_0741: ldstr "Compile_Scripts_Test262Bootstrap:Modules.Compile_Scripts_Test262Bootstrap:__js_module_init__:174"
-			IL_0746: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_073b: ldstr "error"
+			IL_0740: ldloc.s 6
+			IL_0742: ldstr "Compile_Scripts_Test262Bootstrap:Modules.Compile_Scripts_Test262Bootstrap:__js_module_init__:174"
+			IL_0747: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_074c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0750: pop
-			IL_0751: ldstr "process"
-			IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_075b: ldstr "exitCode"
-			IL_0760: ldc.r8 1
-			IL_0769: ldc.i4.1
-			IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_076f: pop
-			IL_0770: leave IL_0775
+			IL_0751: pop
+			IL_0752: ldstr "process"
+			IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_075c: ldstr "exitCode"
+			IL_0761: ldc.r8 1
+			IL_076a: ldc.i4.1
+			IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0770: pop
+			IL_0771: leave IL_0776
 		} // end handler
 
-		IL_0775: ldnull
-		IL_0776: stloc.s 7
-		IL_0778: ret
+		IL_0776: ldnull
+		IL_0777: stloc.s 7
+		IL_0779: ret
 	} // end of method Compile_Scripts_Test262Bootstrap::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262Bootstrap

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -1000,13 +1000,12 @@
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 218 (0xda)
+			// Code size: 196 (0xc4)
 			.maxstack 8
 			.locals init (
 				[0] bool,
-				[1] object[],
-				[2] object,
-				[3] object
+				[1] object,
+				[2] object
 			)
 
 			IL_0000: ldarg.2
@@ -1020,82 +1019,68 @@
 			IL_0010: ldstr "null"
 			IL_0015: ret
 
-			IL_0016: ldarg.0
-			IL_0017: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_001c: ldc.i4.1
-			IL_001d: newarr [System.Runtime]System.Object
-			IL_0022: dup
-			IL_0023: ldc.i4.0
-			IL_0024: ldarg.0
-			IL_0025: stelem.ref
-			IL_0026: stloc.1
-			IL_0027: volatile.
-			IL_0029: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-			IL_002e: brfalse IL_0043
+			IL_0016: volatile.
+			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_001d: brfalse IL_0032
 
-			IL_0033: ldarg.2
-			IL_0034: ldstr "phase"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003e: br IL_0058
+			IL_0022: ldarg.2
+			IL_0023: ldstr "phase"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002d: br IL_0047
 
-			IL_0043: ldarg.2
-			IL_0044: ldstr "phase"
-			IL_0049: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:14"
-			IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0032: ldarg.2
+			IL_0033: ldstr "phase"
+			IL_0038: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:12"
+			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0058: stloc.2
-			IL_0059: ldloc.1
-			IL_005a: ldloc.2
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0060: stloc.2
-			IL_0061: ldstr "{ phase: "
-			IL_0066: ldloc.2
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006c: stloc.3
-			IL_006d: ldloc.3
-			IL_006e: ldstr ", type: "
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0078: stloc.3
-			IL_0079: ldarg.0
-			IL_007a: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_007f: ldc.i4.1
-			IL_0080: newarr [System.Runtime]System.Object
-			IL_0085: dup
-			IL_0086: ldc.i4.0
-			IL_0087: ldarg.0
-			IL_0088: stelem.ref
-			IL_0089: stloc.1
-			IL_008a: volatile.
-			IL_008c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-			IL_0091: brfalse IL_00a6
+			IL_0047: stloc.1
+			IL_0048: ldarg.0
+			IL_0049: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_004e: ldnull
+			IL_004f: ldloc.1
+			IL_0050: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0055: stloc.1
+			IL_0056: ldstr "{ phase: "
+			IL_005b: ldloc.1
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0061: stloc.2
+			IL_0062: ldloc.2
+			IL_0063: ldstr ", type: "
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_006d: stloc.2
+			IL_006e: volatile.
+			IL_0070: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_0075: brfalse IL_008a
 
-			IL_0096: ldarg.2
-			IL_0097: ldstr "type"
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a1: br IL_00bb
+			IL_007a: ldarg.2
+			IL_007b: ldstr "type"
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0085: br IL_009f
 
-			IL_00a6: ldarg.2
-			IL_00a7: ldstr "type"
-			IL_00ac: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:23"
-			IL_00b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_008a: ldarg.2
+			IL_008b: ldstr "type"
+			IL_0090: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M24>:__js_call__:20"
+			IL_0095: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00bb: stloc.2
-			IL_00bc: ldloc.1
-			IL_00bd: ldloc.2
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00c3: stloc.2
-			IL_00c4: ldloc.3
-			IL_00c5: ldloc.2
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00cb: stloc.3
-			IL_00cc: ldloc.3
-			IL_00cd: ldstr " }"
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00d7: stloc.3
-			IL_00d8: ldloc.3
-			IL_00d9: ret
+			IL_009f: stloc.1
+			IL_00a0: ldarg.0
+			IL_00a1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_00a6: ldnull
+			IL_00a7: ldloc.1
+			IL_00a8: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_00ad: stloc.1
+			IL_00ae: ldloc.2
+			IL_00af: ldloc.1
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00b5: stloc.2
+			IL_00b6: ldloc.2
+			IL_00b7: ldstr " }"
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00c1: stloc.2
+			IL_00c2: ldloc.2
+			IL_00c3: ret
 		} // end of method formatNegative::__js_call__
 
 	} // end of class formatNegative
@@ -1266,13 +1251,12 @@
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 313 (0x139)
+			// Code size: 280 (0x118)
 			.maxstack 8
 			.locals init (
 				[0] bool,
-				[1] object[],
-				[2] object,
-				[3] object
+				[1] object,
+				[2] object
 			)
 
 			IL_0000: ldarg.2
@@ -1286,119 +1270,98 @@
 			IL_0010: ldstr "null"
 			IL_0015: ret
 
-			IL_0016: ldarg.0
-			IL_0017: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_001c: ldc.i4.1
-			IL_001d: newarr [System.Runtime]System.Object
-			IL_0022: dup
-			IL_0023: ldc.i4.0
-			IL_0024: ldarg.0
-			IL_0025: stelem.ref
-			IL_0026: stloc.1
-			IL_0027: volatile.
-			IL_0029: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-			IL_002e: brfalse IL_0043
+			IL_0016: volatile.
+			IL_0018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_001d: brfalse IL_0032
 
-			IL_0033: ldarg.2
-			IL_0034: ldstr "code"
-			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_003e: br IL_0058
+			IL_0022: ldarg.2
+			IL_0023: ldstr "code"
+			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002d: br IL_0047
 
-			IL_0043: ldarg.2
-			IL_0044: ldstr "code"
-			IL_0049: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M25>:__js_call__:14"
-			IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0032: ldarg.2
+			IL_0033: ldstr "code"
+			IL_0038: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M25>:__js_call__:12"
+			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0058: stloc.2
-			IL_0059: ldloc.1
-			IL_005a: ldloc.2
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0060: stloc.2
-			IL_0061: ldstr "{ code: "
-			IL_0066: ldloc.2
-			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006c: stloc.3
-			IL_006d: ldloc.3
-			IL_006e: ldstr ", source: "
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0078: stloc.3
-			IL_0079: ldarg.0
-			IL_007a: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_007f: ldc.i4.1
-			IL_0080: newarr [System.Runtime]System.Object
-			IL_0085: dup
-			IL_0086: ldc.i4.0
-			IL_0087: ldarg.0
-			IL_0088: stelem.ref
-			IL_0089: stloc.1
-			IL_008a: volatile.
-			IL_008c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-			IL_0091: brfalse IL_00a6
+			IL_0047: stloc.1
+			IL_0048: ldarg.0
+			IL_0049: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_004e: ldnull
+			IL_004f: ldloc.1
+			IL_0050: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0055: stloc.1
+			IL_0056: ldstr "{ code: "
+			IL_005b: ldloc.1
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0061: stloc.2
+			IL_0062: ldloc.2
+			IL_0063: ldstr ", source: "
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_006d: stloc.2
+			IL_006e: volatile.
+			IL_0070: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0075: brfalse IL_008a
 
-			IL_0096: ldarg.2
-			IL_0097: ldstr "source"
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a1: br IL_00bb
+			IL_007a: ldarg.2
+			IL_007b: ldstr "source"
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0085: br IL_009f
 
-			IL_00a6: ldarg.2
-			IL_00a7: ldstr "source"
-			IL_00ac: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M25>:__js_call__:23"
-			IL_00b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_008a: ldarg.2
+			IL_008b: ldstr "source"
+			IL_0090: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M25>:__js_call__:20"
+			IL_0095: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00bb: stloc.2
-			IL_00bc: ldloc.1
-			IL_00bd: ldloc.2
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00c3: stloc.2
-			IL_00c4: ldloc.3
-			IL_00c5: ldloc.2
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00cb: stloc.3
-			IL_00cc: ldloc.3
-			IL_00cd: ldstr ", reason: "
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00d7: stloc.3
-			IL_00d8: ldarg.0
-			IL_00d9: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_00de: ldc.i4.1
-			IL_00df: newarr [System.Runtime]System.Object
-			IL_00e4: dup
-			IL_00e5: ldc.i4.0
-			IL_00e6: ldarg.0
-			IL_00e7: stelem.ref
-			IL_00e8: stloc.1
-			IL_00e9: volatile.
-			IL_00eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-			IL_00f0: brfalse IL_0105
+			IL_009f: stloc.1
+			IL_00a0: ldarg.0
+			IL_00a1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_00a6: ldnull
+			IL_00a7: ldloc.1
+			IL_00a8: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_00ad: stloc.1
+			IL_00ae: ldloc.2
+			IL_00af: ldloc.1
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00b5: stloc.2
+			IL_00b6: ldloc.2
+			IL_00b7: ldstr ", reason: "
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00c1: stloc.2
+			IL_00c2: volatile.
+			IL_00c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_00c9: brfalse IL_00de
 
-			IL_00f5: ldarg.2
-			IL_00f6: ldstr "reason"
-			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0100: br IL_011a
+			IL_00ce: ldarg.2
+			IL_00cf: ldstr "reason"
+			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d9: br IL_00f3
 
-			IL_0105: ldarg.2
-			IL_0106: ldstr "reason"
-			IL_010b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M25>:__js_call__:32"
-			IL_0110: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00de: ldarg.2
+			IL_00df: ldstr "reason"
+			IL_00e4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M25>:__js_call__:28"
+			IL_00e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_011a: stloc.2
-			IL_011b: ldloc.1
-			IL_011c: ldloc.2
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0122: stloc.2
-			IL_0123: ldloc.3
-			IL_0124: ldloc.2
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_012a: stloc.3
-			IL_012b: ldloc.3
-			IL_012c: ldstr " }"
-			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0136: stloc.3
-			IL_0137: ldloc.3
-			IL_0138: ret
+			IL_00f3: stloc.1
+			IL_00f4: ldarg.0
+			IL_00f5: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_00fa: ldnull
+			IL_00fb: ldloc.1
+			IL_00fc: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0101: stloc.1
+			IL_0102: ldloc.2
+			IL_0103: ldloc.1
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0109: stloc.2
+			IL_010a: ldloc.2
+			IL_010b: ldstr " }"
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0115: stloc.2
+			IL_0116: ldloc.2
+			IL_0117: ret
 		} // end of method formatIssue::__js_call__
 
 	} // end of class formatIssue
@@ -1557,2636 +1520,2264 @@
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
 			// Header size: 12
-			// Code size: 7157 (0x1bf5)
+			// Code size: 6574 (0x19ae)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-				[1] object[],
-				[2] object,
-				[3] object
+				[1] object,
+				[2] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_000c: ldc.i4.1
-			IL_000d: newarr [System.Runtime]System.Object
-			IL_0012: dup
-			IL_0013: ldc.i4.0
-			IL_0014: ldarg.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.1
-			IL_0017: ldloc.1
-			IL_0018: ldarg.2
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_001e: stloc.2
-			IL_001f: ldstr "name: "
-			IL_0024: ldloc.2
-			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_002a: stloc.3
-			IL_002b: ldloc.0
-			IL_002c: ldloc.3
-			IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0032: pop
-			IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0038: stloc.0
-			IL_0039: ldarg.0
-			IL_003a: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_003f: ldc.i4.1
-			IL_0040: newarr [System.Runtime]System.Object
-			IL_0045: dup
-			IL_0046: ldc.i4.0
-			IL_0047: ldarg.0
-			IL_0048: stelem.ref
-			IL_0049: stloc.1
-			IL_004a: volatile.
-			IL_004c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-			IL_0051: brfalse IL_0066
+			IL_0007: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_000c: ldnull
+			IL_000d: ldarg.2
+			IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0013: stloc.1
+			IL_0014: ldstr "name: "
+			IL_0019: ldloc.1
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_001f: stloc.2
+			IL_0020: ldloc.0
+			IL_0021: ldloc.2
+			IL_0022: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0027: pop
+			IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_002d: stloc.0
+			IL_002e: volatile.
+			IL_0030: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0035: brfalse IL_004a
 
-			IL_0056: ldarg.3
-			IL_0057: ldstr "filePath"
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0061: br IL_007b
+			IL_003a: ldarg.3
+			IL_003b: ldstr "filePath"
+			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0045: br IL_005f
 
-			IL_0066: ldarg.3
-			IL_0067: ldstr "filePath"
-			IL_006c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:16"
-			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_004a: ldarg.3
+			IL_004b: ldstr "filePath"
+			IL_0050: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:13"
+			IL_0055: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_007b: stloc.2
-			IL_007c: ldloc.1
-			IL_007d: ldloc.2
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0083: stloc.2
-			IL_0084: ldstr "filePath: "
-			IL_0089: ldloc.2
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_008f: stloc.3
-			IL_0090: ldloc.0
-			IL_0091: ldloc.3
-			IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0097: pop
-			IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_009d: stloc.0
-			IL_009e: ldarg.0
-			IL_009f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_00a4: ldc.i4.1
-			IL_00a5: newarr [System.Runtime]System.Object
-			IL_00aa: dup
-			IL_00ab: ldc.i4.0
-			IL_00ac: ldarg.0
-			IL_00ad: stelem.ref
-			IL_00ae: stloc.1
-			IL_00af: volatile.
-			IL_00b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-			IL_00b6: brfalse IL_00cb
+			IL_005f: stloc.1
+			IL_0060: ldarg.0
+			IL_0061: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0066: ldnull
+			IL_0067: ldloc.1
+			IL_0068: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_006d: stloc.1
+			IL_006e: ldstr "filePath: "
+			IL_0073: ldloc.1
+			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0079: stloc.2
+			IL_007a: ldloc.0
+			IL_007b: ldloc.2
+			IL_007c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0081: pop
+			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0087: stloc.0
+			IL_0088: volatile.
+			IL_008a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_008f: brfalse IL_00a4
 
-			IL_00bb: ldarg.3
-			IL_00bc: ldstr "fileName"
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c6: br IL_00e0
+			IL_0094: ldarg.3
+			IL_0095: ldstr "fileName"
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009f: br IL_00b9
 
-			IL_00cb: ldarg.3
-			IL_00cc: ldstr "fileName"
-			IL_00d1: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:27"
-			IL_00d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00a4: ldarg.3
+			IL_00a5: ldstr "fileName"
+			IL_00aa: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:23"
+			IL_00af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00e0: stloc.2
-			IL_00e1: ldloc.1
-			IL_00e2: ldloc.2
-			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00e8: stloc.2
-			IL_00e9: ldstr "fileName: "
-			IL_00ee: ldloc.2
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00f4: stloc.3
-			IL_00f5: ldloc.0
-			IL_00f6: ldloc.3
-			IL_00f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00fc: pop
-			IL_00fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0102: stloc.0
-			IL_0103: ldarg.0
-			IL_0104: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0109: ldc.i4.1
-			IL_010a: newarr [System.Runtime]System.Object
-			IL_010f: dup
-			IL_0110: ldc.i4.0
-			IL_0111: ldarg.0
-			IL_0112: stelem.ref
+			IL_00b9: stloc.1
+			IL_00ba: ldarg.0
+			IL_00bb: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_00c0: ldnull
+			IL_00c1: ldloc.1
+			IL_00c2: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_00c7: stloc.1
+			IL_00c8: ldstr "fileName: "
+			IL_00cd: ldloc.1
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00d3: stloc.2
+			IL_00d4: ldloc.0
+			IL_00d5: ldloc.2
+			IL_00d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00db: pop
+			IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00e1: stloc.0
+			IL_00e2: volatile.
+			IL_00e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_00e9: brfalse IL_00fe
+
+			IL_00ee: ldarg.3
+			IL_00ef: ldstr "hasFrontmatter"
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f9: br IL_0113
+
+			IL_00fe: ldarg.3
+			IL_00ff: ldstr "hasFrontmatter"
+			IL_0104: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:33"
+			IL_0109: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
 			IL_0113: stloc.1
-			IL_0114: volatile.
-			IL_0116: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_011b: brfalse IL_0130
-
-			IL_0120: ldarg.3
-			IL_0121: ldstr "hasFrontmatter"
-			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_012b: br IL_0145
-
-			IL_0130: ldarg.3
-			IL_0131: ldstr "hasFrontmatter"
-			IL_0136: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:38"
-			IL_013b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0145: stloc.2
-			IL_0146: ldloc.1
-			IL_0147: ldloc.2
-			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_014d: stloc.2
-			IL_014e: ldstr "hasFrontmatter: "
-			IL_0153: ldloc.2
-			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0159: stloc.3
-			IL_015a: ldloc.0
-			IL_015b: ldloc.3
-			IL_015c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0161: pop
-			IL_0162: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0167: stloc.0
-			IL_0168: ldarg.0
-			IL_0169: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_016e: ldc.i4.1
-			IL_016f: newarr [System.Runtime]System.Object
-			IL_0174: dup
-			IL_0175: ldc.i4.0
-			IL_0176: ldarg.0
-			IL_0177: stelem.ref
-			IL_0178: stloc.1
-			IL_0179: volatile.
-			IL_017b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_0180: brfalse IL_0195
-
-			IL_0185: ldarg.3
-			IL_0186: ldstr "unknownKeys"
-			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0190: br IL_01aa
-
-			IL_0195: ldarg.3
-			IL_0196: ldstr "unknownKeys"
-			IL_019b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:49"
-			IL_01a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_01aa: stloc.2
-			IL_01ab: volatile.
-			IL_01ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-			IL_01b2: brfalse IL_01c7
-
-			IL_01b7: ldloc.2
-			IL_01b8: ldstr "length"
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c2: br IL_01dc
-
-			IL_01c7: ldloc.2
-			IL_01c8: ldstr "length"
-			IL_01cd: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:51"
-			IL_01d2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_01dc: stloc.2
-			IL_01dd: ldloc.1
-			IL_01de: ldloc.2
-			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01e4: stloc.2
-			IL_01e5: ldstr "unknownKeys.length: "
-			IL_01ea: ldloc.2
-			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01f0: stloc.3
-			IL_01f1: ldloc.0
-			IL_01f2: ldloc.3
-			IL_01f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01f8: pop
-			IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01fe: stloc.0
-			IL_01ff: ldarg.0
-			IL_0200: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0205: ldc.i4.1
-			IL_0206: newarr [System.Runtime]System.Object
-			IL_020b: dup
-			IL_020c: ldc.i4.0
-			IL_020d: ldarg.0
-			IL_020e: stelem.ref
-			IL_020f: stloc.1
-			IL_0210: volatile.
-			IL_0212: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_0217: brfalse IL_022c
-
-			IL_021c: ldarg.3
-			IL_021d: ldstr "unknownKeys"
-			IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0227: br IL_0241
-
-			IL_022c: ldarg.3
-			IL_022d: ldstr "unknownKeys"
-			IL_0232: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:62"
-			IL_0237: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0241: stloc.2
-			IL_0242: ldloc.2
-			IL_0243: ldc.r8 0.0
-			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0251: stloc.2
-			IL_0252: ldloc.1
-			IL_0253: ldloc.2
-			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0259: stloc.2
-			IL_025a: ldstr "unknownKeys[0]: "
-			IL_025f: ldloc.2
-			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0265: stloc.3
-			IL_0266: ldloc.0
-			IL_0267: ldloc.3
-			IL_0268: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_026d: pop
-			IL_026e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0273: stloc.0
-			IL_0274: ldarg.0
-			IL_0275: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_027a: ldc.i4.1
-			IL_027b: newarr [System.Runtime]System.Object
-			IL_0280: dup
-			IL_0281: ldc.i4.0
-			IL_0282: ldarg.0
-			IL_0283: stelem.ref
-			IL_0284: stloc.1
-			IL_0285: volatile.
-			IL_0287: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_028c: brfalse IL_02a1
-
-			IL_0291: ldarg.3
-			IL_0292: ldstr "description"
-			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029c: br IL_02b6
-
-			IL_02a1: ldarg.3
-			IL_02a2: ldstr "description"
-			IL_02a7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:75"
-			IL_02ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_02b6: stloc.2
-			IL_02b7: ldloc.1
-			IL_02b8: ldloc.2
-			IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_02be: stloc.2
-			IL_02bf: ldstr "description: "
-			IL_02c4: ldloc.2
-			IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02ca: stloc.3
-			IL_02cb: ldloc.0
-			IL_02cc: ldloc.3
-			IL_02cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02d2: pop
-			IL_02d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02d8: stloc.0
-			IL_02d9: ldarg.0
-			IL_02da: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_02df: ldc.i4.1
-			IL_02e0: newarr [System.Runtime]System.Object
-			IL_02e5: dup
-			IL_02e6: ldc.i4.0
-			IL_02e7: ldarg.0
-			IL_02e8: stelem.ref
-			IL_02e9: stloc.1
-			IL_02ea: volatile.
-			IL_02ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_02f1: brfalse IL_0306
-
-			IL_02f6: ldarg.3
-			IL_02f7: ldstr "info"
-			IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0301: br IL_031b
-
-			IL_0306: ldarg.3
-			IL_0307: ldstr "info"
-			IL_030c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:86"
-			IL_0311: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_031b: stloc.2
-			IL_031c: ldloc.1
-			IL_031d: ldloc.2
-			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0323: stloc.2
-			IL_0324: ldstr "info: "
-			IL_0329: ldloc.2
-			IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_032f: stloc.3
-			IL_0330: ldloc.0
-			IL_0331: ldloc.3
-			IL_0332: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0337: pop
-			IL_0338: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_033d: stloc.0
-			IL_033e: ldarg.0
-			IL_033f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0344: ldc.i4.1
-			IL_0345: newarr [System.Runtime]System.Object
-			IL_034a: dup
-			IL_034b: ldc.i4.0
-			IL_034c: ldarg.0
-			IL_034d: stelem.ref
-			IL_034e: stloc.1
-			IL_034f: volatile.
-			IL_0351: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_0356: brfalse IL_036b
-
-			IL_035b: ldarg.3
-			IL_035c: ldstr "esid"
-			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0366: br IL_0380
-
-			IL_036b: ldarg.3
-			IL_036c: ldstr "esid"
-			IL_0371: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:97"
-			IL_0376: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0380: stloc.2
-			IL_0381: ldloc.1
-			IL_0382: ldloc.2
-			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0388: stloc.2
-			IL_0389: ldstr "esid: "
-			IL_038e: ldloc.2
-			IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0394: stloc.3
-			IL_0395: ldloc.0
-			IL_0396: ldloc.3
-			IL_0397: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_039c: pop
-			IL_039d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03a2: stloc.0
-			IL_03a3: ldarg.0
-			IL_03a4: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_03a9: ldc.i4.1
-			IL_03aa: newarr [System.Runtime]System.Object
-			IL_03af: dup
-			IL_03b0: ldc.i4.0
-			IL_03b1: ldarg.0
-			IL_03b2: stelem.ref
-			IL_03b3: stloc.1
-			IL_03b4: volatile.
-			IL_03b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_03bb: brfalse IL_03d0
-
-			IL_03c0: ldarg.3
-			IL_03c1: ldstr "es5id"
-			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03cb: br IL_03e5
-
-			IL_03d0: ldarg.3
-			IL_03d1: ldstr "es5id"
-			IL_03d6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:108"
-			IL_03db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_03e5: stloc.2
-			IL_03e6: ldloc.1
-			IL_03e7: ldloc.2
-			IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_03ed: stloc.2
-			IL_03ee: ldstr "es5id: "
-			IL_03f3: ldloc.2
-			IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03f9: stloc.3
-			IL_03fa: ldloc.0
-			IL_03fb: ldloc.3
-			IL_03fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0401: pop
-			IL_0402: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0407: stloc.0
-			IL_0408: ldarg.0
-			IL_0409: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_040e: ldc.i4.1
-			IL_040f: newarr [System.Runtime]System.Object
-			IL_0414: dup
-			IL_0415: ldc.i4.0
-			IL_0416: ldarg.0
-			IL_0417: stelem.ref
-			IL_0418: stloc.1
-			IL_0419: volatile.
-			IL_041b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_0420: brfalse IL_0435
-
-			IL_0425: ldarg.3
-			IL_0426: ldstr "includes"
-			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0430: br IL_044a
-
-			IL_0435: ldarg.3
-			IL_0436: ldstr "includes"
-			IL_043b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:119"
-			IL_0440: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_044a: stloc.2
-			IL_044b: volatile.
-			IL_044d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_0452: brfalse IL_0467
-
-			IL_0457: ldloc.2
-			IL_0458: ldstr "length"
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0462: br IL_047c
-
-			IL_0467: ldloc.2
-			IL_0468: ldstr "length"
-			IL_046d: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:121"
-			IL_0472: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_047c: stloc.2
-			IL_047d: ldloc.1
-			IL_047e: ldloc.2
-			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0484: stloc.2
-			IL_0485: ldstr "includes.length: "
-			IL_048a: ldloc.2
-			IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0490: stloc.3
-			IL_0491: ldloc.0
-			IL_0492: ldloc.3
-			IL_0493: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0498: pop
-			IL_0499: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_049e: stloc.0
-			IL_049f: ldarg.0
-			IL_04a0: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_04a5: ldc.i4.1
-			IL_04a6: newarr [System.Runtime]System.Object
-			IL_04ab: dup
-			IL_04ac: ldc.i4.0
-			IL_04ad: ldarg.0
-			IL_04ae: stelem.ref
-			IL_04af: stloc.1
-			IL_04b0: volatile.
-			IL_04b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_04b7: brfalse IL_04cc
-
-			IL_04bc: ldarg.3
-			IL_04bd: ldstr "includes"
-			IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04c7: br IL_04e1
-
-			IL_04cc: ldarg.3
-			IL_04cd: ldstr "includes"
-			IL_04d2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:132"
-			IL_04d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_04e1: stloc.2
-			IL_04e2: ldloc.2
-			IL_04e3: ldc.r8 0.0
-			IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_04f1: stloc.2
-			IL_04f2: ldloc.1
-			IL_04f3: ldloc.2
-			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_04f9: stloc.2
-			IL_04fa: ldstr "includes[0]: "
-			IL_04ff: ldloc.2
-			IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0505: stloc.3
-			IL_0506: ldloc.0
-			IL_0507: ldloc.3
-			IL_0508: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_050d: pop
-			IL_050e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0513: stloc.0
-			IL_0514: ldarg.0
-			IL_0515: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_051a: ldc.i4.1
-			IL_051b: newarr [System.Runtime]System.Object
-			IL_0520: dup
-			IL_0521: ldc.i4.0
-			IL_0522: ldarg.0
-			IL_0523: stelem.ref
-			IL_0524: stloc.1
-			IL_0525: volatile.
-			IL_0527: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_052c: brfalse IL_0541
-
-			IL_0531: ldarg.3
-			IL_0532: ldstr "includes"
-			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_053c: br IL_0556
-
-			IL_0541: ldarg.3
-			IL_0542: ldstr "includes"
-			IL_0547: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:145"
-			IL_054c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0556: stloc.2
-			IL_0557: ldloc.2
-			IL_0558: ldc.r8 1
-			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0566: stloc.2
-			IL_0567: ldloc.1
-			IL_0568: ldloc.2
-			IL_0569: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_056e: stloc.2
-			IL_056f: ldstr "includes[1]: "
-			IL_0574: ldloc.2
-			IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_057a: stloc.3
-			IL_057b: ldloc.0
-			IL_057c: ldloc.3
-			IL_057d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0582: pop
-			IL_0583: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0588: stloc.0
-			IL_0589: ldarg.0
-			IL_058a: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_058f: ldc.i4.1
-			IL_0590: newarr [System.Runtime]System.Object
-			IL_0595: dup
-			IL_0596: ldc.i4.0
-			IL_0597: ldarg.0
-			IL_0598: stelem.ref
-			IL_0599: stloc.1
-			IL_059a: volatile.
-			IL_059c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_05a1: brfalse IL_05b6
-
-			IL_05a6: ldarg.3
-			IL_05a7: ldstr "flags"
-			IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05b1: br IL_05cb
-
-			IL_05b6: ldarg.3
-			IL_05b7: ldstr "flags"
-			IL_05bc: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:158"
-			IL_05c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_05cb: stloc.2
-			IL_05cc: volatile.
-			IL_05ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_05d3: brfalse IL_05e8
-
-			IL_05d8: ldloc.2
-			IL_05d9: ldstr "length"
-			IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e3: br IL_05fd
-
-			IL_05e8: ldloc.2
-			IL_05e9: ldstr "length"
-			IL_05ee: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:160"
-			IL_05f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_05fd: stloc.2
-			IL_05fe: ldloc.1
-			IL_05ff: ldloc.2
-			IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0605: stloc.2
-			IL_0606: ldstr "flags.length: "
-			IL_060b: ldloc.2
-			IL_060c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0611: stloc.3
-			IL_0612: ldloc.0
-			IL_0613: ldloc.3
-			IL_0614: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0619: pop
-			IL_061a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_061f: stloc.0
-			IL_0620: ldarg.0
-			IL_0621: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0626: ldc.i4.1
-			IL_0627: newarr [System.Runtime]System.Object
-			IL_062c: dup
-			IL_062d: ldc.i4.0
-			IL_062e: ldarg.0
-			IL_062f: stelem.ref
-			IL_0630: stloc.1
-			IL_0631: volatile.
-			IL_0633: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_0638: brfalse IL_064d
-
-			IL_063d: ldarg.3
-			IL_063e: ldstr "flags"
-			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0648: br IL_0662
-
-			IL_064d: ldarg.3
-			IL_064e: ldstr "flags"
-			IL_0653: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:171"
-			IL_0658: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0662: stloc.2
-			IL_0663: ldloc.2
-			IL_0664: ldc.r8 0.0
-			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0672: stloc.2
-			IL_0673: ldloc.1
-			IL_0674: ldloc.2
-			IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_067a: stloc.2
-			IL_067b: ldstr "flags[0]: "
-			IL_0680: ldloc.2
-			IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0686: stloc.3
-			IL_0687: ldloc.0
-			IL_0688: ldloc.3
-			IL_0689: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_068e: pop
-			IL_068f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0694: stloc.0
-			IL_0695: ldarg.0
-			IL_0696: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_069b: ldc.i4.1
-			IL_069c: newarr [System.Runtime]System.Object
-			IL_06a1: dup
-			IL_06a2: ldc.i4.0
-			IL_06a3: ldarg.0
-			IL_06a4: stelem.ref
-			IL_06a5: stloc.1
-			IL_06a6: volatile.
-			IL_06a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_06ad: brfalse IL_06c2
-
-			IL_06b2: ldarg.3
-			IL_06b3: ldstr "flags"
-			IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06bd: br IL_06d7
-
-			IL_06c2: ldarg.3
-			IL_06c3: ldstr "flags"
-			IL_06c8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:184"
-			IL_06cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_06d7: stloc.2
-			IL_06d8: ldloc.2
-			IL_06d9: ldc.r8 1
-			IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_06e7: stloc.2
-			IL_06e8: ldloc.1
-			IL_06e9: ldloc.2
-			IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_06ef: stloc.2
-			IL_06f0: ldstr "flags[1]: "
-			IL_06f5: ldloc.2
-			IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06fb: stloc.3
-			IL_06fc: ldloc.0
-			IL_06fd: ldloc.3
-			IL_06fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0703: pop
-			IL_0704: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0709: stloc.0
-			IL_070a: ldarg.0
-			IL_070b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0710: ldc.i4.1
-			IL_0711: newarr [System.Runtime]System.Object
-			IL_0716: dup
-			IL_0717: ldc.i4.0
-			IL_0718: ldarg.0
-			IL_0719: stelem.ref
-			IL_071a: stloc.1
-			IL_071b: volatile.
-			IL_071d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_0722: brfalse IL_0737
-
-			IL_0727: ldarg.3
-			IL_0728: ldstr "flags"
-			IL_072d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0732: br IL_074c
-
-			IL_0737: ldarg.3
-			IL_0738: ldstr "flags"
-			IL_073d: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:197"
-			IL_0742: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_074c: stloc.2
-			IL_074d: ldloc.2
-			IL_074e: ldc.r8 2
-			IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_075c: stloc.2
-			IL_075d: ldloc.1
-			IL_075e: ldloc.2
-			IL_075f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0764: stloc.2
-			IL_0765: ldstr "flags[2]: "
-			IL_076a: ldloc.2
-			IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0770: stloc.3
-			IL_0771: ldloc.0
-			IL_0772: ldloc.3
-			IL_0773: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0778: pop
-			IL_0779: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_077e: stloc.0
-			IL_077f: ldarg.0
-			IL_0780: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0785: ldc.i4.1
-			IL_0786: newarr [System.Runtime]System.Object
-			IL_078b: dup
-			IL_078c: ldc.i4.0
-			IL_078d: ldarg.0
-			IL_078e: stelem.ref
-			IL_078f: stloc.1
-			IL_0790: volatile.
-			IL_0792: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_0797: brfalse IL_07ac
-
-			IL_079c: ldarg.3
-			IL_079d: ldstr "features"
-			IL_07a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a7: br IL_07c1
-
-			IL_07ac: ldarg.3
-			IL_07ad: ldstr "features"
-			IL_07b2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:210"
-			IL_07b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_07c1: stloc.2
-			IL_07c2: volatile.
-			IL_07c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_07c9: brfalse IL_07de
-
-			IL_07ce: ldloc.2
-			IL_07cf: ldstr "length"
-			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07d9: br IL_07f3
-
-			IL_07de: ldloc.2
-			IL_07df: ldstr "length"
-			IL_07e4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:212"
-			IL_07e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_07ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_07f3: stloc.2
-			IL_07f4: ldloc.1
-			IL_07f5: ldloc.2
-			IL_07f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_07fb: stloc.2
-			IL_07fc: ldstr "features.length: "
-			IL_0801: ldloc.2
-			IL_0802: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0807: stloc.3
-			IL_0808: ldloc.0
-			IL_0809: ldloc.3
-			IL_080a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_080f: pop
-			IL_0810: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0815: stloc.0
-			IL_0816: ldarg.0
-			IL_0817: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_081c: ldc.i4.1
-			IL_081d: newarr [System.Runtime]System.Object
-			IL_0822: dup
-			IL_0823: ldc.i4.0
-			IL_0824: ldarg.0
-			IL_0825: stelem.ref
-			IL_0826: stloc.1
-			IL_0827: volatile.
-			IL_0829: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_082e: brfalse IL_0843
-
-			IL_0833: ldarg.3
-			IL_0834: ldstr "features"
-			IL_0839: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_083e: br IL_0858
-
-			IL_0843: ldarg.3
-			IL_0844: ldstr "features"
-			IL_0849: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:223"
-			IL_084e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0858: stloc.2
-			IL_0859: ldloc.2
-			IL_085a: ldc.r8 0.0
-			IL_0863: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0868: stloc.2
-			IL_0869: ldloc.1
-			IL_086a: ldloc.2
-			IL_086b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0870: stloc.2
-			IL_0871: ldstr "features[0]: "
-			IL_0876: ldloc.2
-			IL_0877: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_087c: stloc.3
-			IL_087d: ldloc.0
-			IL_087e: ldloc.3
-			IL_087f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0884: pop
-			IL_0885: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_088a: stloc.0
-			IL_088b: ldarg.0
-			IL_088c: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0891: ldc.i4.1
-			IL_0892: newarr [System.Runtime]System.Object
-			IL_0897: dup
-			IL_0898: ldc.i4.0
-			IL_0899: ldarg.0
-			IL_089a: stelem.ref
-			IL_089b: stloc.1
-			IL_089c: volatile.
-			IL_089e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-			IL_08a3: brfalse IL_08b8
-
-			IL_08a8: ldarg.3
-			IL_08a9: ldstr "features"
-			IL_08ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08b3: br IL_08cd
-
-			IL_08b8: ldarg.3
-			IL_08b9: ldstr "features"
-			IL_08be: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:236"
-			IL_08c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-			IL_08c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_08cd: stloc.2
-			IL_08ce: ldloc.2
-			IL_08cf: ldc.r8 1
-			IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_08dd: stloc.2
-			IL_08de: ldloc.1
-			IL_08df: ldloc.2
-			IL_08e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_08e5: stloc.2
-			IL_08e6: ldstr "features[1]: "
-			IL_08eb: ldloc.2
-			IL_08ec: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_08f1: stloc.3
-			IL_08f2: ldloc.0
-			IL_08f3: ldloc.3
-			IL_08f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08f9: pop
-			IL_08fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08ff: stloc.0
-			IL_0900: ldarg.0
-			IL_0901: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0906: ldc.i4.1
-			IL_0907: newarr [System.Runtime]System.Object
-			IL_090c: dup
-			IL_090d: ldc.i4.0
-			IL_090e: ldarg.0
-			IL_090f: stelem.ref
-			IL_0910: stloc.1
-			IL_0911: volatile.
-			IL_0913: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-			IL_0918: brfalse IL_092d
-
-			IL_091d: ldarg.3
-			IL_091e: ldstr "locale"
-			IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0928: br IL_0942
-
-			IL_092d: ldarg.3
-			IL_092e: ldstr "locale"
-			IL_0933: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:249"
-			IL_0938: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-			IL_093d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0942: stloc.2
-			IL_0943: volatile.
-			IL_0945: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-			IL_094a: brfalse IL_095f
-
-			IL_094f: ldloc.2
-			IL_0950: ldstr "length"
-			IL_0955: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_095a: br IL_0974
-
-			IL_095f: ldloc.2
-			IL_0960: ldstr "length"
-			IL_0965: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:251"
-			IL_096a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-			IL_096f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0974: stloc.2
-			IL_0975: ldloc.1
-			IL_0976: ldloc.2
-			IL_0977: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_097c: stloc.2
-			IL_097d: ldstr "locale.length: "
-			IL_0982: ldloc.2
-			IL_0983: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0988: stloc.3
-			IL_0989: ldloc.0
-			IL_098a: ldloc.3
-			IL_098b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0990: pop
-			IL_0991: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0996: stloc.0
-			IL_0997: ldarg.0
-			IL_0998: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_099d: ldc.i4.1
-			IL_099e: newarr [System.Runtime]System.Object
-			IL_09a3: dup
-			IL_09a4: ldc.i4.0
-			IL_09a5: ldarg.0
-			IL_09a6: stelem.ref
-			IL_09a7: stloc.1
-			IL_09a8: volatile.
-			IL_09aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-			IL_09af: brfalse IL_09c4
-
-			IL_09b4: ldarg.3
-			IL_09b5: ldstr "locale"
-			IL_09ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09bf: br IL_09d9
-
-			IL_09c4: ldarg.3
-			IL_09c5: ldstr "locale"
-			IL_09ca: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:262"
-			IL_09cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-			IL_09d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_09d9: stloc.2
-			IL_09da: ldloc.2
-			IL_09db: ldc.r8 0.0
-			IL_09e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_09e9: stloc.2
-			IL_09ea: ldloc.1
-			IL_09eb: ldloc.2
-			IL_09ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_09f1: stloc.2
-			IL_09f2: ldstr "locale[0]: "
-			IL_09f7: ldloc.2
-			IL_09f8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_09fd: stloc.3
-			IL_09fe: ldloc.0
-			IL_09ff: ldloc.3
-			IL_0a00: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a05: pop
-			IL_0a06: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a0b: stloc.0
-			IL_0a0c: ldarg.0
-			IL_0a0d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0a12: ldc.i4.1
-			IL_0a13: newarr [System.Runtime]System.Object
-			IL_0a18: dup
-			IL_0a19: ldc.i4.0
-			IL_0a1a: ldarg.0
-			IL_0a1b: stelem.ref
-			IL_0a1c: stloc.1
-			IL_0a1d: volatile.
-			IL_0a1f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_0a24: brfalse IL_0a39
-
-			IL_0a29: ldarg.3
-			IL_0a2a: ldstr "defines"
-			IL_0a2f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a34: br IL_0a4e
-
-			IL_0a39: ldarg.3
-			IL_0a3a: ldstr "defines"
-			IL_0a3f: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:275"
-			IL_0a44: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_0a49: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0a4e: stloc.2
-			IL_0a4f: volatile.
-			IL_0a51: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_0a56: brfalse IL_0a6b
-
-			IL_0a5b: ldloc.2
-			IL_0a5c: ldstr "length"
-			IL_0a61: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a66: br IL_0a80
-
-			IL_0a6b: ldloc.2
-			IL_0a6c: ldstr "length"
-			IL_0a71: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:277"
-			IL_0a76: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_0a7b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0a80: stloc.2
-			IL_0a81: ldloc.1
-			IL_0a82: ldloc.2
-			IL_0a83: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0a88: stloc.2
-			IL_0a89: ldstr "defines.length: "
-			IL_0a8e: ldloc.2
-			IL_0a8f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0a94: stloc.3
-			IL_0a95: ldloc.0
-			IL_0a96: ldloc.3
-			IL_0a97: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a9c: pop
-			IL_0a9d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0aa2: stloc.0
-			IL_0aa3: ldarg.0
-			IL_0aa4: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0aa9: ldc.i4.1
-			IL_0aaa: newarr [System.Runtime]System.Object
-			IL_0aaf: dup
-			IL_0ab0: ldc.i4.0
-			IL_0ab1: ldarg.0
-			IL_0ab2: stelem.ref
-			IL_0ab3: stloc.1
-			IL_0ab4: volatile.
-			IL_0ab6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-			IL_0abb: brfalse IL_0ad0
-
-			IL_0ac0: ldarg.3
-			IL_0ac1: ldstr "defines"
-			IL_0ac6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0acb: br IL_0ae5
-
-			IL_0ad0: ldarg.3
-			IL_0ad1: ldstr "defines"
-			IL_0ad6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:288"
-			IL_0adb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-			IL_0ae0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0ae5: stloc.2
-			IL_0ae6: ldloc.2
-			IL_0ae7: ldc.r8 0.0
-			IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0af5: stloc.2
-			IL_0af6: ldloc.1
-			IL_0af7: ldloc.2
-			IL_0af8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0afd: stloc.2
-			IL_0afe: ldstr "defines[0]: "
-			IL_0b03: ldloc.2
-			IL_0b04: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0b09: stloc.3
-			IL_0b0a: ldloc.0
-			IL_0b0b: ldloc.3
-			IL_0b0c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b11: pop
-			IL_0b12: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b17: stloc.0
-			IL_0b18: ldarg.0
-			IL_0b19: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatNegative
-			IL_0b1e: ldc.i4.1
-			IL_0b1f: newarr [System.Runtime]System.Object
-			IL_0b24: dup
-			IL_0b25: ldc.i4.0
-			IL_0b26: ldarg.0
-			IL_0b27: stelem.ref
-			IL_0b28: stloc.1
-			IL_0b29: volatile.
-			IL_0b2b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
-			IL_0b30: brfalse IL_0b45
-
-			IL_0b35: ldarg.3
-			IL_0b36: ldstr "negative"
-			IL_0b3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b40: br IL_0b5a
-
-			IL_0b45: ldarg.3
-			IL_0b46: ldstr "negative"
-			IL_0b4b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:301"
-			IL_0b50: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
-			IL_0b55: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0b5a: stloc.2
-			IL_0b5b: ldloc.1
-			IL_0b5c: ldloc.2
-			IL_0b5d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0b62: stloc.2
-			IL_0b63: ldstr "negative: "
-			IL_0b68: ldloc.2
-			IL_0b69: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0b6e: stloc.3
-			IL_0b6f: ldloc.0
-			IL_0b70: ldloc.3
-			IL_0b71: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b76: pop
-			IL_0b77: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b7c: stloc.0
-			IL_0b7d: ldarg.0
-			IL_0b7e: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0b83: ldc.i4.1
-			IL_0b84: newarr [System.Runtime]System.Object
-			IL_0b89: dup
-			IL_0b8a: ldc.i4.0
-			IL_0b8b: ldarg.0
-			IL_0b8c: stelem.ref
-			IL_0b8d: stloc.1
-			IL_0b8e: volatile.
-			IL_0b90: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
-			IL_0b95: brfalse IL_0baa
-
-			IL_0b9a: ldarg.3
-			IL_0b9b: ldstr "execution"
-			IL_0ba0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ba5: br IL_0bbf
-
-			IL_0baa: ldarg.3
-			IL_0bab: ldstr "execution"
-			IL_0bb0: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:312"
-			IL_0bb5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
-			IL_0bba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0bbf: stloc.2
-			IL_0bc0: volatile.
-			IL_0bc2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0bc7: brfalse IL_0bdc
-
-			IL_0bcc: ldloc.2
-			IL_0bcd: ldstr "sourceType"
-			IL_0bd2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bd7: br IL_0bf1
-
-			IL_0bdc: ldloc.2
-			IL_0bdd: ldstr "sourceType"
-			IL_0be2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:314"
-			IL_0be7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0bec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0bf1: stloc.2
+			IL_0114: ldarg.0
+			IL_0115: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_011a: ldnull
+			IL_011b: ldloc.1
+			IL_011c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0121: stloc.1
+			IL_0122: ldstr "hasFrontmatter: "
+			IL_0127: ldloc.1
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_012d: stloc.2
+			IL_012e: ldloc.0
+			IL_012f: ldloc.2
+			IL_0130: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0135: pop
+			IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_013b: stloc.0
+			IL_013c: volatile.
+			IL_013e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0143: brfalse IL_0158
+
+			IL_0148: ldarg.3
+			IL_0149: ldstr "unknownKeys"
+			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0153: br IL_016d
+
+			IL_0158: ldarg.3
+			IL_0159: ldstr "unknownKeys"
+			IL_015e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:43"
+			IL_0163: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_016d: stloc.1
+			IL_016e: volatile.
+			IL_0170: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_0175: brfalse IL_018a
+
+			IL_017a: ldloc.1
+			IL_017b: ldstr "length"
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0185: br IL_019f
+
+			IL_018a: ldloc.1
+			IL_018b: ldstr "length"
+			IL_0190: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:45"
+			IL_0195: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_019f: stloc.1
+			IL_01a0: ldarg.0
+			IL_01a1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_01a6: ldnull
+			IL_01a7: ldloc.1
+			IL_01a8: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_01ad: stloc.1
+			IL_01ae: ldstr "unknownKeys.length: "
+			IL_01b3: ldloc.1
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01b9: stloc.2
+			IL_01ba: ldloc.0
+			IL_01bb: ldloc.2
+			IL_01bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01c1: pop
+			IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01c7: stloc.0
+			IL_01c8: volatile.
+			IL_01ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_01cf: brfalse IL_01e4
+
+			IL_01d4: ldarg.3
+			IL_01d5: ldstr "unknownKeys"
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01df: br IL_01f9
+
+			IL_01e4: ldarg.3
+			IL_01e5: ldstr "unknownKeys"
+			IL_01ea: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:55"
+			IL_01ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_01f9: stloc.1
+			IL_01fa: ldloc.1
+			IL_01fb: ldc.r8 0.0
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0209: stloc.1
+			IL_020a: ldarg.0
+			IL_020b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0210: ldnull
+			IL_0211: ldloc.1
+			IL_0212: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0217: stloc.1
+			IL_0218: ldstr "unknownKeys[0]: "
+			IL_021d: ldloc.1
+			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0223: stloc.2
+			IL_0224: ldloc.0
+			IL_0225: ldloc.2
+			IL_0226: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_022b: pop
+			IL_022c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0231: stloc.0
+			IL_0232: volatile.
+			IL_0234: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0239: brfalse IL_024e
+
+			IL_023e: ldarg.3
+			IL_023f: ldstr "description"
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0249: br IL_0263
+
+			IL_024e: ldarg.3
+			IL_024f: ldstr "description"
+			IL_0254: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:67"
+			IL_0259: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0263: stloc.1
+			IL_0264: ldarg.0
+			IL_0265: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_026a: ldnull
+			IL_026b: ldloc.1
+			IL_026c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0271: stloc.1
+			IL_0272: ldstr "description: "
+			IL_0277: ldloc.1
+			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_027d: stloc.2
+			IL_027e: ldloc.0
+			IL_027f: ldloc.2
+			IL_0280: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0285: pop
+			IL_0286: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_028b: stloc.0
+			IL_028c: volatile.
+			IL_028e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0293: brfalse IL_02a8
+
+			IL_0298: ldarg.3
+			IL_0299: ldstr "info"
+			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a3: br IL_02bd
+
+			IL_02a8: ldarg.3
+			IL_02a9: ldstr "info"
+			IL_02ae: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:77"
+			IL_02b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_02bd: stloc.1
+			IL_02be: ldarg.0
+			IL_02bf: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_02c4: ldnull
+			IL_02c5: ldloc.1
+			IL_02c6: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_02cb: stloc.1
+			IL_02cc: ldstr "info: "
+			IL_02d1: ldloc.1
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02d7: stloc.2
+			IL_02d8: ldloc.0
+			IL_02d9: ldloc.2
+			IL_02da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02df: pop
+			IL_02e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02e5: stloc.0
+			IL_02e6: volatile.
+			IL_02e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_02ed: brfalse IL_0302
+
+			IL_02f2: ldarg.3
+			IL_02f3: ldstr "esid"
+			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fd: br IL_0317
+
+			IL_0302: ldarg.3
+			IL_0303: ldstr "esid"
+			IL_0308: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:87"
+			IL_030d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0317: stloc.1
+			IL_0318: ldarg.0
+			IL_0319: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_031e: ldnull
+			IL_031f: ldloc.1
+			IL_0320: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0325: stloc.1
+			IL_0326: ldstr "esid: "
+			IL_032b: ldloc.1
+			IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0331: stloc.2
+			IL_0332: ldloc.0
+			IL_0333: ldloc.2
+			IL_0334: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0339: pop
+			IL_033a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_033f: stloc.0
+			IL_0340: volatile.
+			IL_0342: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0347: brfalse IL_035c
+
+			IL_034c: ldarg.3
+			IL_034d: ldstr "es5id"
+			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0357: br IL_0371
+
+			IL_035c: ldarg.3
+			IL_035d: ldstr "es5id"
+			IL_0362: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:97"
+			IL_0367: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0371: stloc.1
+			IL_0372: ldarg.0
+			IL_0373: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0378: ldnull
+			IL_0379: ldloc.1
+			IL_037a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_037f: stloc.1
+			IL_0380: ldstr "es5id: "
+			IL_0385: ldloc.1
+			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_038b: stloc.2
+			IL_038c: ldloc.0
+			IL_038d: ldloc.2
+			IL_038e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0393: pop
+			IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0399: stloc.0
+			IL_039a: volatile.
+			IL_039c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_03a1: brfalse IL_03b6
+
+			IL_03a6: ldarg.3
+			IL_03a7: ldstr "includes"
+			IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b1: br IL_03cb
+
+			IL_03b6: ldarg.3
+			IL_03b7: ldstr "includes"
+			IL_03bc: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:107"
+			IL_03c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_03cb: stloc.1
+			IL_03cc: volatile.
+			IL_03ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_03d3: brfalse IL_03e8
+
+			IL_03d8: ldloc.1
+			IL_03d9: ldstr "length"
+			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e3: br IL_03fd
+
+			IL_03e8: ldloc.1
+			IL_03e9: ldstr "length"
+			IL_03ee: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:109"
+			IL_03f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_03fd: stloc.1
+			IL_03fe: ldarg.0
+			IL_03ff: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0404: ldnull
+			IL_0405: ldloc.1
+			IL_0406: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_040b: stloc.1
+			IL_040c: ldstr "includes.length: "
+			IL_0411: ldloc.1
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0417: stloc.2
+			IL_0418: ldloc.0
+			IL_0419: ldloc.2
+			IL_041a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_041f: pop
+			IL_0420: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0425: stloc.0
+			IL_0426: volatile.
+			IL_0428: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_042d: brfalse IL_0442
+
+			IL_0432: ldarg.3
+			IL_0433: ldstr "includes"
+			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_043d: br IL_0457
+
+			IL_0442: ldarg.3
+			IL_0443: ldstr "includes"
+			IL_0448: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:119"
+			IL_044d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0457: stloc.1
+			IL_0458: ldloc.1
+			IL_0459: ldc.r8 0.0
+			IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0467: stloc.1
+			IL_0468: ldarg.0
+			IL_0469: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_046e: ldnull
+			IL_046f: ldloc.1
+			IL_0470: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0475: stloc.1
+			IL_0476: ldstr "includes[0]: "
+			IL_047b: ldloc.1
+			IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0481: stloc.2
+			IL_0482: ldloc.0
+			IL_0483: ldloc.2
+			IL_0484: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0489: pop
+			IL_048a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_048f: stloc.0
+			IL_0490: volatile.
+			IL_0492: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_0497: brfalse IL_04ac
+
+			IL_049c: ldarg.3
+			IL_049d: ldstr "includes"
+			IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a7: br IL_04c1
+
+			IL_04ac: ldarg.3
+			IL_04ad: ldstr "includes"
+			IL_04b2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:131"
+			IL_04b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_04bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_04c1: stloc.1
+			IL_04c2: ldloc.1
+			IL_04c3: ldc.r8 1
+			IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_04d1: stloc.1
+			IL_04d2: ldarg.0
+			IL_04d3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_04d8: ldnull
+			IL_04d9: ldloc.1
+			IL_04da: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_04df: stloc.1
+			IL_04e0: ldstr "includes[1]: "
+			IL_04e5: ldloc.1
+			IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04eb: stloc.2
+			IL_04ec: ldloc.0
+			IL_04ed: ldloc.2
+			IL_04ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04f3: pop
+			IL_04f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04f9: stloc.0
+			IL_04fa: volatile.
+			IL_04fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0501: brfalse IL_0516
+
+			IL_0506: ldarg.3
+			IL_0507: ldstr "flags"
+			IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0511: br IL_052b
+
+			IL_0516: ldarg.3
+			IL_0517: ldstr "flags"
+			IL_051c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:143"
+			IL_0521: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_052b: stloc.1
+			IL_052c: volatile.
+			IL_052e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0533: brfalse IL_0548
+
+			IL_0538: ldloc.1
+			IL_0539: ldstr "length"
+			IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0543: br IL_055d
+
+			IL_0548: ldloc.1
+			IL_0549: ldstr "length"
+			IL_054e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:145"
+			IL_0553: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_055d: stloc.1
+			IL_055e: ldarg.0
+			IL_055f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0564: ldnull
+			IL_0565: ldloc.1
+			IL_0566: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_056b: stloc.1
+			IL_056c: ldstr "flags.length: "
+			IL_0571: ldloc.1
+			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0577: stloc.2
+			IL_0578: ldloc.0
+			IL_0579: ldloc.2
+			IL_057a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_057f: pop
+			IL_0580: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0585: stloc.0
+			IL_0586: volatile.
+			IL_0588: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_058d: brfalse IL_05a2
+
+			IL_0592: ldarg.3
+			IL_0593: ldstr "flags"
+			IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_059d: br IL_05b7
+
+			IL_05a2: ldarg.3
+			IL_05a3: ldstr "flags"
+			IL_05a8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:155"
+			IL_05ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_05b7: stloc.1
+			IL_05b8: ldloc.1
+			IL_05b9: ldc.r8 0.0
+			IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_05c7: stloc.1
+			IL_05c8: ldarg.0
+			IL_05c9: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_05ce: ldnull
+			IL_05cf: ldloc.1
+			IL_05d0: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_05d5: stloc.1
+			IL_05d6: ldstr "flags[0]: "
+			IL_05db: ldloc.1
+			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05e1: stloc.2
+			IL_05e2: ldloc.0
+			IL_05e3: ldloc.2
+			IL_05e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05e9: pop
+			IL_05ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05ef: stloc.0
+			IL_05f0: volatile.
+			IL_05f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_05f7: brfalse IL_060c
+
+			IL_05fc: ldarg.3
+			IL_05fd: ldstr "flags"
+			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0607: br IL_0621
+
+			IL_060c: ldarg.3
+			IL_060d: ldstr "flags"
+			IL_0612: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:167"
+			IL_0617: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0621: stloc.1
+			IL_0622: ldloc.1
+			IL_0623: ldc.r8 1
+			IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0631: stloc.1
+			IL_0632: ldarg.0
+			IL_0633: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0638: ldnull
+			IL_0639: ldloc.1
+			IL_063a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_063f: stloc.1
+			IL_0640: ldstr "flags[1]: "
+			IL_0645: ldloc.1
+			IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_064b: stloc.2
+			IL_064c: ldloc.0
+			IL_064d: ldloc.2
+			IL_064e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0653: pop
+			IL_0654: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0659: stloc.0
+			IL_065a: volatile.
+			IL_065c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0661: brfalse IL_0676
+
+			IL_0666: ldarg.3
+			IL_0667: ldstr "flags"
+			IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0671: br IL_068b
+
+			IL_0676: ldarg.3
+			IL_0677: ldstr "flags"
+			IL_067c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:179"
+			IL_0681: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_068b: stloc.1
+			IL_068c: ldloc.1
+			IL_068d: ldc.r8 2
+			IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_069b: stloc.1
+			IL_069c: ldarg.0
+			IL_069d: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_06a2: ldnull
+			IL_06a3: ldloc.1
+			IL_06a4: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_06a9: stloc.1
+			IL_06aa: ldstr "flags[2]: "
+			IL_06af: ldloc.1
+			IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06b5: stloc.2
+			IL_06b6: ldloc.0
+			IL_06b7: ldloc.2
+			IL_06b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06bd: pop
+			IL_06be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06c3: stloc.0
+			IL_06c4: volatile.
+			IL_06c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_06cb: brfalse IL_06e0
+
+			IL_06d0: ldarg.3
+			IL_06d1: ldstr "features"
+			IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06db: br IL_06f5
+
+			IL_06e0: ldarg.3
+			IL_06e1: ldstr "features"
+			IL_06e6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:191"
+			IL_06eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_06f5: stloc.1
+			IL_06f6: volatile.
+			IL_06f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_06fd: brfalse IL_0712
+
+			IL_0702: ldloc.1
+			IL_0703: ldstr "length"
+			IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_070d: br IL_0727
+
+			IL_0712: ldloc.1
+			IL_0713: ldstr "length"
+			IL_0718: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:193"
+			IL_071d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_0722: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0727: stloc.1
+			IL_0728: ldarg.0
+			IL_0729: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_072e: ldnull
+			IL_072f: ldloc.1
+			IL_0730: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0735: stloc.1
+			IL_0736: ldstr "features.length: "
+			IL_073b: ldloc.1
+			IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0741: stloc.2
+			IL_0742: ldloc.0
+			IL_0743: ldloc.2
+			IL_0744: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0749: pop
+			IL_074a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_074f: stloc.0
+			IL_0750: volatile.
+			IL_0752: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0757: brfalse IL_076c
+
+			IL_075c: ldarg.3
+			IL_075d: ldstr "features"
+			IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0767: br IL_0781
+
+			IL_076c: ldarg.3
+			IL_076d: ldstr "features"
+			IL_0772: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:203"
+			IL_0777: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_077c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0781: stloc.1
+			IL_0782: ldloc.1
+			IL_0783: ldc.r8 0.0
+			IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0791: stloc.1
+			IL_0792: ldarg.0
+			IL_0793: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0798: ldnull
+			IL_0799: ldloc.1
+			IL_079a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_079f: stloc.1
+			IL_07a0: ldstr "features[0]: "
+			IL_07a5: ldloc.1
+			IL_07a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_07ab: stloc.2
+			IL_07ac: ldloc.0
+			IL_07ad: ldloc.2
+			IL_07ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07b3: pop
+			IL_07b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07b9: stloc.0
+			IL_07ba: volatile.
+			IL_07bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_07c1: brfalse IL_07d6
+
+			IL_07c6: ldarg.3
+			IL_07c7: ldstr "features"
+			IL_07cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d1: br IL_07eb
+
+			IL_07d6: ldarg.3
+			IL_07d7: ldstr "features"
+			IL_07dc: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:215"
+			IL_07e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_07eb: stloc.1
+			IL_07ec: ldloc.1
+			IL_07ed: ldc.r8 1
+			IL_07f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_07fb: stloc.1
+			IL_07fc: ldarg.0
+			IL_07fd: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0802: ldnull
+			IL_0803: ldloc.1
+			IL_0804: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0809: stloc.1
+			IL_080a: ldstr "features[1]: "
+			IL_080f: ldloc.1
+			IL_0810: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0815: stloc.2
+			IL_0816: ldloc.0
+			IL_0817: ldloc.2
+			IL_0818: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_081d: pop
+			IL_081e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0823: stloc.0
+			IL_0824: volatile.
+			IL_0826: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_082b: brfalse IL_0840
+
+			IL_0830: ldarg.3
+			IL_0831: ldstr "locale"
+			IL_0836: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_083b: br IL_0855
+
+			IL_0840: ldarg.3
+			IL_0841: ldstr "locale"
+			IL_0846: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:227"
+			IL_084b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0855: stloc.1
+			IL_0856: volatile.
+			IL_0858: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_085d: brfalse IL_0872
+
+			IL_0862: ldloc.1
+			IL_0863: ldstr "length"
+			IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_086d: br IL_0887
+
+			IL_0872: ldloc.1
+			IL_0873: ldstr "length"
+			IL_0878: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:229"
+			IL_087d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_0882: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0887: stloc.1
+			IL_0888: ldarg.0
+			IL_0889: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_088e: ldnull
+			IL_088f: ldloc.1
+			IL_0890: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0895: stloc.1
+			IL_0896: ldstr "locale.length: "
+			IL_089b: ldloc.1
+			IL_089c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_08a1: stloc.2
+			IL_08a2: ldloc.0
+			IL_08a3: ldloc.2
+			IL_08a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_08a9: pop
+			IL_08aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08af: stloc.0
+			IL_08b0: volatile.
+			IL_08b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_08b7: brfalse IL_08cc
+
+			IL_08bc: ldarg.3
+			IL_08bd: ldstr "locale"
+			IL_08c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08c7: br IL_08e1
+
+			IL_08cc: ldarg.3
+			IL_08cd: ldstr "locale"
+			IL_08d2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:239"
+			IL_08d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_08dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_08e1: stloc.1
+			IL_08e2: ldloc.1
+			IL_08e3: ldc.r8 0.0
+			IL_08ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_08f1: stloc.1
+			IL_08f2: ldarg.0
+			IL_08f3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_08f8: ldnull
+			IL_08f9: ldloc.1
+			IL_08fa: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_08ff: stloc.1
+			IL_0900: ldstr "locale[0]: "
+			IL_0905: ldloc.1
+			IL_0906: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_090b: stloc.2
+			IL_090c: ldloc.0
+			IL_090d: ldloc.2
+			IL_090e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0913: pop
+			IL_0914: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0919: stloc.0
+			IL_091a: volatile.
+			IL_091c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0921: brfalse IL_0936
+
+			IL_0926: ldarg.3
+			IL_0927: ldstr "defines"
+			IL_092c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0931: br IL_094b
+
+			IL_0936: ldarg.3
+			IL_0937: ldstr "defines"
+			IL_093c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:251"
+			IL_0941: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0946: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_094b: stloc.1
+			IL_094c: volatile.
+			IL_094e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0953: brfalse IL_0968
+
+			IL_0958: ldloc.1
+			IL_0959: ldstr "length"
+			IL_095e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0963: br IL_097d
+
+			IL_0968: ldloc.1
+			IL_0969: ldstr "length"
+			IL_096e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:253"
+			IL_0973: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0978: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_097d: stloc.1
+			IL_097e: ldarg.0
+			IL_097f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0984: ldnull
+			IL_0985: ldloc.1
+			IL_0986: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_098b: stloc.1
+			IL_098c: ldstr "defines.length: "
+			IL_0991: ldloc.1
+			IL_0992: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0997: stloc.2
+			IL_0998: ldloc.0
+			IL_0999: ldloc.2
+			IL_099a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_099f: pop
+			IL_09a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09a5: stloc.0
+			IL_09a6: volatile.
+			IL_09a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_09ad: brfalse IL_09c2
+
+			IL_09b2: ldarg.3
+			IL_09b3: ldstr "defines"
+			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09bd: br IL_09d7
+
+			IL_09c2: ldarg.3
+			IL_09c3: ldstr "defines"
+			IL_09c8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:263"
+			IL_09cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_09d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_09d7: stloc.1
+			IL_09d8: ldloc.1
+			IL_09d9: ldc.r8 0.0
+			IL_09e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_09e7: stloc.1
+			IL_09e8: ldarg.0
+			IL_09e9: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_09ee: ldnull
+			IL_09ef: ldloc.1
+			IL_09f0: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_09f5: stloc.1
+			IL_09f6: ldstr "defines[0]: "
+			IL_09fb: ldloc.1
+			IL_09fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0a01: stloc.2
+			IL_0a02: ldloc.0
+			IL_0a03: ldloc.2
+			IL_0a04: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a09: pop
+			IL_0a0a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a0f: stloc.0
+			IL_0a10: volatile.
+			IL_0a12: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_0a17: brfalse IL_0a2c
+
+			IL_0a1c: ldarg.3
+			IL_0a1d: ldstr "negative"
+			IL_0a22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a27: br IL_0a41
+
+			IL_0a2c: ldarg.3
+			IL_0a2d: ldstr "negative"
+			IL_0a32: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:275"
+			IL_0a37: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_0a3c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0a41: stloc.1
+			IL_0a42: ldarg.0
+			IL_0a43: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0a48: ldnull
+			IL_0a49: ldloc.1
+			IL_0a4a: call object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0a4f: stloc.1
+			IL_0a50: ldstr "negative: "
+			IL_0a55: ldloc.1
+			IL_0a56: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0a5b: stloc.2
+			IL_0a5c: ldloc.0
+			IL_0a5d: ldloc.2
+			IL_0a5e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a63: pop
+			IL_0a64: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a69: stloc.0
+			IL_0a6a: volatile.
+			IL_0a6c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_0a71: brfalse IL_0a86
+
+			IL_0a76: ldarg.3
+			IL_0a77: ldstr "execution"
+			IL_0a7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a81: br IL_0a9b
+
+			IL_0a86: ldarg.3
+			IL_0a87: ldstr "execution"
+			IL_0a8c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:285"
+			IL_0a91: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0a9b: stloc.1
+			IL_0a9c: volatile.
+			IL_0a9e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0aa3: brfalse IL_0ab8
+
+			IL_0aa8: ldloc.1
+			IL_0aa9: ldstr "sourceType"
+			IL_0aae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ab3: br IL_0acd
+
+			IL_0ab8: ldloc.1
+			IL_0ab9: ldstr "sourceType"
+			IL_0abe: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:287"
+			IL_0ac3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0ac8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0acd: stloc.1
+			IL_0ace: ldarg.0
+			IL_0acf: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0ad4: ldnull
+			IL_0ad5: ldloc.1
+			IL_0ad6: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0adb: stloc.1
+			IL_0adc: ldstr "execution.sourceType: "
+			IL_0ae1: ldloc.1
+			IL_0ae2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0ae7: stloc.2
+			IL_0ae8: ldloc.0
+			IL_0ae9: ldloc.2
+			IL_0aea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0aef: pop
+			IL_0af0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0af5: stloc.0
+			IL_0af6: volatile.
+			IL_0af8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_0afd: brfalse IL_0b12
+
+			IL_0b02: ldarg.3
+			IL_0b03: ldstr "execution"
+			IL_0b08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b0d: br IL_0b27
+
+			IL_0b12: ldarg.3
+			IL_0b13: ldstr "execution"
+			IL_0b18: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:297"
+			IL_0b1d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_0b22: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0b27: stloc.1
+			IL_0b28: volatile.
+			IL_0b2a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+			IL_0b2f: brfalse IL_0b44
+
+			IL_0b34: ldloc.1
+			IL_0b35: ldstr "strictMode"
+			IL_0b3a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b3f: br IL_0b59
+
+			IL_0b44: ldloc.1
+			IL_0b45: ldstr "strictMode"
+			IL_0b4a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:299"
+			IL_0b4f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+			IL_0b54: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0b59: stloc.1
+			IL_0b5a: ldarg.0
+			IL_0b5b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0b60: ldnull
+			IL_0b61: ldloc.1
+			IL_0b62: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0b67: stloc.1
+			IL_0b68: ldstr "execution.strictMode: "
+			IL_0b6d: ldloc.1
+			IL_0b6e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0b73: stloc.2
+			IL_0b74: ldloc.0
+			IL_0b75: ldloc.2
+			IL_0b76: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b7b: pop
+			IL_0b7c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b81: stloc.0
+			IL_0b82: volatile.
+			IL_0b84: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+			IL_0b89: brfalse IL_0b9e
+
+			IL_0b8e: ldarg.3
+			IL_0b8f: ldstr "execution"
+			IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b99: br IL_0bb3
+
+			IL_0b9e: ldarg.3
+			IL_0b9f: ldstr "execution"
+			IL_0ba4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:309"
+			IL_0ba9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+			IL_0bae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0bb3: stloc.1
+			IL_0bb4: volatile.
+			IL_0bb6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+			IL_0bbb: brfalse IL_0bd0
+
+			IL_0bc0: ldloc.1
+			IL_0bc1: ldstr "defaultHarnessIncludes"
+			IL_0bc6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bcb: br IL_0be5
+
+			IL_0bd0: ldloc.1
+			IL_0bd1: ldstr "defaultHarnessIncludes"
+			IL_0bd6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:311"
+			IL_0bdb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+			IL_0be0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0be5: stloc.1
+			IL_0be6: volatile.
+			IL_0be8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
+			IL_0bed: brfalse IL_0c02
+
 			IL_0bf2: ldloc.1
-			IL_0bf3: ldloc.2
-			IL_0bf4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0bf9: stloc.2
-			IL_0bfa: ldstr "execution.sourceType: "
-			IL_0bff: ldloc.2
-			IL_0c00: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0c05: stloc.3
-			IL_0c06: ldloc.0
-			IL_0c07: ldloc.3
-			IL_0c08: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0c0d: pop
-			IL_0c0e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0c13: stloc.0
-			IL_0c14: ldarg.0
-			IL_0c15: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0c1a: ldc.i4.1
-			IL_0c1b: newarr [System.Runtime]System.Object
-			IL_0c20: dup
-			IL_0c21: ldc.i4.0
-			IL_0c22: ldarg.0
-			IL_0c23: stelem.ref
-			IL_0c24: stloc.1
-			IL_0c25: volatile.
-			IL_0c27: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
-			IL_0c2c: brfalse IL_0c41
-
-			IL_0c31: ldarg.3
-			IL_0c32: ldstr "execution"
-			IL_0c37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c3c: br IL_0c56
-
-			IL_0c41: ldarg.3
-			IL_0c42: ldstr "execution"
-			IL_0c47: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:325"
-			IL_0c4c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
-			IL_0c51: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0c56: stloc.2
-			IL_0c57: volatile.
-			IL_0c59: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
-			IL_0c5e: brfalse IL_0c73
-
-			IL_0c63: ldloc.2
-			IL_0c64: ldstr "strictMode"
-			IL_0c69: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c6e: br IL_0c88
-
-			IL_0c73: ldloc.2
-			IL_0c74: ldstr "strictMode"
-			IL_0c79: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:327"
-			IL_0c7e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
-			IL_0c83: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0c88: stloc.2
-			IL_0c89: ldloc.1
-			IL_0c8a: ldloc.2
-			IL_0c8b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0c90: stloc.2
-			IL_0c91: ldstr "execution.strictMode: "
-			IL_0c96: ldloc.2
-			IL_0c97: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0c9c: stloc.3
-			IL_0c9d: ldloc.0
-			IL_0c9e: ldloc.3
-			IL_0c9f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0ca4: pop
-			IL_0ca5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0caa: stloc.0
-			IL_0cab: ldarg.0
-			IL_0cac: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0cb1: ldc.i4.1
-			IL_0cb2: newarr [System.Runtime]System.Object
-			IL_0cb7: dup
-			IL_0cb8: ldc.i4.0
-			IL_0cb9: ldarg.0
-			IL_0cba: stelem.ref
-			IL_0cbb: stloc.1
-			IL_0cbc: volatile.
-			IL_0cbe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
-			IL_0cc3: brfalse IL_0cd8
-
-			IL_0cc8: ldarg.3
-			IL_0cc9: ldstr "execution"
-			IL_0cce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cd3: br IL_0ced
-
-			IL_0cd8: ldarg.3
-			IL_0cd9: ldstr "execution"
-			IL_0cde: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:338"
-			IL_0ce3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
-			IL_0ce8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0ced: stloc.2
-			IL_0cee: volatile.
-			IL_0cf0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
-			IL_0cf5: brfalse IL_0d0a
-
-			IL_0cfa: ldloc.2
-			IL_0cfb: ldstr "defaultHarnessIncludes"
-			IL_0d00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d05: br IL_0d1f
-
-			IL_0d0a: ldloc.2
-			IL_0d0b: ldstr "defaultHarnessIncludes"
-			IL_0d10: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:340"
-			IL_0d15: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
-			IL_0d1a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0d1f: stloc.2
-			IL_0d20: volatile.
-			IL_0d22: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
-			IL_0d27: brfalse IL_0d3c
-
-			IL_0d2c: ldloc.2
-			IL_0d2d: ldstr "length"
-			IL_0d32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d37: br IL_0d51
-
-			IL_0d3c: ldloc.2
-			IL_0d3d: ldstr "length"
-			IL_0d42: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:342"
-			IL_0d47: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
-			IL_0d4c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0d51: stloc.2
-			IL_0d52: ldloc.1
-			IL_0d53: ldloc.2
-			IL_0d54: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0d59: stloc.2
-			IL_0d5a: ldstr "execution.defaultHarnessIncludes.length: "
-			IL_0d5f: ldloc.2
-			IL_0d60: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0d65: stloc.3
-			IL_0d66: ldloc.0
-			IL_0d67: ldloc.3
-			IL_0d68: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0d6d: pop
-			IL_0d6e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0d73: stloc.0
-			IL_0d74: ldarg.0
-			IL_0d75: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0d7a: ldc.i4.1
-			IL_0d7b: newarr [System.Runtime]System.Object
-			IL_0d80: dup
-			IL_0d81: ldc.i4.0
-			IL_0d82: ldarg.0
-			IL_0d83: stelem.ref
-			IL_0d84: stloc.1
-			IL_0d85: volatile.
-			IL_0d87: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
-			IL_0d8c: brfalse IL_0da1
-
-			IL_0d91: ldarg.3
-			IL_0d92: ldstr "execution"
-			IL_0d97: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d9c: br IL_0db6
-
-			IL_0da1: ldarg.3
-			IL_0da2: ldstr "execution"
-			IL_0da7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:353"
-			IL_0dac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
-			IL_0db1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0db6: stloc.2
-			IL_0db7: volatile.
-			IL_0db9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
-			IL_0dbe: brfalse IL_0dd3
-
-			IL_0dc3: ldloc.2
-			IL_0dc4: ldstr "defaultHarnessIncludes"
-			IL_0dc9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0dce: br IL_0de8
-
-			IL_0dd3: ldloc.2
-			IL_0dd4: ldstr "defaultHarnessIncludes"
-			IL_0dd9: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:355"
-			IL_0dde: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
-			IL_0de3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0de8: stloc.2
-			IL_0de9: ldloc.2
-			IL_0dea: ldc.r8 0.0
-			IL_0df3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0df8: stloc.2
-			IL_0df9: ldloc.1
-			IL_0dfa: ldloc.2
-			IL_0dfb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0e00: stloc.2
-			IL_0e01: ldstr "execution.defaultHarnessIncludes[0]: "
-			IL_0e06: ldloc.2
-			IL_0e07: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0e0c: stloc.3
-			IL_0e0d: ldloc.0
-			IL_0e0e: ldloc.3
-			IL_0e0f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0e14: pop
-			IL_0e15: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0e1a: stloc.0
-			IL_0e1b: ldarg.0
-			IL_0e1c: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0e21: ldc.i4.1
-			IL_0e22: newarr [System.Runtime]System.Object
-			IL_0e27: dup
-			IL_0e28: ldc.i4.0
-			IL_0e29: ldarg.0
-			IL_0e2a: stelem.ref
-			IL_0e2b: stloc.1
-			IL_0e2c: volatile.
-			IL_0e2e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
-			IL_0e33: brfalse IL_0e48
-
-			IL_0e38: ldarg.3
-			IL_0e39: ldstr "execution"
-			IL_0e3e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e43: br IL_0e5d
-
-			IL_0e48: ldarg.3
-			IL_0e49: ldstr "execution"
-			IL_0e4e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:368"
-			IL_0e53: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
-			IL_0e58: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0e5d: stloc.2
-			IL_0e5e: volatile.
-			IL_0e60: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
-			IL_0e65: brfalse IL_0e7a
-
-			IL_0e6a: ldloc.2
-			IL_0e6b: ldstr "defaultHarnessIncludes"
-			IL_0e70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e75: br IL_0e8f
-
-			IL_0e7a: ldloc.2
-			IL_0e7b: ldstr "defaultHarnessIncludes"
-			IL_0e80: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:370"
-			IL_0e85: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
-			IL_0e8a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0e8f: stloc.2
-			IL_0e90: ldloc.2
-			IL_0e91: ldc.r8 1
-			IL_0e9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e9f: stloc.2
-			IL_0ea0: ldloc.1
-			IL_0ea1: ldloc.2
-			IL_0ea2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0ea7: stloc.2
-			IL_0ea8: ldstr "execution.defaultHarnessIncludes[1]: "
-			IL_0ead: ldloc.2
-			IL_0eae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0eb3: stloc.3
-			IL_0eb4: ldloc.0
-			IL_0eb5: ldloc.3
-			IL_0eb6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0ebb: pop
-			IL_0ebc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0ec1: stloc.0
-			IL_0ec2: ldarg.0
-			IL_0ec3: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0ec8: ldc.i4.1
-			IL_0ec9: newarr [System.Runtime]System.Object
-			IL_0ece: dup
-			IL_0ecf: ldc.i4.0
-			IL_0ed0: ldarg.0
-			IL_0ed1: stelem.ref
-			IL_0ed2: stloc.1
-			IL_0ed3: volatile.
-			IL_0ed5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-			IL_0eda: brfalse IL_0eef
-
-			IL_0edf: ldarg.3
-			IL_0ee0: ldstr "execution"
-			IL_0ee5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0eea: br IL_0f04
-
-			IL_0eef: ldarg.3
-			IL_0ef0: ldstr "execution"
-			IL_0ef5: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:383"
-			IL_0efa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-			IL_0eff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0f04: stloc.2
-			IL_0f05: volatile.
-			IL_0f07: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-			IL_0f0c: brfalse IL_0f21
-
-			IL_0f11: ldloc.2
-			IL_0f12: ldstr "harnessIncludes"
-			IL_0f17: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f1c: br IL_0f36
-
-			IL_0f21: ldloc.2
-			IL_0f22: ldstr "harnessIncludes"
-			IL_0f27: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:385"
-			IL_0f2c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-			IL_0f31: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0f36: stloc.2
-			IL_0f37: volatile.
-			IL_0f39: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-			IL_0f3e: brfalse IL_0f53
-
-			IL_0f43: ldloc.2
-			IL_0f44: ldstr "length"
-			IL_0f49: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f4e: br IL_0f68
-
-			IL_0f53: ldloc.2
-			IL_0f54: ldstr "length"
-			IL_0f59: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:387"
-			IL_0f5e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-			IL_0f63: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0f68: stloc.2
-			IL_0f69: ldloc.1
-			IL_0f6a: ldloc.2
-			IL_0f6b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0f70: stloc.2
-			IL_0f71: ldstr "execution.harnessIncludes.length: "
-			IL_0f76: ldloc.2
-			IL_0f77: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0f7c: stloc.3
-			IL_0f7d: ldloc.0
-			IL_0f7e: ldloc.3
-			IL_0f7f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0f84: pop
-			IL_0f85: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0f8a: stloc.0
-			IL_0f8b: ldarg.0
-			IL_0f8c: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_0f91: ldc.i4.1
-			IL_0f92: newarr [System.Runtime]System.Object
-			IL_0f97: dup
-			IL_0f98: ldc.i4.0
-			IL_0f99: ldarg.0
-			IL_0f9a: stelem.ref
-			IL_0f9b: stloc.1
-			IL_0f9c: volatile.
-			IL_0f9e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-			IL_0fa3: brfalse IL_0fb8
-
-			IL_0fa8: ldarg.3
-			IL_0fa9: ldstr "execution"
-			IL_0fae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0fb3: br IL_0fcd
-
-			IL_0fb8: ldarg.3
-			IL_0fb9: ldstr "execution"
-			IL_0fbe: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:398"
-			IL_0fc3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-			IL_0fc8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0fcd: stloc.2
-			IL_0fce: volatile.
-			IL_0fd0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-			IL_0fd5: brfalse IL_0fea
-
-			IL_0fda: ldloc.2
-			IL_0fdb: ldstr "harnessIncludes"
-			IL_0fe0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0fe5: br IL_0fff
-
-			IL_0fea: ldloc.2
-			IL_0feb: ldstr "harnessIncludes"
-			IL_0ff0: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:400"
-			IL_0ff5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-			IL_0ffa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0fff: stloc.2
-			IL_1000: ldloc.2
-			IL_1001: ldc.r8 0.0
-			IL_100a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_100f: stloc.2
-			IL_1010: ldloc.1
-			IL_1011: ldloc.2
-			IL_1012: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1017: stloc.2
-			IL_1018: ldstr "execution.harnessIncludes[0]: "
-			IL_101d: ldloc.2
-			IL_101e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1023: stloc.3
-			IL_1024: ldloc.0
-			IL_1025: ldloc.3
-			IL_1026: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_102b: pop
-			IL_102c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1031: stloc.0
-			IL_1032: ldarg.0
-			IL_1033: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1038: ldc.i4.1
-			IL_1039: newarr [System.Runtime]System.Object
-			IL_103e: dup
-			IL_103f: ldc.i4.0
-			IL_1040: ldarg.0
-			IL_1041: stelem.ref
-			IL_1042: stloc.1
-			IL_1043: volatile.
-			IL_1045: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-			IL_104a: brfalse IL_105f
-
-			IL_104f: ldarg.3
-			IL_1050: ldstr "execution"
-			IL_1055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_105a: br IL_1074
-
-			IL_105f: ldarg.3
-			IL_1060: ldstr "execution"
-			IL_1065: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:413"
-			IL_106a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-			IL_106f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1074: stloc.2
-			IL_1075: volatile.
-			IL_1077: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-			IL_107c: brfalse IL_1091
-
-			IL_1081: ldloc.2
-			IL_1082: ldstr "harnessIncludes"
-			IL_1087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_108c: br IL_10a6
-
-			IL_1091: ldloc.2
-			IL_1092: ldstr "harnessIncludes"
-			IL_1097: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:415"
-			IL_109c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-			IL_10a1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_10a6: stloc.2
-			IL_10a7: ldloc.2
-			IL_10a8: ldc.r8 1
-			IL_10b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_10b6: stloc.2
-			IL_10b7: ldloc.1
-			IL_10b8: ldloc.2
-			IL_10b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_10be: stloc.2
-			IL_10bf: ldstr "execution.harnessIncludes[1]: "
-			IL_10c4: ldloc.2
-			IL_10c5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_10ca: stloc.3
-			IL_10cb: ldloc.0
-			IL_10cc: ldloc.3
-			IL_10cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_10d2: pop
-			IL_10d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_10d8: stloc.0
-			IL_10d9: ldarg.0
-			IL_10da: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_10df: ldc.i4.1
-			IL_10e0: newarr [System.Runtime]System.Object
-			IL_10e5: dup
-			IL_10e6: ldc.i4.0
-			IL_10e7: ldarg.0
-			IL_10e8: stelem.ref
-			IL_10e9: stloc.1
-			IL_10ea: volatile.
-			IL_10ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-			IL_10f1: brfalse IL_1106
-
-			IL_10f6: ldarg.3
-			IL_10f7: ldstr "execution"
-			IL_10fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1101: br IL_111b
-
-			IL_1106: ldarg.3
-			IL_1107: ldstr "execution"
-			IL_110c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:428"
-			IL_1111: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-			IL_1116: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_111b: stloc.2
-			IL_111c: volatile.
-			IL_111e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
-			IL_1123: brfalse IL_1138
-
-			IL_1128: ldloc.2
-			IL_1129: ldstr "harnessIncludes"
-			IL_112e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1133: br IL_114d
-
-			IL_1138: ldloc.2
-			IL_1139: ldstr "harnessIncludes"
-			IL_113e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:430"
-			IL_1143: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
-			IL_1148: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_114d: stloc.2
-			IL_114e: ldloc.2
-			IL_114f: ldc.r8 2
-			IL_1158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_115d: stloc.2
-			IL_115e: ldloc.1
-			IL_115f: ldloc.2
-			IL_1160: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1165: stloc.2
-			IL_1166: ldstr "execution.harnessIncludes[2]: "
-			IL_116b: ldloc.2
-			IL_116c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1171: stloc.3
-			IL_1172: ldloc.0
-			IL_1173: ldloc.3
-			IL_1174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1179: pop
-			IL_117a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_117f: stloc.0
-			IL_1180: ldarg.0
-			IL_1181: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1186: ldc.i4.1
-			IL_1187: newarr [System.Runtime]System.Object
-			IL_118c: dup
-			IL_118d: ldc.i4.0
-			IL_118e: ldarg.0
-			IL_118f: stelem.ref
-			IL_1190: stloc.1
-			IL_1191: volatile.
-			IL_1193: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
-			IL_1198: brfalse IL_11ad
-
-			IL_119d: ldarg.3
-			IL_119e: ldstr "execution"
-			IL_11a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_11a8: br IL_11c2
-
-			IL_11ad: ldarg.3
-			IL_11ae: ldstr "execution"
-			IL_11b3: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:443"
-			IL_11b8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
-			IL_11bd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_11c2: stloc.2
-			IL_11c3: volatile.
-			IL_11c5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
-			IL_11ca: brfalse IL_11df
-
-			IL_11cf: ldloc.2
-			IL_11d0: ldstr "harnessIncludes"
-			IL_11d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_11da: br IL_11f4
-
-			IL_11df: ldloc.2
-			IL_11e0: ldstr "harnessIncludes"
-			IL_11e5: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:445"
-			IL_11ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
-			IL_11ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_11f4: stloc.2
-			IL_11f5: ldloc.2
-			IL_11f6: ldc.r8 3
-			IL_11ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1204: stloc.2
-			IL_1205: ldloc.1
-			IL_1206: ldloc.2
-			IL_1207: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_120c: stloc.2
-			IL_120d: ldstr "execution.harnessIncludes[3]: "
-			IL_1212: ldloc.2
-			IL_1213: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1218: stloc.3
-			IL_1219: ldloc.0
-			IL_121a: ldloc.3
-			IL_121b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1220: pop
-			IL_1221: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1226: stloc.0
-			IL_1227: ldarg.0
-			IL_1228: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_122d: ldc.i4.1
-			IL_122e: newarr [System.Runtime]System.Object
-			IL_1233: dup
-			IL_1234: ldc.i4.0
-			IL_1235: ldarg.0
-			IL_1236: stelem.ref
-			IL_1237: stloc.1
-			IL_1238: volatile.
-			IL_123a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
-			IL_123f: brfalse IL_1254
-
-			IL_1244: ldarg.3
-			IL_1245: ldstr "execution"
-			IL_124a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_124f: br IL_1269
-
-			IL_1254: ldarg.3
-			IL_1255: ldstr "execution"
-			IL_125a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:458"
-			IL_125f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
-			IL_1264: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1269: stloc.2
-			IL_126a: volatile.
-			IL_126c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
-			IL_1271: brfalse IL_1286
-
-			IL_1276: ldloc.2
-			IL_1277: ldstr "requiresDefaultHarness"
-			IL_127c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1281: br IL_129b
-
-			IL_1286: ldloc.2
-			IL_1287: ldstr "requiresDefaultHarness"
-			IL_128c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:460"
-			IL_1291: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
-			IL_1296: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_129b: stloc.2
-			IL_129c: ldloc.1
-			IL_129d: ldloc.2
-			IL_129e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_12a3: stloc.2
-			IL_12a4: ldstr "execution.requiresDefaultHarness: "
-			IL_12a9: ldloc.2
-			IL_12aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_12af: stloc.3
-			IL_12b0: ldloc.0
-			IL_12b1: ldloc.3
-			IL_12b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_12b7: pop
-			IL_12b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_12bd: stloc.0
-			IL_12be: ldarg.0
-			IL_12bf: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_12c4: ldc.i4.1
-			IL_12c5: newarr [System.Runtime]System.Object
-			IL_12ca: dup
-			IL_12cb: ldc.i4.0
-			IL_12cc: ldarg.0
-			IL_12cd: stelem.ref
-			IL_12ce: stloc.1
-			IL_12cf: volatile.
-			IL_12d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
-			IL_12d6: brfalse IL_12eb
-
-			IL_12db: ldarg.3
-			IL_12dc: ldstr "execution"
-			IL_12e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_12e6: br IL_1300
-
-			IL_12eb: ldarg.3
-			IL_12ec: ldstr "execution"
-			IL_12f1: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:471"
-			IL_12f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
-			IL_12fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1300: stloc.2
-			IL_1301: volatile.
-			IL_1303: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
-			IL_1308: brfalse IL_131d
-
-			IL_130d: ldloc.2
-			IL_130e: ldstr "requiresAsyncHarness"
-			IL_1313: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1318: br IL_1332
-
-			IL_131d: ldloc.2
-			IL_131e: ldstr "requiresAsyncHarness"
-			IL_1323: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:473"
-			IL_1328: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
-			IL_132d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1332: stloc.2
-			IL_1333: ldloc.1
-			IL_1334: ldloc.2
-			IL_1335: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_133a: stloc.2
-			IL_133b: ldstr "execution.requiresAsyncHarness: "
-			IL_1340: ldloc.2
-			IL_1341: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1346: stloc.3
-			IL_1347: ldloc.0
-			IL_1348: ldloc.3
-			IL_1349: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_134e: pop
-			IL_134f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1354: stloc.0
-			IL_1355: ldarg.0
-			IL_1356: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_135b: ldc.i4.1
-			IL_135c: newarr [System.Runtime]System.Object
-			IL_1361: dup
-			IL_1362: ldc.i4.0
-			IL_1363: ldarg.0
-			IL_1364: stelem.ref
-			IL_1365: stloc.1
-			IL_1366: volatile.
-			IL_1368: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
-			IL_136d: brfalse IL_1382
-
-			IL_1372: ldarg.3
-			IL_1373: ldstr "execution"
-			IL_1378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_137d: br IL_1397
-
-			IL_1382: ldarg.3
-			IL_1383: ldstr "execution"
-			IL_1388: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:484"
-			IL_138d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
-			IL_1392: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1397: stloc.2
-			IL_1398: volatile.
-			IL_139a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
-			IL_139f: brfalse IL_13b4
-
-			IL_13a4: ldloc.2
-			IL_13a5: ldstr "requiresAgent"
-			IL_13aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_13af: br IL_13c9
-
-			IL_13b4: ldloc.2
-			IL_13b5: ldstr "requiresAgent"
-			IL_13ba: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:486"
-			IL_13bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
-			IL_13c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_13c9: stloc.2
-			IL_13ca: ldloc.1
-			IL_13cb: ldloc.2
-			IL_13cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_13d1: stloc.2
-			IL_13d2: ldstr "execution.requiresAgent: "
-			IL_13d7: ldloc.2
-			IL_13d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_13dd: stloc.3
-			IL_13de: ldloc.0
-			IL_13df: ldloc.3
-			IL_13e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_13e5: pop
-			IL_13e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_13eb: stloc.0
-			IL_13ec: ldarg.0
-			IL_13ed: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_13f2: ldc.i4.1
-			IL_13f3: newarr [System.Runtime]System.Object
-			IL_13f8: dup
-			IL_13f9: ldc.i4.0
-			IL_13fa: ldarg.0
-			IL_13fb: stelem.ref
-			IL_13fc: stloc.1
-			IL_13fd: volatile.
-			IL_13ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
-			IL_1404: brfalse IL_1419
-
-			IL_1409: ldarg.3
-			IL_140a: ldstr "execution"
-			IL_140f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1414: br IL_142e
-
-			IL_1419: ldarg.3
-			IL_141a: ldstr "execution"
-			IL_141f: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:497"
-			IL_1424: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
-			IL_1429: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_142e: stloc.2
-			IL_142f: volatile.
-			IL_1431: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
-			IL_1436: brfalse IL_144b
-
-			IL_143b: ldloc.2
-			IL_143c: ldstr "canBlock"
-			IL_1441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1446: br IL_1460
-
-			IL_144b: ldloc.2
-			IL_144c: ldstr "canBlock"
-			IL_1451: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:499"
-			IL_1456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
-			IL_145b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1460: stloc.2
-			IL_1461: ldloc.1
-			IL_1462: ldloc.2
-			IL_1463: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1468: stloc.2
-			IL_1469: ldstr "execution.canBlock: "
-			IL_146e: ldloc.2
-			IL_146f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1474: stloc.3
-			IL_1475: ldloc.0
-			IL_1476: ldloc.3
-			IL_1477: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_147c: pop
-			IL_147d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1482: stloc.0
-			IL_1483: ldarg.0
-			IL_1484: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1489: ldc.i4.1
-			IL_148a: newarr [System.Runtime]System.Object
-			IL_148f: dup
-			IL_1490: ldc.i4.0
-			IL_1491: ldarg.0
-			IL_1492: stelem.ref
-			IL_1493: stloc.1
-			IL_1494: volatile.
-			IL_1496: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
-			IL_149b: brfalse IL_14b0
-
-			IL_14a0: ldarg.3
-			IL_14a1: ldstr "execution"
-			IL_14a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_14ab: br IL_14c5
-
-			IL_14b0: ldarg.3
-			IL_14b1: ldstr "execution"
-			IL_14b6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:510"
-			IL_14bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
-			IL_14c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_14c5: stloc.2
-			IL_14c6: volatile.
-			IL_14c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
-			IL_14cd: brfalse IL_14e2
-
-			IL_14d2: ldloc.2
-			IL_14d3: ldstr "isModule"
-			IL_14d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_14dd: br IL_14f7
-
-			IL_14e2: ldloc.2
-			IL_14e3: ldstr "isModule"
-			IL_14e8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:512"
-			IL_14ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
-			IL_14f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
+			IL_0bf3: ldstr "length"
+			IL_0bf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bfd: br IL_0c17
+
+			IL_0c02: ldloc.1
+			IL_0c03: ldstr "length"
+			IL_0c08: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:313"
+			IL_0c0d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
+			IL_0c12: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0c17: stloc.1
+			IL_0c18: ldarg.0
+			IL_0c19: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0c1e: ldnull
+			IL_0c1f: ldloc.1
+			IL_0c20: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0c25: stloc.1
+			IL_0c26: ldstr "execution.defaultHarnessIncludes.length: "
+			IL_0c2b: ldloc.1
+			IL_0c2c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0c31: stloc.2
+			IL_0c32: ldloc.0
+			IL_0c33: ldloc.2
+			IL_0c34: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c39: pop
+			IL_0c3a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c3f: stloc.0
+			IL_0c40: volatile.
+			IL_0c42: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
+			IL_0c47: brfalse IL_0c5c
+
+			IL_0c4c: ldarg.3
+			IL_0c4d: ldstr "execution"
+			IL_0c52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c57: br IL_0c71
+
+			IL_0c5c: ldarg.3
+			IL_0c5d: ldstr "execution"
+			IL_0c62: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:323"
+			IL_0c67: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
+			IL_0c6c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0c71: stloc.1
+			IL_0c72: volatile.
+			IL_0c74: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+			IL_0c79: brfalse IL_0c8e
+
+			IL_0c7e: ldloc.1
+			IL_0c7f: ldstr "defaultHarnessIncludes"
+			IL_0c84: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c89: br IL_0ca3
+
+			IL_0c8e: ldloc.1
+			IL_0c8f: ldstr "defaultHarnessIncludes"
+			IL_0c94: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:325"
+			IL_0c99: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+			IL_0c9e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0ca3: stloc.1
+			IL_0ca4: ldloc.1
+			IL_0ca5: ldc.r8 0.0
+			IL_0cae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0cb3: stloc.1
+			IL_0cb4: ldarg.0
+			IL_0cb5: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0cba: ldnull
+			IL_0cbb: ldloc.1
+			IL_0cbc: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0cc1: stloc.1
+			IL_0cc2: ldstr "execution.defaultHarnessIncludes[0]: "
+			IL_0cc7: ldloc.1
+			IL_0cc8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0ccd: stloc.2
+			IL_0cce: ldloc.0
+			IL_0ccf: ldloc.2
+			IL_0cd0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0cd5: pop
+			IL_0cd6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0cdb: stloc.0
+			IL_0cdc: volatile.
+			IL_0cde: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
+			IL_0ce3: brfalse IL_0cf8
+
+			IL_0ce8: ldarg.3
+			IL_0ce9: ldstr "execution"
+			IL_0cee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0cf3: br IL_0d0d
+
+			IL_0cf8: ldarg.3
+			IL_0cf9: ldstr "execution"
+			IL_0cfe: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:337"
+			IL_0d03: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_99
+			IL_0d08: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0d0d: stloc.1
+			IL_0d0e: volatile.
+			IL_0d10: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+			IL_0d15: brfalse IL_0d2a
+
+			IL_0d1a: ldloc.1
+			IL_0d1b: ldstr "defaultHarnessIncludes"
+			IL_0d20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d25: br IL_0d3f
+
+			IL_0d2a: ldloc.1
+			IL_0d2b: ldstr "defaultHarnessIncludes"
+			IL_0d30: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:339"
+			IL_0d35: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+			IL_0d3a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0d3f: stloc.1
+			IL_0d40: ldloc.1
+			IL_0d41: ldc.r8 1
+			IL_0d4a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d4f: stloc.1
+			IL_0d50: ldarg.0
+			IL_0d51: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0d56: ldnull
+			IL_0d57: ldloc.1
+			IL_0d58: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0d5d: stloc.1
+			IL_0d5e: ldstr "execution.defaultHarnessIncludes[1]: "
+			IL_0d63: ldloc.1
+			IL_0d64: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0d69: stloc.2
+			IL_0d6a: ldloc.0
+			IL_0d6b: ldloc.2
+			IL_0d6c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0d71: pop
+			IL_0d72: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0d77: stloc.0
+			IL_0d78: volatile.
+			IL_0d7a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+			IL_0d7f: brfalse IL_0d94
+
+			IL_0d84: ldarg.3
+			IL_0d85: ldstr "execution"
+			IL_0d8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d8f: br IL_0da9
+
+			IL_0d94: ldarg.3
+			IL_0d95: ldstr "execution"
+			IL_0d9a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:351"
+			IL_0d9f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+			IL_0da4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0da9: stloc.1
+			IL_0daa: volatile.
+			IL_0dac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
+			IL_0db1: brfalse IL_0dc6
+
+			IL_0db6: ldloc.1
+			IL_0db7: ldstr "harnessIncludes"
+			IL_0dbc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dc1: br IL_0ddb
+
+			IL_0dc6: ldloc.1
+			IL_0dc7: ldstr "harnessIncludes"
+			IL_0dcc: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:353"
+			IL_0dd1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
+			IL_0dd6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0ddb: stloc.1
+			IL_0ddc: volatile.
+			IL_0dde: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
+			IL_0de3: brfalse IL_0df8
+
+			IL_0de8: ldloc.1
+			IL_0de9: ldstr "length"
+			IL_0dee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0df3: br IL_0e0d
+
+			IL_0df8: ldloc.1
+			IL_0df9: ldstr "length"
+			IL_0dfe: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:355"
+			IL_0e03: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
+			IL_0e08: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0e0d: stloc.1
+			IL_0e0e: ldarg.0
+			IL_0e0f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0e14: ldnull
+			IL_0e15: ldloc.1
+			IL_0e16: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0e1b: stloc.1
+			IL_0e1c: ldstr "execution.harnessIncludes.length: "
+			IL_0e21: ldloc.1
+			IL_0e22: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0e27: stloc.2
+			IL_0e28: ldloc.0
+			IL_0e29: ldloc.2
+			IL_0e2a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0e2f: pop
+			IL_0e30: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0e35: stloc.0
+			IL_0e36: volatile.
+			IL_0e38: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+			IL_0e3d: brfalse IL_0e52
+
+			IL_0e42: ldarg.3
+			IL_0e43: ldstr "execution"
+			IL_0e48: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e4d: br IL_0e67
+
+			IL_0e52: ldarg.3
+			IL_0e53: ldstr "execution"
+			IL_0e58: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:365"
+			IL_0e5d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+			IL_0e62: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0e67: stloc.1
+			IL_0e68: volatile.
+			IL_0e6a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+			IL_0e6f: brfalse IL_0e84
+
+			IL_0e74: ldloc.1
+			IL_0e75: ldstr "harnessIncludes"
+			IL_0e7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e7f: br IL_0e99
+
+			IL_0e84: ldloc.1
+			IL_0e85: ldstr "harnessIncludes"
+			IL_0e8a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:367"
+			IL_0e8f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+			IL_0e94: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0e99: stloc.1
+			IL_0e9a: ldloc.1
+			IL_0e9b: ldc.r8 0.0
+			IL_0ea4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0ea9: stloc.1
+			IL_0eaa: ldarg.0
+			IL_0eab: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0eb0: ldnull
+			IL_0eb1: ldloc.1
+			IL_0eb2: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0eb7: stloc.1
+			IL_0eb8: ldstr "execution.harnessIncludes[0]: "
+			IL_0ebd: ldloc.1
+			IL_0ebe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0ec3: stloc.2
+			IL_0ec4: ldloc.0
+			IL_0ec5: ldloc.2
+			IL_0ec6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ecb: pop
+			IL_0ecc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0ed1: stloc.0
+			IL_0ed2: volatile.
+			IL_0ed4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+			IL_0ed9: brfalse IL_0eee
+
+			IL_0ede: ldarg.3
+			IL_0edf: ldstr "execution"
+			IL_0ee4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ee9: br IL_0f03
+
+			IL_0eee: ldarg.3
+			IL_0eef: ldstr "execution"
+			IL_0ef4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:379"
+			IL_0ef9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+			IL_0efe: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0f03: stloc.1
+			IL_0f04: volatile.
+			IL_0f06: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+			IL_0f0b: brfalse IL_0f20
+
+			IL_0f10: ldloc.1
+			IL_0f11: ldstr "harnessIncludes"
+			IL_0f16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f1b: br IL_0f35
+
+			IL_0f20: ldloc.1
+			IL_0f21: ldstr "harnessIncludes"
+			IL_0f26: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:381"
+			IL_0f2b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+			IL_0f30: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0f35: stloc.1
+			IL_0f36: ldloc.1
+			IL_0f37: ldc.r8 1
+			IL_0f40: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0f45: stloc.1
+			IL_0f46: ldarg.0
+			IL_0f47: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0f4c: ldnull
+			IL_0f4d: ldloc.1
+			IL_0f4e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0f53: stloc.1
+			IL_0f54: ldstr "execution.harnessIncludes[1]: "
+			IL_0f59: ldloc.1
+			IL_0f5a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0f5f: stloc.2
+			IL_0f60: ldloc.0
+			IL_0f61: ldloc.2
+			IL_0f62: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0f67: pop
+			IL_0f68: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0f6d: stloc.0
+			IL_0f6e: volatile.
+			IL_0f70: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+			IL_0f75: brfalse IL_0f8a
+
+			IL_0f7a: ldarg.3
+			IL_0f7b: ldstr "execution"
+			IL_0f80: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f85: br IL_0f9f
+
+			IL_0f8a: ldarg.3
+			IL_0f8b: ldstr "execution"
+			IL_0f90: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:393"
+			IL_0f95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+			IL_0f9a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0f9f: stloc.1
+			IL_0fa0: volatile.
+			IL_0fa2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_0fa7: brfalse IL_0fbc
+
+			IL_0fac: ldloc.1
+			IL_0fad: ldstr "harnessIncludes"
+			IL_0fb2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fb7: br IL_0fd1
+
+			IL_0fbc: ldloc.1
+			IL_0fbd: ldstr "harnessIncludes"
+			IL_0fc2: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:395"
+			IL_0fc7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_0fcc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0fd1: stloc.1
+			IL_0fd2: ldloc.1
+			IL_0fd3: ldc.r8 2
+			IL_0fdc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0fe1: stloc.1
+			IL_0fe2: ldarg.0
+			IL_0fe3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0fe8: ldnull
+			IL_0fe9: ldloc.1
+			IL_0fea: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0fef: stloc.1
+			IL_0ff0: ldstr "execution.harnessIncludes[2]: "
+			IL_0ff5: ldloc.1
+			IL_0ff6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0ffb: stloc.2
+			IL_0ffc: ldloc.0
+			IL_0ffd: ldloc.2
+			IL_0ffe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_1003: pop
+			IL_1004: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1009: stloc.0
+			IL_100a: volatile.
+			IL_100c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_1011: brfalse IL_1026
+
+			IL_1016: ldarg.3
+			IL_1017: ldstr "execution"
+			IL_101c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1021: br IL_103b
+
+			IL_1026: ldarg.3
+			IL_1027: ldstr "execution"
+			IL_102c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:407"
+			IL_1031: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_1036: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_103b: stloc.1
+			IL_103c: volatile.
+			IL_103e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_1043: brfalse IL_1058
+
+			IL_1048: ldloc.1
+			IL_1049: ldstr "harnessIncludes"
+			IL_104e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1053: br IL_106d
+
+			IL_1058: ldloc.1
+			IL_1059: ldstr "harnessIncludes"
+			IL_105e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:409"
+			IL_1063: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_1068: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_106d: stloc.1
+			IL_106e: ldloc.1
+			IL_106f: ldc.r8 3
+			IL_1078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_107d: stloc.1
+			IL_107e: ldarg.0
+			IL_107f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1084: ldnull
+			IL_1085: ldloc.1
+			IL_1086: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_108b: stloc.1
+			IL_108c: ldstr "execution.harnessIncludes[3]: "
+			IL_1091: ldloc.1
+			IL_1092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1097: stloc.2
+			IL_1098: ldloc.0
+			IL_1099: ldloc.2
+			IL_109a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_109f: pop
+			IL_10a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_10a5: stloc.0
+			IL_10a6: volatile.
+			IL_10a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+			IL_10ad: brfalse IL_10c2
+
+			IL_10b2: ldarg.3
+			IL_10b3: ldstr "execution"
+			IL_10b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_10bd: br IL_10d7
+
+			IL_10c2: ldarg.3
+			IL_10c3: ldstr "execution"
+			IL_10c8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:421"
+			IL_10cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+			IL_10d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_10d7: stloc.1
+			IL_10d8: volatile.
+			IL_10da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
+			IL_10df: brfalse IL_10f4
+
+			IL_10e4: ldloc.1
+			IL_10e5: ldstr "requiresDefaultHarness"
+			IL_10ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_10ef: br IL_1109
+
+			IL_10f4: ldloc.1
+			IL_10f5: ldstr "requiresDefaultHarness"
+			IL_10fa: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:423"
+			IL_10ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_113
+			IL_1104: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_1109: stloc.1
+			IL_110a: ldarg.0
+			IL_110b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1110: ldnull
+			IL_1111: ldloc.1
+			IL_1112: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_1117: stloc.1
+			IL_1118: ldstr "execution.requiresDefaultHarness: "
+			IL_111d: ldloc.1
+			IL_111e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1123: stloc.2
+			IL_1124: ldloc.0
+			IL_1125: ldloc.2
+			IL_1126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_112b: pop
+			IL_112c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1131: stloc.0
+			IL_1132: volatile.
+			IL_1134: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
+			IL_1139: brfalse IL_114e
+
+			IL_113e: ldarg.3
+			IL_113f: ldstr "execution"
+			IL_1144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1149: br IL_1163
+
+			IL_114e: ldarg.3
+			IL_114f: ldstr "execution"
+			IL_1154: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:433"
+			IL_1159: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_114
+			IL_115e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_1163: stloc.1
+			IL_1164: volatile.
+			IL_1166: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
+			IL_116b: brfalse IL_1180
+
+			IL_1170: ldloc.1
+			IL_1171: ldstr "requiresAsyncHarness"
+			IL_1176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_117b: br IL_1195
+
+			IL_1180: ldloc.1
+			IL_1181: ldstr "requiresAsyncHarness"
+			IL_1186: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:435"
+			IL_118b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_115
+			IL_1190: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_1195: stloc.1
+			IL_1196: ldarg.0
+			IL_1197: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_119c: ldnull
+			IL_119d: ldloc.1
+			IL_119e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_11a3: stloc.1
+			IL_11a4: ldstr "execution.requiresAsyncHarness: "
+			IL_11a9: ldloc.1
+			IL_11aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_11af: stloc.2
+			IL_11b0: ldloc.0
+			IL_11b1: ldloc.2
+			IL_11b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_11b7: pop
+			IL_11b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_11bd: stloc.0
+			IL_11be: volatile.
+			IL_11c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
+			IL_11c5: brfalse IL_11da
+
+			IL_11ca: ldarg.3
+			IL_11cb: ldstr "execution"
+			IL_11d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_11d5: br IL_11ef
+
+			IL_11da: ldarg.3
+			IL_11db: ldstr "execution"
+			IL_11e0: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:445"
+			IL_11e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_116
+			IL_11ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_11ef: stloc.1
+			IL_11f0: volatile.
+			IL_11f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
+			IL_11f7: brfalse IL_120c
+
+			IL_11fc: ldloc.1
+			IL_11fd: ldstr "requiresAgent"
+			IL_1202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1207: br IL_1221
+
+			IL_120c: ldloc.1
+			IL_120d: ldstr "requiresAgent"
+			IL_1212: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:447"
+			IL_1217: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_117
+			IL_121c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_1221: stloc.1
+			IL_1222: ldarg.0
+			IL_1223: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1228: ldnull
+			IL_1229: ldloc.1
+			IL_122a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_122f: stloc.1
+			IL_1230: ldstr "execution.requiresAgent: "
+			IL_1235: ldloc.1
+			IL_1236: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_123b: stloc.2
+			IL_123c: ldloc.0
+			IL_123d: ldloc.2
+			IL_123e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_1243: pop
+			IL_1244: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1249: stloc.0
+			IL_124a: volatile.
+			IL_124c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
+			IL_1251: brfalse IL_1266
+
+			IL_1256: ldarg.3
+			IL_1257: ldstr "execution"
+			IL_125c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1261: br IL_127b
+
+			IL_1266: ldarg.3
+			IL_1267: ldstr "execution"
+			IL_126c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:457"
+			IL_1271: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_118
+			IL_1276: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_127b: stloc.1
+			IL_127c: volatile.
+			IL_127e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
+			IL_1283: brfalse IL_1298
+
+			IL_1288: ldloc.1
+			IL_1289: ldstr "canBlock"
+			IL_128e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1293: br IL_12ad
+
+			IL_1298: ldloc.1
+			IL_1299: ldstr "canBlock"
+			IL_129e: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:459"
+			IL_12a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_119
+			IL_12a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_12ad: stloc.1
+			IL_12ae: ldarg.0
+			IL_12af: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_12b4: ldnull
+			IL_12b5: ldloc.1
+			IL_12b6: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_12bb: stloc.1
+			IL_12bc: ldstr "execution.canBlock: "
+			IL_12c1: ldloc.1
+			IL_12c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_12c7: stloc.2
+			IL_12c8: ldloc.0
+			IL_12c9: ldloc.2
+			IL_12ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_12cf: pop
+			IL_12d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_12d5: stloc.0
+			IL_12d6: volatile.
+			IL_12d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
+			IL_12dd: brfalse IL_12f2
+
+			IL_12e2: ldarg.3
+			IL_12e3: ldstr "execution"
+			IL_12e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_12ed: br IL_1307
+
+			IL_12f2: ldarg.3
+			IL_12f3: ldstr "execution"
+			IL_12f8: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:469"
+			IL_12fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_120
+			IL_1302: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_1307: stloc.1
+			IL_1308: volatile.
+			IL_130a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
+			IL_130f: brfalse IL_1324
+
+			IL_1314: ldloc.1
+			IL_1315: ldstr "isModule"
+			IL_131a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_131f: br IL_1339
+
+			IL_1324: ldloc.1
+			IL_1325: ldstr "isModule"
+			IL_132a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:471"
+			IL_132f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_121
+			IL_1334: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_1339: stloc.1
+			IL_133a: ldarg.0
+			IL_133b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1340: ldnull
+			IL_1341: ldloc.1
+			IL_1342: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_1347: stloc.1
+			IL_1348: ldstr "execution.isModule: "
+			IL_134d: ldloc.1
+			IL_134e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1353: stloc.2
+			IL_1354: ldloc.0
+			IL_1355: ldloc.2
+			IL_1356: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_135b: pop
+			IL_135c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1361: stloc.0
+			IL_1362: volatile.
+			IL_1364: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
+			IL_1369: brfalse IL_137e
+
+			IL_136e: ldarg.3
+			IL_136f: ldstr "execution"
+			IL_1374: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1379: br IL_1393
+
+			IL_137e: ldarg.3
+			IL_137f: ldstr "execution"
+			IL_1384: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:481"
+			IL_1389: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
+			IL_138e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_1393: stloc.1
+			IL_1394: volatile.
+			IL_1396: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
+			IL_139b: brfalse IL_13b0
+
+			IL_13a0: ldloc.1
+			IL_13a1: ldstr "isRaw"
+			IL_13a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_13ab: br IL_13c5
+
+			IL_13b0: ldloc.1
+			IL_13b1: ldstr "isRaw"
+			IL_13b6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:483"
+			IL_13bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
+			IL_13c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_13c5: stloc.1
+			IL_13c6: ldarg.0
+			IL_13c7: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_13cc: ldnull
+			IL_13cd: ldloc.1
+			IL_13ce: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_13d3: stloc.1
+			IL_13d4: ldstr "execution.isRaw: "
+			IL_13d9: ldloc.1
+			IL_13da: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_13df: stloc.2
+			IL_13e0: ldloc.0
+			IL_13e1: ldloc.2
+			IL_13e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_13e7: pop
+			IL_13e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_13ed: stloc.0
+			IL_13ee: volatile.
+			IL_13f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
+			IL_13f5: brfalse IL_140a
+
+			IL_13fa: ldarg.3
+			IL_13fb: ldstr "execution"
+			IL_1400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1405: br IL_141f
+
+			IL_140a: ldarg.3
+			IL_140b: ldstr "execution"
+			IL_1410: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:493"
+			IL_1415: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
+			IL_141a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_141f: stloc.1
+			IL_1420: volatile.
+			IL_1422: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
+			IL_1427: brfalse IL_143c
+
+			IL_142c: ldloc.1
+			IL_142d: ldstr "isAsync"
+			IL_1432: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1437: br IL_1451
+
+			IL_143c: ldloc.1
+			IL_143d: ldstr "isAsync"
+			IL_1442: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:495"
+			IL_1447: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
+			IL_144c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_1451: stloc.1
+			IL_1452: ldarg.0
+			IL_1453: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1458: ldnull
+			IL_1459: ldloc.1
+			IL_145a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_145f: stloc.1
+			IL_1460: ldstr "execution.isAsync: "
+			IL_1465: ldloc.1
+			IL_1466: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_146b: stloc.2
+			IL_146c: ldloc.0
+			IL_146d: ldloc.2
+			IL_146e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_1473: pop
+			IL_1474: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1479: stloc.0
+			IL_147a: volatile.
+			IL_147c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
+			IL_1481: brfalse IL_1496
+
+			IL_1486: ldarg.3
+			IL_1487: ldstr "execution"
+			IL_148c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1491: br IL_14ab
+
+			IL_1496: ldarg.3
+			IL_1497: ldstr "execution"
+			IL_149c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:505"
+			IL_14a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
+			IL_14a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_14ab: stloc.1
+			IL_14ac: volatile.
+			IL_14ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
+			IL_14b3: brfalse IL_14c8
+
+			IL_14b8: ldloc.1
+			IL_14b9: ldstr "isGenerated"
+			IL_14be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_14c3: br IL_14dd
+
+			IL_14c8: ldloc.1
+			IL_14c9: ldstr "isGenerated"
+			IL_14ce: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:507"
+			IL_14d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
+			IL_14d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_14dd: stloc.1
+			IL_14de: ldarg.0
+			IL_14df: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_14e4: ldnull
+			IL_14e5: ldloc.1
+			IL_14e6: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_14eb: stloc.1
+			IL_14ec: ldstr "execution.isGenerated: "
+			IL_14f1: ldloc.1
+			IL_14f2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_14f7: stloc.2
-			IL_14f8: ldloc.1
+			IL_14f8: ldloc.0
 			IL_14f9: ldloc.2
-			IL_14fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_14ff: stloc.2
-			IL_1500: ldstr "execution.isModule: "
-			IL_1505: ldloc.2
-			IL_1506: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_150b: stloc.3
-			IL_150c: ldloc.0
-			IL_150d: ldloc.3
-			IL_150e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1513: pop
-			IL_1514: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1519: stloc.0
-			IL_151a: ldarg.0
-			IL_151b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1520: ldc.i4.1
-			IL_1521: newarr [System.Runtime]System.Object
-			IL_1526: dup
-			IL_1527: ldc.i4.0
-			IL_1528: ldarg.0
-			IL_1529: stelem.ref
-			IL_152a: stloc.1
-			IL_152b: volatile.
-			IL_152d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
-			IL_1532: brfalse IL_1547
+			IL_14fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_14ff: pop
+			IL_1500: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1505: stloc.0
+			IL_1506: volatile.
+			IL_1508: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
+			IL_150d: brfalse IL_1522
 
-			IL_1537: ldarg.3
-			IL_1538: ldstr "execution"
-			IL_153d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1542: br IL_155c
+			IL_1512: ldarg.3
+			IL_1513: ldstr "execution"
+			IL_1518: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_151d: br IL_1537
 
-			IL_1547: ldarg.3
-			IL_1548: ldstr "execution"
-			IL_154d: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:523"
-			IL_1552: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_122
-			IL_1557: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1522: ldarg.3
+			IL_1523: ldstr "execution"
+			IL_1528: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:517"
+			IL_152d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
+			IL_1532: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_155c: stloc.2
-			IL_155d: volatile.
-			IL_155f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
-			IL_1564: brfalse IL_1579
+			IL_1537: stloc.1
+			IL_1538: volatile.
+			IL_153a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
+			IL_153f: brfalse IL_1554
 
-			IL_1569: ldloc.2
-			IL_156a: ldstr "isRaw"
-			IL_156f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1574: br IL_158e
+			IL_1544: ldloc.1
+			IL_1545: ldstr "isNonDeterministic"
+			IL_154a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_154f: br IL_1569
 
-			IL_1579: ldloc.2
-			IL_157a: ldstr "isRaw"
-			IL_157f: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:525"
-			IL_1584: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_123
-			IL_1589: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1554: ldloc.1
+			IL_1555: ldstr "isNonDeterministic"
+			IL_155a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:519"
+			IL_155f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
+			IL_1564: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_158e: stloc.2
-			IL_158f: ldloc.1
-			IL_1590: ldloc.2
-			IL_1591: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1596: stloc.2
-			IL_1597: ldstr "execution.isRaw: "
-			IL_159c: ldloc.2
-			IL_159d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_15a2: stloc.3
-			IL_15a3: ldloc.0
-			IL_15a4: ldloc.3
-			IL_15a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_15aa: pop
-			IL_15ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_15b0: stloc.0
-			IL_15b1: ldarg.0
-			IL_15b2: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_15b7: ldc.i4.1
-			IL_15b8: newarr [System.Runtime]System.Object
-			IL_15bd: dup
-			IL_15be: ldc.i4.0
-			IL_15bf: ldarg.0
-			IL_15c0: stelem.ref
-			IL_15c1: stloc.1
-			IL_15c2: volatile.
-			IL_15c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
-			IL_15c9: brfalse IL_15de
+			IL_1569: stloc.1
+			IL_156a: ldarg.0
+			IL_156b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1570: ldnull
+			IL_1571: ldloc.1
+			IL_1572: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_1577: stloc.1
+			IL_1578: ldstr "execution.isNonDeterministic: "
+			IL_157d: ldloc.1
+			IL_157e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1583: stloc.2
+			IL_1584: ldloc.0
+			IL_1585: ldloc.2
+			IL_1586: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_158b: pop
+			IL_158c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1591: stloc.0
+			IL_1592: volatile.
+			IL_1594: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
+			IL_1599: brfalse IL_15ae
 
-			IL_15ce: ldarg.3
-			IL_15cf: ldstr "execution"
-			IL_15d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_15d9: br IL_15f3
+			IL_159e: ldarg.3
+			IL_159f: ldstr "execution"
+			IL_15a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_15a9: br IL_15c3
 
-			IL_15de: ldarg.3
-			IL_15df: ldstr "execution"
-			IL_15e4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:536"
-			IL_15e9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_124
-			IL_15ee: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_15ae: ldarg.3
+			IL_15af: ldstr "execution"
+			IL_15b4: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:529"
+			IL_15b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
+			IL_15be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_15f3: stloc.2
-			IL_15f4: volatile.
-			IL_15f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
-			IL_15fb: brfalse IL_1610
+			IL_15c3: stloc.1
+			IL_15c4: volatile.
+			IL_15c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
+			IL_15cb: brfalse IL_15e0
 
-			IL_1600: ldloc.2
-			IL_1601: ldstr "isAsync"
-			IL_1606: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_160b: br IL_1625
+			IL_15d0: ldloc.1
+			IL_15d1: ldstr "isFixture"
+			IL_15d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_15db: br IL_15f5
 
-			IL_1610: ldloc.2
-			IL_1611: ldstr "isAsync"
-			IL_1616: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:538"
-			IL_161b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_125
-			IL_1620: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_15e0: ldloc.1
+			IL_15e1: ldstr "isFixture"
+			IL_15e6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:531"
+			IL_15eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
+			IL_15f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1625: stloc.2
-			IL_1626: ldloc.1
-			IL_1627: ldloc.2
-			IL_1628: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_162d: stloc.2
-			IL_162e: ldstr "execution.isAsync: "
-			IL_1633: ldloc.2
-			IL_1634: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1639: stloc.3
-			IL_163a: ldloc.0
-			IL_163b: ldloc.3
-			IL_163c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1641: pop
-			IL_1642: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1647: stloc.0
-			IL_1648: ldarg.0
-			IL_1649: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_164e: ldc.i4.1
-			IL_164f: newarr [System.Runtime]System.Object
-			IL_1654: dup
-			IL_1655: ldc.i4.0
-			IL_1656: ldarg.0
-			IL_1657: stelem.ref
-			IL_1658: stloc.1
-			IL_1659: volatile.
-			IL_165b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
-			IL_1660: brfalse IL_1675
+			IL_15f5: stloc.1
+			IL_15f6: ldarg.0
+			IL_15f7: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_15fc: ldnull
+			IL_15fd: ldloc.1
+			IL_15fe: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_1603: stloc.1
+			IL_1604: ldstr "execution.isFixture: "
+			IL_1609: ldloc.1
+			IL_160a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_160f: stloc.2
+			IL_1610: ldloc.0
+			IL_1611: ldloc.2
+			IL_1612: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_1617: pop
+			IL_1618: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_161d: stloc.0
+			IL_161e: volatile.
+			IL_1620: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
+			IL_1625: brfalse IL_163a
 
-			IL_1665: ldarg.3
-			IL_1666: ldstr "execution"
-			IL_166b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1670: br IL_168a
+			IL_162a: ldarg.3
+			IL_162b: ldstr "mvpBlockers"
+			IL_1630: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1635: br IL_164f
 
-			IL_1675: ldarg.3
-			IL_1676: ldstr "execution"
-			IL_167b: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:549"
-			IL_1680: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_126
-			IL_1685: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_163a: ldarg.3
+			IL_163b: ldstr "mvpBlockers"
+			IL_1640: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:541"
+			IL_1645: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
+			IL_164a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_168a: stloc.2
-			IL_168b: volatile.
-			IL_168d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
-			IL_1692: brfalse IL_16a7
+			IL_164f: stloc.1
+			IL_1650: volatile.
+			IL_1652: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
+			IL_1657: brfalse IL_166c
 
-			IL_1697: ldloc.2
-			IL_1698: ldstr "isGenerated"
-			IL_169d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_16a2: br IL_16bc
+			IL_165c: ldloc.1
+			IL_165d: ldstr "length"
+			IL_1662: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1667: br IL_1681
 
-			IL_16a7: ldloc.2
-			IL_16a8: ldstr "isGenerated"
-			IL_16ad: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:551"
-			IL_16b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_127
-			IL_16b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_166c: ldloc.1
+			IL_166d: ldstr "length"
+			IL_1672: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:543"
+			IL_1677: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
+			IL_167c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_16bc: stloc.2
-			IL_16bd: ldloc.1
-			IL_16be: ldloc.2
-			IL_16bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_16c4: stloc.2
-			IL_16c5: ldstr "execution.isGenerated: "
-			IL_16ca: ldloc.2
-			IL_16cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_16d0: stloc.3
-			IL_16d1: ldloc.0
-			IL_16d2: ldloc.3
-			IL_16d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_16d8: pop
-			IL_16d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_16de: stloc.0
-			IL_16df: ldarg.0
-			IL_16e0: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_16e5: ldc.i4.1
-			IL_16e6: newarr [System.Runtime]System.Object
-			IL_16eb: dup
-			IL_16ec: ldc.i4.0
-			IL_16ed: ldarg.0
-			IL_16ee: stelem.ref
-			IL_16ef: stloc.1
-			IL_16f0: volatile.
-			IL_16f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
-			IL_16f7: brfalse IL_170c
+			IL_1681: stloc.1
+			IL_1682: ldarg.0
+			IL_1683: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1688: ldnull
+			IL_1689: ldloc.1
+			IL_168a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_168f: stloc.1
+			IL_1690: ldstr "mvpBlockers.length: "
+			IL_1695: ldloc.1
+			IL_1696: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_169b: stloc.2
+			IL_169c: ldloc.0
+			IL_169d: ldloc.2
+			IL_169e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_16a3: pop
+			IL_16a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_16a9: stloc.0
+			IL_16aa: volatile.
+			IL_16ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
+			IL_16b1: brfalse IL_16c6
 
-			IL_16fc: ldarg.3
-			IL_16fd: ldstr "execution"
-			IL_1702: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1707: br IL_1721
+			IL_16b6: ldarg.3
+			IL_16b7: ldstr "mvpBlockers"
+			IL_16bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_16c1: br IL_16db
 
-			IL_170c: ldarg.3
-			IL_170d: ldstr "execution"
-			IL_1712: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:562"
-			IL_1717: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_128
-			IL_171c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_16c6: ldarg.3
+			IL_16c7: ldstr "mvpBlockers"
+			IL_16cc: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:553"
+			IL_16d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
+			IL_16d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1721: stloc.2
-			IL_1722: volatile.
-			IL_1724: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
-			IL_1729: brfalse IL_173e
+			IL_16db: stloc.1
+			IL_16dc: ldloc.1
+			IL_16dd: ldc.r8 0.0
+			IL_16e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_16eb: stloc.1
+			IL_16ec: ldarg.0
+			IL_16ed: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_16f2: ldnull
+			IL_16f3: ldloc.1
+			IL_16f4: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_16f9: stloc.1
+			IL_16fa: ldstr "mvpBlockers[0]: "
+			IL_16ff: ldloc.1
+			IL_1700: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1705: stloc.2
+			IL_1706: ldloc.0
+			IL_1707: ldloc.2
+			IL_1708: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_170d: pop
+			IL_170e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1713: stloc.0
+			IL_1714: volatile.
+			IL_1716: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
+			IL_171b: brfalse IL_1730
 
-			IL_172e: ldloc.2
-			IL_172f: ldstr "isNonDeterministic"
-			IL_1734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1739: br IL_1753
+			IL_1720: ldarg.3
+			IL_1721: ldstr "mvpBlockers"
+			IL_1726: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_172b: br IL_1745
 
-			IL_173e: ldloc.2
-			IL_173f: ldstr "isNonDeterministic"
-			IL_1744: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:564"
-			IL_1749: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_129
-			IL_174e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1730: ldarg.3
+			IL_1731: ldstr "mvpBlockers"
+			IL_1736: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:565"
+			IL_173b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
+			IL_1740: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1753: stloc.2
-			IL_1754: ldloc.1
-			IL_1755: ldloc.2
-			IL_1756: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_175b: stloc.2
-			IL_175c: ldstr "execution.isNonDeterministic: "
-			IL_1761: ldloc.2
-			IL_1762: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1767: stloc.3
-			IL_1768: ldloc.0
-			IL_1769: ldloc.3
-			IL_176a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_176f: pop
-			IL_1770: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1775: stloc.0
-			IL_1776: ldarg.0
-			IL_1777: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_177c: ldc.i4.1
-			IL_177d: newarr [System.Runtime]System.Object
-			IL_1782: dup
-			IL_1783: ldc.i4.0
-			IL_1784: ldarg.0
-			IL_1785: stelem.ref
-			IL_1786: stloc.1
-			IL_1787: volatile.
-			IL_1789: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
-			IL_178e: brfalse IL_17a3
+			IL_1745: stloc.1
+			IL_1746: ldloc.1
+			IL_1747: ldc.r8 1
+			IL_1750: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1755: stloc.1
+			IL_1756: ldarg.0
+			IL_1757: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_175c: ldnull
+			IL_175d: ldloc.1
+			IL_175e: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_1763: stloc.1
+			IL_1764: ldstr "mvpBlockers[1]: "
+			IL_1769: ldloc.1
+			IL_176a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_176f: stloc.2
+			IL_1770: ldloc.0
+			IL_1771: ldloc.2
+			IL_1772: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_1777: pop
+			IL_1778: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_177d: stloc.0
+			IL_177e: volatile.
+			IL_1780: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
+			IL_1785: brfalse IL_179a
 
-			IL_1793: ldarg.3
-			IL_1794: ldstr "execution"
-			IL_1799: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_179e: br IL_17b8
+			IL_178a: ldarg.3
+			IL_178b: ldstr "mvpBlockers"
+			IL_1790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1795: br IL_17af
 
-			IL_17a3: ldarg.3
-			IL_17a4: ldstr "execution"
-			IL_17a9: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:575"
-			IL_17ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_130
-			IL_17b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_179a: ldarg.3
+			IL_179b: ldstr "mvpBlockers"
+			IL_17a0: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:577"
+			IL_17a5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
+			IL_17aa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_17b8: stloc.2
-			IL_17b9: volatile.
-			IL_17bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
-			IL_17c0: brfalse IL_17d5
+			IL_17af: stloc.1
+			IL_17b0: ldloc.1
+			IL_17b1: ldc.r8 2
+			IL_17ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_17bf: stloc.1
+			IL_17c0: ldarg.0
+			IL_17c1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_17c6: ldnull
+			IL_17c7: ldloc.1
+			IL_17c8: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_17cd: stloc.1
+			IL_17ce: ldstr "mvpBlockers[2]: "
+			IL_17d3: ldloc.1
+			IL_17d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_17d9: stloc.2
+			IL_17da: ldloc.0
+			IL_17db: ldloc.2
+			IL_17dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_17e1: pop
+			IL_17e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_17e7: stloc.0
+			IL_17e8: volatile.
+			IL_17ea: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
+			IL_17ef: brfalse IL_1804
 
-			IL_17c5: ldloc.2
-			IL_17c6: ldstr "isFixture"
-			IL_17cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_17d0: br IL_17ea
+			IL_17f4: ldarg.3
+			IL_17f5: ldstr "mvpBlockers"
+			IL_17fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_17ff: br IL_1819
 
-			IL_17d5: ldloc.2
-			IL_17d6: ldstr "isFixture"
-			IL_17db: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:577"
-			IL_17e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_131
-			IL_17e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1804: ldarg.3
+			IL_1805: ldstr "mvpBlockers"
+			IL_180a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:589"
+			IL_180f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
+			IL_1814: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_17ea: stloc.2
-			IL_17eb: ldloc.1
-			IL_17ec: ldloc.2
-			IL_17ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_17f2: stloc.2
-			IL_17f3: ldstr "execution.isFixture: "
-			IL_17f8: ldloc.2
-			IL_17f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_17fe: stloc.3
-			IL_17ff: ldloc.0
-			IL_1800: ldloc.3
-			IL_1801: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1806: pop
-			IL_1807: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_180c: stloc.0
-			IL_180d: ldarg.0
-			IL_180e: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1813: ldc.i4.1
-			IL_1814: newarr [System.Runtime]System.Object
-			IL_1819: dup
-			IL_181a: ldc.i4.0
-			IL_181b: ldarg.0
-			IL_181c: stelem.ref
-			IL_181d: stloc.1
-			IL_181e: volatile.
-			IL_1820: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
-			IL_1825: brfalse IL_183a
+			IL_1819: stloc.1
+			IL_181a: ldloc.1
+			IL_181b: ldc.r8 3
+			IL_1824: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1829: stloc.1
+			IL_182a: ldarg.0
+			IL_182b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1830: ldnull
+			IL_1831: ldloc.1
+			IL_1832: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_1837: stloc.1
+			IL_1838: ldstr "mvpBlockers[3]: "
+			IL_183d: ldloc.1
+			IL_183e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1843: stloc.2
+			IL_1844: ldloc.0
+			IL_1845: ldloc.2
+			IL_1846: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_184b: pop
+			IL_184c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1851: stloc.0
+			IL_1852: volatile.
+			IL_1854: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
+			IL_1859: brfalse IL_186e
 
-			IL_182a: ldarg.3
-			IL_182b: ldstr "mvpBlockers"
-			IL_1830: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1835: br IL_184f
+			IL_185e: ldarg.3
+			IL_185f: ldstr "unsupported"
+			IL_1864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1869: br IL_1883
 
-			IL_183a: ldarg.3
-			IL_183b: ldstr "mvpBlockers"
-			IL_1840: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:588"
-			IL_1845: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_132
-			IL_184a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_186e: ldarg.3
+			IL_186f: ldstr "unsupported"
+			IL_1874: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:601"
+			IL_1879: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
+			IL_187e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_184f: stloc.2
-			IL_1850: volatile.
-			IL_1852: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
-			IL_1857: brfalse IL_186c
+			IL_1883: stloc.1
+			IL_1884: volatile.
+			IL_1886: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
+			IL_188b: brfalse IL_18a0
 
-			IL_185c: ldloc.2
-			IL_185d: ldstr "length"
-			IL_1862: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1867: br IL_1881
+			IL_1890: ldloc.1
+			IL_1891: ldstr "length"
+			IL_1896: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_189b: br IL_18b5
 
-			IL_186c: ldloc.2
-			IL_186d: ldstr "length"
-			IL_1872: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:590"
-			IL_1877: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_133
-			IL_187c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_18a0: ldloc.1
+			IL_18a1: ldstr "length"
+			IL_18a6: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:603"
+			IL_18ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
+			IL_18b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1881: stloc.2
-			IL_1882: ldloc.1
-			IL_1883: ldloc.2
-			IL_1884: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1889: stloc.2
-			IL_188a: ldstr "mvpBlockers.length: "
-			IL_188f: ldloc.2
-			IL_1890: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1895: stloc.3
-			IL_1896: ldloc.0
-			IL_1897: ldloc.3
-			IL_1898: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_189d: pop
-			IL_189e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_18a3: stloc.0
-			IL_18a4: ldarg.0
-			IL_18a5: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_18aa: ldc.i4.1
-			IL_18ab: newarr [System.Runtime]System.Object
-			IL_18b0: dup
-			IL_18b1: ldc.i4.0
-			IL_18b2: ldarg.0
-			IL_18b3: stelem.ref
-			IL_18b4: stloc.1
-			IL_18b5: volatile.
-			IL_18b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
-			IL_18bc: brfalse IL_18d1
+			IL_18b5: stloc.1
+			IL_18b6: ldarg.0
+			IL_18b7: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_18bc: ldnull
+			IL_18bd: ldloc.1
+			IL_18be: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_18c3: stloc.1
+			IL_18c4: ldstr "unsupported.length: "
+			IL_18c9: ldloc.1
+			IL_18ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_18cf: stloc.2
+			IL_18d0: ldloc.0
+			IL_18d1: ldloc.2
+			IL_18d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_18d7: pop
+			IL_18d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_18dd: stloc.0
+			IL_18de: volatile.
+			IL_18e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
+			IL_18e5: brfalse IL_18fa
 
-			IL_18c1: ldarg.3
-			IL_18c2: ldstr "mvpBlockers"
-			IL_18c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_18cc: br IL_18e6
+			IL_18ea: ldarg.3
+			IL_18eb: ldstr "unsupported"
+			IL_18f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_18f5: br IL_190f
 
-			IL_18d1: ldarg.3
-			IL_18d2: ldstr "mvpBlockers"
-			IL_18d7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:601"
-			IL_18dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_134
-			IL_18e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_18fa: ldarg.3
+			IL_18fb: ldstr "unsupported"
+			IL_1900: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:613"
+			IL_1905: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
+			IL_190a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_18e6: stloc.2
-			IL_18e7: ldloc.2
-			IL_18e8: ldc.r8 0.0
-			IL_18f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_18f6: stloc.2
-			IL_18f7: ldloc.1
-			IL_18f8: ldloc.2
-			IL_18f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_18fe: stloc.2
-			IL_18ff: ldstr "mvpBlockers[0]: "
-			IL_1904: ldloc.2
-			IL_1905: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_190a: stloc.3
-			IL_190b: ldloc.0
-			IL_190c: ldloc.3
-			IL_190d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1912: pop
-			IL_1913: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1918: stloc.0
-			IL_1919: ldarg.0
-			IL_191a: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_191f: ldc.i4.1
-			IL_1920: newarr [System.Runtime]System.Object
-			IL_1925: dup
-			IL_1926: ldc.i4.0
-			IL_1927: ldarg.0
-			IL_1928: stelem.ref
-			IL_1929: stloc.1
-			IL_192a: volatile.
-			IL_192c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
-			IL_1931: brfalse IL_1946
+			IL_190f: stloc.1
+			IL_1910: ldloc.1
+			IL_1911: ldc.r8 0.0
+			IL_191a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_191f: stloc.1
+			IL_1920: ldarg.0
+			IL_1921: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1926: ldnull
+			IL_1927: ldloc.1
+			IL_1928: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_192d: stloc.1
+			IL_192e: ldstr "unsupported[0]: "
+			IL_1933: ldloc.1
+			IL_1934: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_1939: stloc.2
+			IL_193a: ldloc.0
+			IL_193b: ldloc.2
+			IL_193c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_1941: pop
+			IL_1942: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_1947: stloc.0
+			IL_1948: volatile.
+			IL_194a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
+			IL_194f: brfalse IL_1964
 
-			IL_1936: ldarg.3
-			IL_1937: ldstr "mvpBlockers"
-			IL_193c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1941: br IL_195b
+			IL_1954: ldarg.3
+			IL_1955: ldstr "unsupported"
+			IL_195a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_195f: br IL_1979
 
-			IL_1946: ldarg.3
-			IL_1947: ldstr "mvpBlockers"
-			IL_194c: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:614"
-			IL_1951: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_135
-			IL_1956: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1964: ldarg.3
+			IL_1965: ldstr "unsupported"
+			IL_196a: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:625"
+			IL_196f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
+			IL_1974: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_195b: stloc.2
-			IL_195c: ldloc.2
-			IL_195d: ldc.r8 1
-			IL_1966: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_196b: stloc.2
-			IL_196c: ldloc.1
-			IL_196d: ldloc.2
-			IL_196e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1973: stloc.2
-			IL_1974: ldstr "mvpBlockers[1]: "
-			IL_1979: ldloc.2
-			IL_197a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_197f: stloc.3
-			IL_1980: ldloc.0
-			IL_1981: ldloc.3
-			IL_1982: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1987: pop
-			IL_1988: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_198d: stloc.0
-			IL_198e: ldarg.0
-			IL_198f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_1994: ldc.i4.1
-			IL_1995: newarr [System.Runtime]System.Object
-			IL_199a: dup
-			IL_199b: ldc.i4.0
-			IL_199c: ldarg.0
-			IL_199d: stelem.ref
-			IL_199e: stloc.1
-			IL_199f: volatile.
-			IL_19a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
-			IL_19a6: brfalse IL_19bb
-
-			IL_19ab: ldarg.3
-			IL_19ac: ldstr "mvpBlockers"
-			IL_19b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_19b6: br IL_19d0
-
-			IL_19bb: ldarg.3
-			IL_19bc: ldstr "mvpBlockers"
-			IL_19c1: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:627"
-			IL_19c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_136
-			IL_19cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_19d0: stloc.2
-			IL_19d1: ldloc.2
-			IL_19d2: ldc.r8 2
-			IL_19db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_19e0: stloc.2
-			IL_19e1: ldloc.1
-			IL_19e2: ldloc.2
-			IL_19e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_19e8: stloc.2
-			IL_19e9: ldstr "mvpBlockers[2]: "
-			IL_19ee: ldloc.2
-			IL_19ef: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_19f4: stloc.3
-			IL_19f5: ldloc.0
-			IL_19f6: ldloc.3
-			IL_19f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_19fc: pop
-			IL_19fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1a02: stloc.0
-			IL_1a03: ldarg.0
-			IL_1a04: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_1a09: ldc.i4.1
-			IL_1a0a: newarr [System.Runtime]System.Object
-			IL_1a0f: dup
-			IL_1a10: ldc.i4.0
-			IL_1a11: ldarg.0
-			IL_1a12: stelem.ref
-			IL_1a13: stloc.1
-			IL_1a14: volatile.
-			IL_1a16: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
-			IL_1a1b: brfalse IL_1a30
-
-			IL_1a20: ldarg.3
-			IL_1a21: ldstr "mvpBlockers"
-			IL_1a26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1a2b: br IL_1a45
-
-			IL_1a30: ldarg.3
-			IL_1a31: ldstr "mvpBlockers"
-			IL_1a36: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:640"
-			IL_1a3b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_137
-			IL_1a40: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1a45: stloc.2
-			IL_1a46: ldloc.2
-			IL_1a47: ldc.r8 3
-			IL_1a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1a55: stloc.2
-			IL_1a56: ldloc.1
-			IL_1a57: ldloc.2
-			IL_1a58: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1a5d: stloc.2
-			IL_1a5e: ldstr "mvpBlockers[3]: "
-			IL_1a63: ldloc.2
-			IL_1a64: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1a69: stloc.3
-			IL_1a6a: ldloc.0
-			IL_1a6b: ldloc.3
-			IL_1a6c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1a71: pop
-			IL_1a72: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1a77: stloc.0
-			IL_1a78: ldarg.0
-			IL_1a79: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
-			IL_1a7e: ldc.i4.1
-			IL_1a7f: newarr [System.Runtime]System.Object
-			IL_1a84: dup
-			IL_1a85: ldc.i4.0
-			IL_1a86: ldarg.0
-			IL_1a87: stelem.ref
-			IL_1a88: stloc.1
-			IL_1a89: volatile.
-			IL_1a8b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
-			IL_1a90: brfalse IL_1aa5
-
-			IL_1a95: ldarg.3
-			IL_1a96: ldstr "unsupported"
-			IL_1a9b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1aa0: br IL_1aba
-
-			IL_1aa5: ldarg.3
-			IL_1aa6: ldstr "unsupported"
-			IL_1aab: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:653"
-			IL_1ab0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_138
-			IL_1ab5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1aba: stloc.2
-			IL_1abb: volatile.
-			IL_1abd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
-			IL_1ac2: brfalse IL_1ad7
-
-			IL_1ac7: ldloc.2
-			IL_1ac8: ldstr "length"
-			IL_1acd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1ad2: br IL_1aec
-
-			IL_1ad7: ldloc.2
-			IL_1ad8: ldstr "length"
-			IL_1add: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:655"
-			IL_1ae2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_139
-			IL_1ae7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1aec: stloc.2
-			IL_1aed: ldloc.1
-			IL_1aee: ldloc.2
-			IL_1aef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1af4: stloc.2
-			IL_1af5: ldstr "unsupported.length: "
-			IL_1afa: ldloc.2
-			IL_1afb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1b00: stloc.3
-			IL_1b01: ldloc.0
-			IL_1b02: ldloc.3
-			IL_1b03: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1b08: pop
-			IL_1b09: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1b0e: stloc.0
-			IL_1b0f: ldarg.0
-			IL_1b10: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_1b15: ldc.i4.1
-			IL_1b16: newarr [System.Runtime]System.Object
-			IL_1b1b: dup
-			IL_1b1c: ldc.i4.0
-			IL_1b1d: ldarg.0
-			IL_1b1e: stelem.ref
-			IL_1b1f: stloc.1
-			IL_1b20: volatile.
-			IL_1b22: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
-			IL_1b27: brfalse IL_1b3c
-
-			IL_1b2c: ldarg.3
-			IL_1b2d: ldstr "unsupported"
-			IL_1b32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1b37: br IL_1b51
-
-			IL_1b3c: ldarg.3
-			IL_1b3d: ldstr "unsupported"
-			IL_1b42: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:666"
-			IL_1b47: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_140
-			IL_1b4c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1b51: stloc.2
-			IL_1b52: ldloc.2
-			IL_1b53: ldc.r8 0.0
-			IL_1b5c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1b61: stloc.2
-			IL_1b62: ldloc.1
-			IL_1b63: ldloc.2
-			IL_1b64: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1b69: stloc.2
-			IL_1b6a: ldstr "unsupported[0]: "
-			IL_1b6f: ldloc.2
-			IL_1b70: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1b75: stloc.3
-			IL_1b76: ldloc.0
-			IL_1b77: ldloc.3
-			IL_1b78: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1b7d: pop
-			IL_1b7e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1b83: stloc.0
-			IL_1b84: ldarg.0
-			IL_1b85: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
-			IL_1b8a: ldc.i4.1
-			IL_1b8b: newarr [System.Runtime]System.Object
-			IL_1b90: dup
-			IL_1b91: ldc.i4.0
-			IL_1b92: ldarg.0
-			IL_1b93: stelem.ref
-			IL_1b94: stloc.1
-			IL_1b95: volatile.
-			IL_1b97: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
-			IL_1b9c: brfalse IL_1bb1
-
-			IL_1ba1: ldarg.3
-			IL_1ba2: ldstr "unsupported"
-			IL_1ba7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1bac: br IL_1bc6
-
-			IL_1bb1: ldarg.3
-			IL_1bb2: ldstr "unsupported"
-			IL_1bb7: ldstr "Compile_Scripts_Test262MetadataParser:<TwoPhaseDummy_M26>:__js_call__:679"
-			IL_1bbc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_141
-			IL_1bc1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1bc6: stloc.2
-			IL_1bc7: ldloc.2
-			IL_1bc8: ldc.r8 1
-			IL_1bd1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1bd6: stloc.2
-			IL_1bd7: ldloc.1
-			IL_1bd8: ldloc.2
-			IL_1bd9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_1bde: stloc.2
-			IL_1bdf: ldstr "unsupported[1]: "
-			IL_1be4: ldloc.2
-			IL_1be5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1bea: stloc.3
-			IL_1beb: ldloc.0
-			IL_1bec: ldloc.3
-			IL_1bed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_1bf2: pop
-			IL_1bf3: ldnull
-			IL_1bf4: ret
+			IL_1979: stloc.1
+			IL_197a: ldloc.1
+			IL_197b: ldc.r8 1
+			IL_1984: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1989: stloc.1
+			IL_198a: ldarg.0
+			IL_198b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_1990: ldnull
+			IL_1991: ldloc.1
+			IL_1992: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_1997: stloc.1
+			IL_1998: ldstr "unsupported[1]: "
+			IL_199d: ldloc.1
+			IL_199e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_19a3: stloc.2
+			IL_19a4: ldloc.0
+			IL_19a5: ldloc.2
+			IL_19a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_19ab: pop
+			IL_19ac: ldnull
+			IL_19ad: ret
 		} // end of method writeParsedResult::__js_call__
 
 	} // end of class writeParsedResult
@@ -4242,7 +3833,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 774 (0x306)
+		// Code size: 759 (0x2f7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262MetadataParser/Scope,
@@ -4476,71 +4067,66 @@
 		IL_023a: ldloc.s 14
 		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 		IL_0241: stloc.s 7
-		IL_0243: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0248: stloc.s 8
-		IL_024a: ldloc.1
-		IL_024b: ldloc.s 8
-		IL_024d: ldstr "basic-strict"
-		IL_0252: ldloc.3
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0258: pop
-		IL_0259: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_025e: stloc.s 15
-		IL_0260: ldloc.s 15
-		IL_0262: ldstr "---"
-		IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026c: pop
-		IL_026d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0272: stloc.s 8
-		IL_0274: ldloc.1
-		IL_0275: ldloc.s 8
-		IL_0277: ldstr "negative-parse"
-		IL_027c: ldloc.s 4
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0283: pop
-		IL_0284: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0289: stloc.s 15
-		IL_028b: ldloc.s 15
-		IL_028d: ldstr "---"
-		IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0297: pop
-		IL_0298: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_029d: stloc.s 8
-		IL_029f: ldloc.1
-		IL_02a0: ldloc.s 8
-		IL_02a2: ldstr "async-generated"
-		IL_02a7: ldloc.s 5
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02ae: pop
-		IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b4: stloc.s 15
-		IL_02b6: ldloc.s 15
-		IL_02b8: ldstr "---"
-		IL_02bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c2: pop
-		IL_02c3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02c8: stloc.s 8
-		IL_02ca: ldloc.1
-		IL_02cb: ldloc.s 8
-		IL_02cd: ldstr "module-resolution"
-		IL_02d2: ldloc.s 6
-		IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02d9: pop
-		IL_02da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02df: stloc.s 15
-		IL_02e1: ldloc.s 15
-		IL_02e3: ldstr "---"
-		IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ed: pop
-		IL_02ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02f3: stloc.s 8
-		IL_02f5: ldloc.1
-		IL_02f6: ldloc.s 8
-		IL_02f8: ldstr "fixture-unsupported"
-		IL_02fd: ldloc.s 7
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0304: pop
-		IL_0305: ret
+		IL_0243: ldloc.0
+		IL_0244: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_0249: ldnull
+		IL_024a: ldstr "basic-strict"
+		IL_024f: ldloc.3
+		IL_0250: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
+		IL_0255: pop
+		IL_0256: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025b: stloc.s 15
+		IL_025d: ldloc.s 15
+		IL_025f: ldstr "---"
+		IL_0264: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0269: pop
+		IL_026a: ldloc.0
+		IL_026b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_0270: ldnull
+		IL_0271: ldstr "negative-parse"
+		IL_0276: ldloc.s 4
+		IL_0278: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
+		IL_027d: pop
+		IL_027e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0283: stloc.s 15
+		IL_0285: ldloc.s 15
+		IL_0287: ldstr "---"
+		IL_028c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0291: pop
+		IL_0292: ldloc.0
+		IL_0293: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_0298: ldnull
+		IL_0299: ldstr "async-generated"
+		IL_029e: ldloc.s 5
+		IL_02a0: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
+		IL_02a5: pop
+		IL_02a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ab: stloc.s 15
+		IL_02ad: ldloc.s 15
+		IL_02af: ldstr "---"
+		IL_02b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02b9: pop
+		IL_02ba: ldloc.0
+		IL_02bb: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_02c0: ldnull
+		IL_02c1: ldstr "module-resolution"
+		IL_02c6: ldloc.s 6
+		IL_02c8: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
+		IL_02cd: pop
+		IL_02ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d3: stloc.s 15
+		IL_02d5: ldloc.s 15
+		IL_02d7: ldstr "---"
+		IL_02dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e1: pop
+		IL_02e2: ldloc.0
+		IL_02e3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_02e8: ldnull
+		IL_02e9: ldstr "fixture-unsupported"
+		IL_02ee: ldloc.s 7
+		IL_02f0: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
+		IL_02f5: pop
+		IL_02f6: ret
 	} // end of method Compile_Scripts_Test262MetadataParser::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262MetadataParser
@@ -5632,7 +5218,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 621 (0x26d)
+			// Code size: 612 (0x264)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5801,7 +5387,7 @@
 				IL_01bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
 				IL_01c2: stloc.s 9
 				IL_01c4: ldloc.s 9
-				IL_01c6: brfalse IL_026b
+				IL_01c6: brfalse IL_0262
 
 				IL_01cb: ldloc.1
 				IL_01cc: ldloc.3
@@ -5842,33 +5428,28 @@
 				IL_022a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 				IL_022f: stloc.s 9
 				IL_0231: ldloc.s 9
-				IL_0233: brfalse IL_025a
+				IL_0233: brfalse IL_0251
 
 				IL_0238: ldarg.0
-				IL_0239: ldfld object Modules.test262_metadataParser/Scope::unquote
-				IL_023e: ldc.i4.1
-				IL_023f: newarr [System.Runtime]System.Object
-				IL_0244: dup
-				IL_0245: ldc.i4.0
-				IL_0246: ldarg.0
-				IL_0247: stelem.ref
-				IL_0248: ldloc.s 4
-				IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_024f: stloc.s 5
-				IL_0251: ldloc.2
-				IL_0252: ldloc.s 5
-				IL_0254: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0259: pop
+				IL_0239: castclass Modules.test262_metadataParser/Scope
+				IL_023e: ldnull
+				IL_023f: ldloc.s 4
+				IL_0241: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0246: stloc.s 5
+				IL_0248: ldloc.2
+				IL_0249: ldloc.s 5
+				IL_024b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0250: pop
 
-				IL_025a: ldloc.3
-				IL_025b: ldc.r8 1
-				IL_0264: add
-				IL_0265: stloc.3
-				IL_0266: br IL_017a
+				IL_0251: ldloc.3
+				IL_0252: ldc.r8 1
+				IL_025b: add
+				IL_025c: stloc.3
+				IL_025d: br IL_017a
 			// end loop
 
-			IL_026b: ldloc.2
-			IL_026c: ret
+			IL_0262: ldloc.2
+			IL_0263: ret
 		} // end of method parseInlineList::__js_call__
 
 	} // end of class parseInlineList
@@ -6860,7 +6441,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 773 (0x305)
+			// Code size: 764 (0x2fc)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -6923,7 +6504,7 @@
 				IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
 				IL_008a: stloc.s 7
 				IL_008c: ldloc.s 7
-				IL_008e: brfalse IL_02b3
+				IL_008e: brfalse IL_02aa
 
 				IL_0093: volatile.
 				IL_0095: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_152
@@ -7019,149 +6600,144 @@
 				IL_0198: br IL_001b
 
 				IL_019d: ldarg.0
-				IL_019e: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_01a3: ldc.i4.1
-				IL_01a4: newarr [System.Runtime]System.Object
-				IL_01a9: dup
-				IL_01aa: ldc.i4.0
-				IL_01ab: ldarg.0
-				IL_01ac: stelem.ref
-				IL_01ad: ldloc.2
-				IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_01b3: stloc.s 6
-				IL_01b5: ldloc.s 6
-				IL_01b7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01bc: stloc.3
-				IL_01bd: ldloc.3
-				IL_01be: ldarg.s parentIndent
-				IL_01c0: cgt
-				IL_01c2: ldc.i4.0
-				IL_01c3: ceq
-				IL_01c5: brfalse IL_01cf
+				IL_019e: castclass Modules.test262_metadataParser/Scope
+				IL_01a3: ldnull
+				IL_01a4: ldloc.2
+				IL_01a5: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_01aa: stloc.s 6
+				IL_01ac: ldloc.s 6
+				IL_01ae: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_01b3: stloc.3
+				IL_01b4: ldloc.3
+				IL_01b5: ldarg.s parentIndent
+				IL_01b7: cgt
+				IL_01b9: ldc.i4.0
+				IL_01ba: ceq
+				IL_01bc: brfalse IL_01c6
 
-				IL_01ca: br IL_02b3
+				IL_01c1: br IL_02aa
 
-				IL_01cf: ldloc.1
-				IL_01d0: stloc.s 8
-				IL_01d2: ldloc.s 8
-				IL_01d4: ldc.r8 0.0
-				IL_01dd: box [System.Runtime]System.Double
-				IL_01e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-				IL_01e7: stloc.s 7
-				IL_01e9: ldloc.s 7
-				IL_01eb: brfalse IL_01fb
+				IL_01c6: ldloc.1
+				IL_01c7: stloc.s 8
+				IL_01c9: ldloc.s 8
+				IL_01cb: ldc.r8 0.0
+				IL_01d4: box [System.Runtime]System.Double
+				IL_01d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+				IL_01de: stloc.s 7
+				IL_01e0: ldloc.s 7
+				IL_01e2: brfalse IL_01f2
 
-				IL_01f0: ldloc.3
-				IL_01f1: box [System.Runtime]System.Double
-				IL_01f6: stloc.s 8
-				IL_01f8: ldloc.s 8
-				IL_01fa: stloc.1
+				IL_01e7: ldloc.3
+				IL_01e8: box [System.Runtime]System.Double
+				IL_01ed: stloc.s 8
+				IL_01ef: ldloc.s 8
+				IL_01f1: stloc.1
 
-				IL_01fb: ldloc.2
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0201: stloc.s 6
-				IL_0203: ldc.i4.0
-				IL_0204: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0209: brfalse IL_023c
+				IL_01f2: ldloc.2
+				IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01f8: stloc.s 6
+				IL_01fa: ldc.i4.0
+				IL_01fb: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0200: brfalse IL_0233
 
-				IL_020e: ldloc.s 6
-				IL_0210: isinst [System.Runtime]System.String
-				IL_0215: dup
-				IL_0216: brtrue IL_022e
+				IL_0205: ldloc.s 6
+				IL_0207: isinst [System.Runtime]System.String
+				IL_020c: dup
+				IL_020d: brtrue IL_0225
 
-				IL_021b: pop
-				IL_021c: ldloc.s 6
-				IL_021e: ldstr "substring"
-				IL_0223: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_0228: dup
-				IL_0229: brfalse IL_023b
+				IL_0212: pop
+				IL_0213: ldloc.s 6
+				IL_0215: ldstr "substring"
+				IL_021a: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_021f: dup
+				IL_0220: brfalse IL_0232
 
-				IL_022e: ldloc.1
-				IL_022f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-				IL_0234: stloc.s 6
-				IL_0236: br IL_024b
+				IL_0225: ldloc.1
+				IL_0226: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_022b: stloc.s 6
+				IL_022d: br IL_0242
 
-				IL_023b: pop
+				IL_0232: pop
 
-				IL_023c: ldloc.s 6
-				IL_023e: ldstr "substring"
-				IL_0243: ldloc.1
-				IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0249: stloc.s 6
+				IL_0233: ldloc.s 6
+				IL_0235: ldstr "substring"
+				IL_023a: ldloc.1
+				IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0240: stloc.s 6
 
-				IL_024b: ldloc.0
-				IL_024c: ldloc.s 6
-				IL_024e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0253: pop
-				IL_0254: volatile.
-				IL_0256: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
-				IL_025b: brfalse IL_0270
+				IL_0242: ldloc.0
+				IL_0243: ldloc.s 6
+				IL_0245: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_024a: pop
+				IL_024b: volatile.
+				IL_024d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
+				IL_0252: brfalse IL_0267
 
-				IL_0260: ldarg.3
-				IL_0261: ldstr "index"
-				IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_026b: br IL_0285
+				IL_0257: ldarg.3
+				IL_0258: ldstr "index"
+				IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0262: br IL_027c
 
-				IL_0270: ldarg.3
-				IL_0271: ldstr "index"
-				IL_0276: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:76"
-				IL_027b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
-				IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0267: ldarg.3
+				IL_0268: ldstr "index"
+				IL_026d: ldstr "test262/metadataParser:<TwoPhaseDummy_M33>:__js_call__:75"
+				IL_0272: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_154
+				IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
+				IL_027c: stloc.s 6
+				IL_027e: ldloc.s 6
+				IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
 				IL_0285: stloc.s 6
 				IL_0287: ldloc.s 6
-				IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
-				IL_028e: stloc.s 6
-				IL_0290: ldloc.s 6
-				IL_0292: ldc.i4.1
-				IL_0293: box [System.Runtime]System.Boolean
-				IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
-				IL_029d: stloc.s 6
-				IL_029f: ldarg.3
-				IL_02a0: ldstr "index"
-				IL_02a5: ldloc.s 6
-				IL_02a7: ldc.i4.1
-				IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_02ad: pop
-				IL_02ae: br IL_001b
+				IL_0289: ldc.i4.1
+				IL_028a: box [System.Runtime]System.Boolean
+				IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
+				IL_0294: stloc.s 6
+				IL_0296: ldarg.3
+				IL_0297: ldstr "index"
+				IL_029c: ldloc.s 6
+				IL_029e: ldc.i4.1
+				IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_02a4: pop
+				IL_02a5: br IL_001b
 			// end loop
 
-			IL_02b3: ldarg.s style
-			IL_02b5: ldstr ">"
-			IL_02ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_02bf: stloc.s 7
-			IL_02c1: ldloc.s 7
-			IL_02c3: brfalse IL_02ec
+			IL_02aa: ldarg.s style
+			IL_02ac: ldstr ">"
+			IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_02b6: stloc.s 7
+			IL_02b8: ldloc.s 7
+			IL_02ba: brfalse IL_02e3
 
-			IL_02c8: ldc.i4.1
-			IL_02c9: newarr [System.Runtime]System.Object
-			IL_02ce: dup
-			IL_02cf: ldc.i4.0
-			IL_02d0: ldarg.0
-			IL_02d1: stelem.ref
-			IL_02d2: stloc.s 9
-			IL_02d4: ldloc.s 9
-			IL_02d6: ldc.i4.0
-			IL_02d7: ldelem.ref
-			IL_02d8: castclass Modules.test262_metadataParser/Scope
-			IL_02dd: ldnull
-			IL_02de: ldloc.0
-			IL_02df: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_02e4: tail.
-			IL_02e6: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_02eb: ret
+			IL_02bf: ldc.i4.1
+			IL_02c0: newarr [System.Runtime]System.Object
+			IL_02c5: dup
+			IL_02c6: ldc.i4.0
+			IL_02c7: ldarg.0
+			IL_02c8: stelem.ref
+			IL_02c9: stloc.s 9
+			IL_02cb: ldloc.s 9
+			IL_02cd: ldc.i4.0
+			IL_02ce: ldelem.ref
+			IL_02cf: castclass Modules.test262_metadataParser/Scope
+			IL_02d4: ldnull
+			IL_02d5: ldloc.0
+			IL_02d6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02db: tail.
+			IL_02dd: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_02e2: ret
 
-			IL_02ec: ldloc.0
-			IL_02ed: ldc.i4.1
-			IL_02ee: newarr [System.Runtime]System.Object
-			IL_02f3: dup
-			IL_02f4: ldc.i4.0
-			IL_02f5: ldstr "\n"
-			IL_02fa: stelem.ref
-			IL_02fb: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0300: stloc.s 10
-			IL_0302: ldloc.s 10
-			IL_0304: ret
+			IL_02e3: ldloc.0
+			IL_02e4: ldc.i4.1
+			IL_02e5: newarr [System.Runtime]System.Object
+			IL_02ea: dup
+			IL_02eb: ldc.i4.0
+			IL_02ec: ldstr "\n"
+			IL_02f1: stelem.ref
+			IL_02f2: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_02f7: stloc.s 10
+			IL_02f9: ldloc.s 10
+			IL_02fb: ret
 		} // end of method parseBlockScalar::__js_call__
 
 	} // end of class parseBlockScalar
@@ -7386,7 +6962,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 514 (0x202)
+			// Code size: 501 (0x1f5)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7398,8 +6974,8 @@
 				[6] object,
 				[7] object,
 				[8] object,
-				[9] object[],
-				[10] object
+				[9] object,
+				[10] object[]
 			)
 
 			IL_0000: volatile.
@@ -7551,72 +7127,65 @@
 			IL_0178: ldstr ""
 			IL_017d: ret
 
-			IL_017e: ldarg.0
-			IL_017f: ldfld object Modules.test262_metadataParser/Scope::countIndent
-			IL_0184: ldc.i4.1
-			IL_0185: newarr [System.Runtime]System.Object
-			IL_018a: dup
-			IL_018b: ldc.i4.0
-			IL_018c: ldarg.0
-			IL_018d: stelem.ref
-			IL_018e: stloc.s 9
-			IL_0190: ldarg.2
-			IL_0191: ldloc.0
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0197: stloc.2
-			IL_0198: ldloc.s 9
-			IL_019a: ldloc.2
-			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01a0: stloc.2
-			IL_01a1: ldloc.2
-			IL_01a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01a7: stloc.1
-			IL_01a8: ldloc.1
-			IL_01a9: ldarg.s parentIndent
-			IL_01ab: cgt
-			IL_01ad: ldc.i4.0
-			IL_01ae: ceq
-			IL_01b0: brfalse IL_01c9
+			IL_017e: ldarg.2
+			IL_017f: ldloc.0
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0185: stloc.2
+			IL_0186: ldarg.0
+			IL_0187: castclass Modules.test262_metadataParser/Scope
+			IL_018c: ldnull
+			IL_018d: ldloc.2
+			IL_018e: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_0193: stloc.2
+			IL_0194: ldloc.2
+			IL_0195: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_019a: stloc.1
+			IL_019b: ldloc.1
+			IL_019c: ldarg.s parentIndent
+			IL_019e: cgt
+			IL_01a0: ldc.i4.0
+			IL_01a1: ceq
+			IL_01a3: brfalse IL_01bc
 
-			IL_01b5: ldarg.3
-			IL_01b6: ldstr "index"
-			IL_01bb: ldloc.0
-			IL_01bc: ldc.i4.1
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_01c2: pop
-			IL_01c3: ldstr ""
-			IL_01c8: ret
+			IL_01a8: ldarg.3
+			IL_01a9: ldstr "index"
+			IL_01ae: ldloc.0
+			IL_01af: ldc.i4.1
+			IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_01b5: pop
+			IL_01b6: ldstr ""
+			IL_01bb: ret
 
-			IL_01c9: ldarg.3
-			IL_01ca: ldstr "index"
-			IL_01cf: ldloc.0
-			IL_01d0: ldc.i4.1
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_01d6: pop
-			IL_01d7: ldloc.1
-			IL_01d8: box [System.Runtime]System.Double
-			IL_01dd: stloc.s 10
-			IL_01df: ldc.i4.1
-			IL_01e0: newarr [System.Runtime]System.Object
-			IL_01e5: dup
-			IL_01e6: ldc.i4.0
-			IL_01e7: ldarg.0
-			IL_01e8: stelem.ref
-			IL_01e9: stloc.s 9
-			IL_01eb: ldloc.s 9
-			IL_01ed: ldc.i4.0
-			IL_01ee: ldelem.ref
-			IL_01ef: castclass Modules.test262_metadataParser/Scope
-			IL_01f4: ldnull
-			IL_01f5: ldarg.2
-			IL_01f6: ldarg.3
-			IL_01f7: ldloc.1
-			IL_01f8: tail.
-			IL_01fa: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
-			IL_01ff: ret
+			IL_01bc: ldarg.3
+			IL_01bd: ldstr "index"
+			IL_01c2: ldloc.0
+			IL_01c3: ldc.i4.1
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_01c9: pop
+			IL_01ca: ldloc.1
+			IL_01cb: box [System.Runtime]System.Double
+			IL_01d0: stloc.s 9
+			IL_01d2: ldc.i4.1
+			IL_01d3: newarr [System.Runtime]System.Object
+			IL_01d8: dup
+			IL_01d9: ldc.i4.0
+			IL_01da: ldarg.0
+			IL_01db: stelem.ref
+			IL_01dc: stloc.s 10
+			IL_01de: ldloc.s 10
+			IL_01e0: ldc.i4.0
+			IL_01e1: ldelem.ref
+			IL_01e2: castclass Modules.test262_metadataParser/Scope
+			IL_01e7: ldnull
+			IL_01e8: ldarg.2
+			IL_01e9: ldarg.3
+			IL_01ea: ldloc.1
+			IL_01eb: tail.
+			IL_01ed: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+			IL_01f2: ret
 
-			IL_0200: ldnull
-			IL_0201: ret
+			IL_01f3: ldnull
+			IL_01f4: ret
 		} // end of method parseIndentedValue::__js_call__
 
 	} // end of class parseIndentedValue
@@ -7938,7 +7507,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1361 (0x551)
+			// Code size: 1307 (0x51b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -7960,8 +7529,7 @@
 				[16] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[17] object,
 				[18] object,
-				[19] object,
-				[20] object[]
+				[19] object
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -8004,7 +7572,7 @@
 				IL_0070: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
 				IL_0075: stloc.s 12
 				IL_0077: ldloc.s 12
-				IL_0079: brfalse IL_054f
+				IL_0079: brfalse IL_0519
 
 				IL_007e: volatile.
 				IL_0080: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_160
@@ -8096,365 +7664,339 @@
 				IL_0177: br IL_0006
 
 				IL_017c: ldarg.0
-				IL_017d: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_0182: ldc.i4.1
-				IL_0183: newarr [System.Runtime]System.Object
-				IL_0188: dup
-				IL_0189: ldc.i4.0
-				IL_018a: ldarg.0
-				IL_018b: stelem.ref
-				IL_018c: ldloc.1
-				IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0192: stloc.s 11
-				IL_0194: ldloc.s 11
-				IL_0196: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_019b: stloc.2
-				IL_019c: ldloc.2
-				IL_019d: ldarg.s baseIndent
-				IL_019f: clt
-				IL_01a1: brfalse IL_01ab
+				IL_017d: castclass Modules.test262_metadataParser/Scope
+				IL_0182: ldnull
+				IL_0183: ldloc.1
+				IL_0184: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0189: stloc.s 11
+				IL_018b: ldloc.s 11
+				IL_018d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0192: stloc.2
+				IL_0193: ldloc.2
+				IL_0194: ldarg.s baseIndent
+				IL_0196: clt
+				IL_0198: brfalse IL_01a2
 
-				IL_01a6: br IL_054f
+				IL_019d: br IL_0519
 
-				IL_01ab: ldloc.2
-				IL_01ac: ldarg.s baseIndent
-				IL_01ae: cgt
-				IL_01b0: brfalse IL_0238
+				IL_01a2: ldloc.2
+				IL_01a3: ldarg.s baseIndent
+				IL_01a5: cgt
+				IL_01a7: brfalse IL_022f
 
-				IL_01b5: volatile.
-				IL_01b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
-				IL_01bc: brfalse IL_01d1
+				IL_01ac: volatile.
+				IL_01ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
+				IL_01b3: brfalse IL_01c8
 
-				IL_01c1: ldarg.3
-				IL_01c2: ldstr "index"
-				IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01cc: br IL_01e6
+				IL_01b8: ldarg.3
+				IL_01b9: ldstr "index"
+				IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01c3: br IL_01dd
 
-				IL_01d1: ldarg.3
-				IL_01d2: ldstr "index"
-				IL_01d7: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:58"
-				IL_01dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
-				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_01c8: ldarg.3
+				IL_01c9: ldstr "index"
+				IL_01ce: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:57"
+				IL_01d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_162
+				IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_01e6: stloc.s 11
-				IL_01e8: ldloc.s 11
-				IL_01ea: ldc.r8 1
-				IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_01f8: stloc.s 13
-				IL_01fa: ldloc.s 13
-				IL_01fc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0201: stloc.s 14
-				IL_0203: ldstr "Unexpected indentation at frontmatter line "
-				IL_0208: ldloc.s 14
-				IL_020a: call string [System.Runtime]System.String::Concat(string, string)
-				IL_020f: ldstr "."
-				IL_0214: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0219: stloc.s 14
-				IL_021b: ldloc.s 14
-				IL_021d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0222: stloc.3
-				IL_0223: ldloc.3
-				IL_0224: isinst [System.Runtime]System.Exception
-				IL_0229: dup
-				IL_022a: brtrue IL_0237
+				IL_01dd: stloc.s 11
+				IL_01df: ldloc.s 11
+				IL_01e1: ldc.r8 1
+				IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01ef: stloc.s 13
+				IL_01f1: ldloc.s 13
+				IL_01f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01f8: stloc.s 14
+				IL_01fa: ldstr "Unexpected indentation at frontmatter line "
+				IL_01ff: ldloc.s 14
+				IL_0201: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0206: ldstr "."
+				IL_020b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0210: stloc.s 14
+				IL_0212: ldloc.s 14
+				IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0219: stloc.3
+				IL_021a: ldloc.3
+				IL_021b: isinst [System.Runtime]System.Exception
+				IL_0220: dup
+				IL_0221: brtrue IL_022e
 
-				IL_022f: pop
-				IL_0230: ldloc.3
-				IL_0231: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0236: throw
+				IL_0226: pop
+				IL_0227: ldloc.3
+				IL_0228: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_022d: throw
 
-				IL_0237: throw
+				IL_022e: throw
 
-				IL_0238: ldloc.1
-				IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_023e: stloc.s 11
-				IL_0240: ldloc.2
-				IL_0241: box [System.Runtime]System.Double
-				IL_0246: stloc.s 15
-				IL_0248: ldc.i4.0
-				IL_0249: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_024e: brfalse IL_0282
+				IL_022f: ldloc.1
+				IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0235: stloc.s 11
+				IL_0237: ldloc.2
+				IL_0238: box [System.Runtime]System.Double
+				IL_023d: stloc.s 15
+				IL_023f: ldc.i4.0
+				IL_0240: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0245: brfalse IL_0279
 
-				IL_0253: ldloc.s 11
-				IL_0255: isinst [System.Runtime]System.String
-				IL_025a: dup
-				IL_025b: brtrue IL_0273
+				IL_024a: ldloc.s 11
+				IL_024c: isinst [System.Runtime]System.String
+				IL_0251: dup
+				IL_0252: brtrue IL_026a
 
-				IL_0260: pop
-				IL_0261: ldloc.s 11
-				IL_0263: ldstr "substring"
-				IL_0268: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_026d: dup
-				IL_026e: brfalse IL_0281
+				IL_0257: pop
+				IL_0258: ldloc.s 11
+				IL_025a: ldstr "substring"
+				IL_025f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0264: dup
+				IL_0265: brfalse IL_0278
 
-				IL_0273: ldloc.s 15
-				IL_0275: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-				IL_027a: stloc.s 4
-				IL_027c: br IL_0292
+				IL_026a: ldloc.s 15
+				IL_026c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_0271: stloc.s 4
+				IL_0273: br IL_0289
 
-				IL_0281: pop
+				IL_0278: pop
 
-				IL_0282: ldloc.s 11
-				IL_0284: ldstr "substring"
-				IL_0289: ldloc.s 15
-				IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0290: stloc.s 4
+				IL_0279: ldloc.s 11
+				IL_027b: ldstr "substring"
+				IL_0280: ldloc.s 15
+				IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0287: stloc.s 4
 
-				IL_0292: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_0297: ldstr ""
-				IL_029c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_02a1: stloc.s 16
-				IL_02a3: volatile.
-				IL_02a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
-				IL_02aa: brfalse IL_02c2
+				IL_0289: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_028e: ldstr ""
+				IL_0293: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0298: stloc.s 16
+				IL_029a: volatile.
+				IL_029c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
+				IL_02a1: brfalse IL_02b9
 
-				IL_02af: ldloc.s 16
-				IL_02b1: ldstr "exec"
-				IL_02b6: ldloc.s 4
-				IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02bd: br IL_02da
+				IL_02a6: ldloc.s 16
+				IL_02a8: ldstr "exec"
+				IL_02ad: ldloc.s 4
+				IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02b4: br IL_02d1
 
-				IL_02c2: ldloc.s 16
-				IL_02c4: ldstr "exec"
-				IL_02c9: ldloc.s 4
-				IL_02cb: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:78"
-				IL_02d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
-				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+				IL_02b9: ldloc.s 16
+				IL_02bb: ldstr "exec"
+				IL_02c0: ldloc.s 4
+				IL_02c2: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:77"
+				IL_02c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_163
+				IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_02da: stloc.s 5
-				IL_02dc: ldloc.s 5
-				IL_02de: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_02e3: ldc.i4.0
-				IL_02e4: ceq
-				IL_02e6: stloc.s 12
-				IL_02e8: ldloc.s 12
-				IL_02ea: brfalse IL_0385
+				IL_02d1: stloc.s 5
+				IL_02d3: ldloc.s 5
+				IL_02d5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02da: ldc.i4.0
+				IL_02db: ceq
+				IL_02dd: stloc.s 12
+				IL_02df: ldloc.s 12
+				IL_02e1: brfalse IL_037c
 
-				IL_02ef: volatile.
-				IL_02f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
-				IL_02f6: brfalse IL_030b
+				IL_02e6: volatile.
+				IL_02e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
+				IL_02ed: brfalse IL_0302
 
-				IL_02fb: ldarg.3
-				IL_02fc: ldstr "index"
-				IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0306: br IL_0320
+				IL_02f2: ldarg.3
+				IL_02f3: ldstr "index"
+				IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02fd: br IL_0317
 
-				IL_030b: ldarg.3
-				IL_030c: ldstr "index"
-				IL_0311: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:87"
-				IL_0316: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
-				IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0302: ldarg.3
+				IL_0303: ldstr "index"
+				IL_0308: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:86"
+				IL_030d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_164
+				IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0320: stloc.s 11
-				IL_0322: ldloc.s 11
-				IL_0324: ldc.r8 1
-				IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0332: stloc.s 13
-				IL_0334: ldloc.s 13
-				IL_0336: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_033b: stloc.s 14
-				IL_033d: ldstr "Invalid frontmatter line "
-				IL_0342: ldloc.s 14
-				IL_0344: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0349: ldstr ": "
-				IL_034e: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0353: ldloc.s 4
-				IL_0355: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0317: stloc.s 11
+				IL_0319: ldloc.s 11
+				IL_031b: ldc.r8 1
+				IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0329: stloc.s 13
+				IL_032b: ldloc.s 13
+				IL_032d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0332: stloc.s 14
+				IL_0334: ldstr "Invalid frontmatter line "
+				IL_0339: ldloc.s 14
+				IL_033b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0340: ldstr ": "
+				IL_0345: call string [System.Runtime]System.String::Concat(string, string)
+				IL_034a: ldloc.s 4
+				IL_034c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0351: stloc.s 14
+				IL_0353: ldloc.s 14
+				IL_0355: call string [System.Runtime]System.String::Concat(string, string)
 				IL_035a: stloc.s 14
 				IL_035c: ldloc.s 14
-				IL_035e: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0363: stloc.s 14
-				IL_0365: ldloc.s 14
-				IL_0367: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_036c: stloc.s 6
-				IL_036e: ldloc.s 6
-				IL_0370: isinst [System.Runtime]System.Exception
-				IL_0375: dup
-				IL_0376: brtrue IL_0384
+				IL_035e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0363: stloc.s 6
+				IL_0365: ldloc.s 6
+				IL_0367: isinst [System.Runtime]System.Exception
+				IL_036c: dup
+				IL_036d: brtrue IL_037b
 
-				IL_037b: pop
-				IL_037c: ldloc.s 6
-				IL_037e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0383: throw
+				IL_0372: pop
+				IL_0373: ldloc.s 6
+				IL_0375: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_037a: throw
 
-				IL_0384: throw
+				IL_037b: throw
 
-				IL_0385: ldloc.s 5
-				IL_0387: ldc.r8 1
-				IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0395: stloc.s 7
-				IL_0397: ldloc.s 5
-				IL_0399: ldc.r8 2
-				IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_037c: ldloc.s 5
+				IL_037e: ldc.r8 1
+				IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_038c: stloc.s 7
+				IL_038e: ldloc.s 5
+				IL_0390: ldc.r8 2
+				IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_039e: stloc.s 11
+				IL_03a0: ldloc.s 11
+				IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_03a7: stloc.s 11
-				IL_03a9: ldloc.s 11
-				IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03b0: stloc.s 11
-				IL_03b2: ldc.i4.0
-				IL_03b3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_03b8: brfalse IL_03ea
+				IL_03a9: ldc.i4.0
+				IL_03aa: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_03af: brfalse IL_03e1
 
-				IL_03bd: ldloc.s 11
-				IL_03bf: isinst [System.Runtime]System.String
-				IL_03c4: dup
-				IL_03c5: brtrue IL_03dd
+				IL_03b4: ldloc.s 11
+				IL_03b6: isinst [System.Runtime]System.String
+				IL_03bb: dup
+				IL_03bc: brtrue IL_03d4
 
-				IL_03ca: pop
-				IL_03cb: ldloc.s 11
-				IL_03cd: ldstr "trim"
-				IL_03d2: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_03d7: dup
-				IL_03d8: brfalse IL_03e9
+				IL_03c1: pop
+				IL_03c2: ldloc.s 11
+				IL_03c4: ldstr "trim"
+				IL_03c9: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_03ce: dup
+				IL_03cf: brfalse IL_03e0
 
-				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_03e2: stloc.s 8
-				IL_03e4: br IL_03f8
+				IL_03d4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_03d9: stloc.s 8
+				IL_03db: br IL_03ef
 
-				IL_03e9: pop
+				IL_03e0: pop
 
-				IL_03ea: ldloc.s 11
-				IL_03ec: ldstr "trim"
-				IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_03f6: stloc.s 8
+				IL_03e1: ldloc.s 11
+				IL_03e3: ldstr "trim"
+				IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_03ed: stloc.s 8
 
-				IL_03f8: volatile.
-				IL_03fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
-				IL_03ff: brfalse IL_0414
+				IL_03ef: volatile.
+				IL_03f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
+				IL_03f6: brfalse IL_040b
 
-				IL_0404: ldarg.3
-				IL_0405: ldstr "index"
-				IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_040f: br IL_0429
+				IL_03fb: ldarg.3
+				IL_03fc: ldstr "index"
+				IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0406: br IL_0420
 
-				IL_0414: ldarg.3
-				IL_0415: ldstr "index"
-				IL_041a: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:113"
-				IL_041f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
-				IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_040b: ldarg.3
+				IL_040c: ldstr "index"
+				IL_0411: ldstr "test262/metadataParser:<TwoPhaseDummy_M35>:__js_call__:112"
+				IL_0416: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_165
+				IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
+				IL_0420: stloc.s 11
+				IL_0422: ldloc.s 11
+				IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
 				IL_0429: stloc.s 11
 				IL_042b: ldloc.s 11
-				IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
-				IL_0432: stloc.s 11
-				IL_0434: ldloc.s 11
-				IL_0436: ldc.i4.1
-				IL_0437: box [System.Runtime]System.Boolean
-				IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
-				IL_0441: stloc.s 11
-				IL_0443: ldarg.3
-				IL_0444: ldstr "index"
-				IL_0449: ldloc.s 11
-				IL_044b: ldc.i4.1
-				IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0451: pop
-				IL_0452: ldnull
-				IL_0453: stloc.s 9
-				IL_0455: ldloc.s 8
-				IL_0457: ldstr "|"
-				IL_045c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0461: stloc.s 12
-				IL_0463: ldloc.s 12
-				IL_0465: box [System.Runtime]System.Boolean
-				IL_046a: stloc.s 17
-				IL_046c: ldloc.s 17
-				IL_046e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0473: stloc.s 12
-				IL_0475: ldloc.s 12
-				IL_0477: brtrue IL_049c
+				IL_042d: ldc.i4.1
+				IL_042e: box [System.Runtime]System.Boolean
+				IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
+				IL_0438: stloc.s 11
+				IL_043a: ldarg.3
+				IL_043b: ldstr "index"
+				IL_0440: ldloc.s 11
+				IL_0442: ldc.i4.1
+				IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0448: pop
+				IL_0449: ldnull
+				IL_044a: stloc.s 9
+				IL_044c: ldloc.s 8
+				IL_044e: ldstr "|"
+				IL_0453: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0458: stloc.s 12
+				IL_045a: ldloc.s 12
+				IL_045c: box [System.Runtime]System.Boolean
+				IL_0461: stloc.s 17
+				IL_0463: ldloc.s 17
+				IL_0465: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_046a: stloc.s 12
+				IL_046c: ldloc.s 12
+				IL_046e: brtrue IL_0493
 
-				IL_047c: ldloc.s 8
-				IL_047e: ldstr ">"
-				IL_0483: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0488: stloc.s 12
-				IL_048a: ldloc.s 12
-				IL_048c: box [System.Runtime]System.Boolean
-				IL_0491: stloc.s 18
-				IL_0493: ldloc.s 18
+				IL_0473: ldloc.s 8
+				IL_0475: ldstr ">"
+				IL_047a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_047f: stloc.s 12
+				IL_0481: ldloc.s 12
+				IL_0483: box [System.Runtime]System.Boolean
+				IL_0488: stloc.s 18
+				IL_048a: ldloc.s 18
+				IL_048c: stloc.s 19
+				IL_048e: br IL_0497
+
+				IL_0493: ldloc.s 17
 				IL_0495: stloc.s 19
-				IL_0497: br IL_04a0
 
-				IL_049c: ldloc.s 17
-				IL_049e: stloc.s 19
+				IL_0497: ldloc.s 19
+				IL_0499: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_049e: stloc.s 12
+				IL_04a0: ldloc.s 12
+				IL_04a2: brfalse IL_04c4
 
-				IL_04a0: ldloc.s 19
-				IL_04a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_04a7: stloc.s 12
-				IL_04a9: ldloc.s 12
-				IL_04ab: brfalse IL_04df
+				IL_04a7: ldarg.0
+				IL_04a8: castclass Modules.test262_metadataParser/Scope
+				IL_04ad: ldnull
+				IL_04ae: ldarg.2
+				IL_04af: ldarg.3
+				IL_04b0: ldarg.s baseIndent
+				IL_04b2: ldloc.s 8
+				IL_04b4: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64, object)
+				IL_04b9: stloc.s 11
+				IL_04bb: ldloc.s 11
+				IL_04bd: stloc.s 9
+				IL_04bf: br IL_0508
 
-				IL_04b0: ldarg.0
-				IL_04b1: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_04b6: ldc.i4.1
-				IL_04b7: newarr [System.Runtime]System.Object
-				IL_04bc: dup
-				IL_04bd: ldc.i4.0
-				IL_04be: ldarg.0
-				IL_04bf: stelem.ref
-				IL_04c0: stloc.s 20
-				IL_04c2: ldloc.s 20
-				IL_04c4: ldarg.2
-				IL_04c5: ldarg.3
-				IL_04c6: ldarg.s baseIndent
-				IL_04c8: box [System.Runtime]System.Double
-				IL_04cd: ldloc.s 8
-				IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-				IL_04d4: stloc.s 11
-				IL_04d6: ldloc.s 11
-				IL_04d8: stloc.s 9
-				IL_04da: br IL_053e
+				IL_04c4: ldloc.s 8
+				IL_04c6: ldstr ""
+				IL_04cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_04d0: stloc.s 12
+				IL_04d2: ldloc.s 12
+				IL_04d4: brfalse IL_04f4
 
-				IL_04df: ldloc.s 8
-				IL_04e1: ldstr ""
-				IL_04e6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_04eb: stloc.s 12
-				IL_04ed: ldloc.s 12
-				IL_04ef: brfalse IL_0521
+				IL_04d9: ldarg.0
+				IL_04da: castclass Modules.test262_metadataParser/Scope
+				IL_04df: ldnull
+				IL_04e0: ldarg.2
+				IL_04e1: ldarg.3
+				IL_04e2: ldarg.s baseIndent
+				IL_04e4: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+				IL_04e9: stloc.s 11
+				IL_04eb: ldloc.s 11
+				IL_04ed: stloc.s 9
+				IL_04ef: br IL_0508
 
 				IL_04f4: ldarg.0
-				IL_04f5: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_04fa: ldc.i4.1
-				IL_04fb: newarr [System.Runtime]System.Object
-				IL_0500: dup
-				IL_0501: ldc.i4.0
-				IL_0502: ldarg.0
-				IL_0503: stelem.ref
-				IL_0504: stloc.s 20
-				IL_0506: ldloc.s 20
-				IL_0508: ldarg.2
-				IL_0509: ldarg.3
-				IL_050a: ldarg.s baseIndent
-				IL_050c: box [System.Runtime]System.Double
-				IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_0516: stloc.s 11
-				IL_0518: ldloc.s 11
-				IL_051a: stloc.s 9
-				IL_051c: br IL_053e
+				IL_04f5: castclass Modules.test262_metadataParser/Scope
+				IL_04fa: ldnull
+				IL_04fb: ldloc.s 8
+				IL_04fd: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0502: stloc.s 11
+				IL_0504: ldloc.s 11
+				IL_0506: stloc.s 9
 
-				IL_0521: ldarg.0
-				IL_0522: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_0527: ldc.i4.1
-				IL_0528: newarr [System.Runtime]System.Object
-				IL_052d: dup
-				IL_052e: ldc.i4.0
-				IL_052f: ldarg.0
-				IL_0530: stelem.ref
-				IL_0531: ldloc.s 8
-				IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0538: stloc.s 11
-				IL_053a: ldloc.s 11
-				IL_053c: stloc.s 9
-
-				IL_053e: ldloc.0
-				IL_053f: ldloc.s 7
-				IL_0541: ldloc.s 9
-				IL_0543: ldc.i4.1
-				IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0549: pop
-				IL_054a: br IL_0006
+				IL_0508: ldloc.0
+				IL_0509: ldloc.s 7
+				IL_050b: ldloc.s 9
+				IL_050d: ldc.i4.1
+				IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0513: pop
+				IL_0514: br IL_0006
 			// end loop
 
-			IL_054f: ldloc.0
-			IL_0550: ret
+			IL_0519: ldloc.0
+			IL_051a: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -8604,73 +8146,64 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 156 (0x9c)
+			// Code size: 139 (0x8b)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object[],
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[3] object[]
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.test262_metadataParser/Scope::normalizeLineEndings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.1
-			IL_0011: ldloc.1
-			IL_0012: ldarg.2
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0018: stloc.2
-			IL_0019: ldloc.2
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001f: volatile.
-			IL_0021: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
-			IL_0026: brfalse IL_003f
+			IL_0000: ldnull
+			IL_0001: ldarg.2
+			IL_0002: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
+			IL_0007: stloc.1
+			IL_0008: ldloc.1
+			IL_0009: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000e: volatile.
+			IL_0010: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
+			IL_0015: brfalse IL_002e
 
-			IL_002b: ldstr "split"
-			IL_0030: ldstr "\n"
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_003a: br IL_0058
+			IL_001a: ldstr "split"
+			IL_001f: ldstr "\n"
+			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0029: br IL_0047
 
-			IL_003f: ldstr "split"
-			IL_0044: ldstr "\n"
-			IL_0049: ldstr "test262/metadataParser:<TwoPhaseDummy_M36>:__js_call__:7"
-			IL_004e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_002e: ldstr "split"
+			IL_0033: ldstr "\n"
+			IL_0038: ldstr "test262/metadataParser:<TwoPhaseDummy_M36>:__js_call__:6"
+			IL_003d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_166
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0058: stloc.0
-			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_005e: dup
-			IL_005f: ldstr "index"
-			IL_0064: ldc.r8 0.0
-			IL_006d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_0072: stloc.3
-			IL_0073: ldc.i4.1
-			IL_0074: newarr [System.Runtime]System.Object
-			IL_0079: dup
-			IL_007a: ldc.i4.0
-			IL_007b: ldarg.0
-			IL_007c: stelem.ref
-			IL_007d: stloc.1
-			IL_007e: ldloc.1
-			IL_007f: ldc.i4.0
-			IL_0080: ldelem.ref
-			IL_0081: castclass Modules.test262_metadataParser/Scope
-			IL_0086: ldnull
-			IL_0087: ldloc.0
-			IL_0088: ldloc.3
-			IL_0089: ldc.r8 0.0
-			IL_0092: tail.
-			IL_0094: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
-			IL_0099: ret
+			IL_0047: stloc.0
+			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004d: dup
+			IL_004e: ldstr "index"
+			IL_0053: ldc.r8 0.0
+			IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_0061: stloc.2
+			IL_0062: ldc.i4.1
+			IL_0063: newarr [System.Runtime]System.Object
+			IL_0068: dup
+			IL_0069: ldc.i4.0
+			IL_006a: ldarg.0
+			IL_006b: stelem.ref
+			IL_006c: stloc.3
+			IL_006d: ldloc.3
+			IL_006e: ldc.i4.0
+			IL_006f: ldelem.ref
+			IL_0070: castclass Modules.test262_metadataParser/Scope
+			IL_0075: ldnull
+			IL_0076: ldloc.0
+			IL_0077: ldloc.2
+			IL_0078: ldc.r8 0.0
+			IL_0081: tail.
+			IL_0083: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+			IL_0088: ret
 
-			IL_009a: ldnull
-			IL_009b: ret
+			IL_0089: ldnull
+			IL_008a: ret
 		} // end of method parseTest262Frontmatter::__js_call__
 
 	} // end of class parseTest262Frontmatter
@@ -8879,7 +8412,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 652 (0x28c)
+			// Code size: 633 (0x279)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -8887,248 +8420,238 @@
 				[2] object,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.Error,
 				[4] object,
-				[5] object[],
-				[6] object,
-				[7] bool,
-				[8] object
+				[5] object,
+				[6] bool,
+				[7] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.test262_metadataParser/Scope::normalizeLineEndings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.s 5
-			IL_0012: ldloc.s 5
-			IL_0014: ldarg.2
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_001a: stloc.0
-			IL_001b: ldloc.0
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0021: stloc.s 6
-			IL_0023: ldc.i4.0
-			IL_0024: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0029: brfalse IL_0064
+			IL_0000: ldnull
+			IL_0001: ldarg.2
+			IL_0002: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
+			IL_0007: stloc.0
+			IL_0008: ldloc.0
+			IL_0009: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000e: stloc.s 5
+			IL_0010: ldc.i4.0
+			IL_0011: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0016: brfalse IL_0051
 
-			IL_002e: ldloc.s 6
-			IL_0030: isinst [System.Runtime]System.String
+			IL_001b: ldloc.s 5
+			IL_001d: isinst [System.Runtime]System.String
+			IL_0022: dup
+			IL_0023: brtrue IL_003b
+
+			IL_0028: pop
+			IL_0029: ldloc.s 5
+			IL_002b: ldstr "indexOf"
+			IL_0030: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
 			IL_0035: dup
-			IL_0036: brtrue IL_004e
+			IL_0036: brfalse IL_0050
 
-			IL_003b: pop
-			IL_003c: ldloc.s 6
-			IL_003e: ldstr "indexOf"
-			IL_0043: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0048: dup
-			IL_0049: brfalse IL_0063
+			IL_003b: ldstr "/*---"
+			IL_0040: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0045: box [System.Runtime]System.Double
+			IL_004a: stloc.1
+			IL_004b: br IL_0063
 
-			IL_004e: ldstr "/*---"
-			IL_0053: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0058: box [System.Runtime]System.Double
-			IL_005d: stloc.1
-			IL_005e: br IL_0076
+			IL_0050: pop
 
-			IL_0063: pop
+			IL_0051: ldloc.s 5
+			IL_0053: ldstr "indexOf"
+			IL_0058: ldstr "/*---"
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0062: stloc.1
 
-			IL_0064: ldloc.s 6
-			IL_0066: ldstr "indexOf"
-			IL_006b: ldstr "/*---"
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0075: stloc.1
+			IL_0063: ldloc.1
+			IL_0064: ldc.r8 0.0
+			IL_006d: box [System.Runtime]System.Double
+			IL_0072: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_0077: stloc.s 6
+			IL_0079: ldloc.s 6
+			IL_007b: brfalse IL_0087
 
-			IL_0076: ldloc.1
-			IL_0077: ldc.r8 0.0
-			IL_0080: box [System.Runtime]System.Double
-			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_008a: stloc.s 7
-			IL_008c: ldloc.s 7
-			IL_008e: brfalse IL_009a
+			IL_0080: ldc.i4.0
+			IL_0081: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0086: ret
 
-			IL_0093: ldc.i4.0
-			IL_0094: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0099: ret
+			IL_0087: ldloc.0
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008d: stloc.s 5
+			IL_008f: ldloc.1
+			IL_0090: ldc.r8 5
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_009e: stloc.s 7
+			IL_00a0: ldc.i4.0
+			IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00a6: brfalse IL_00e3
 
-			IL_009a: ldloc.0
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a0: stloc.s 6
-			IL_00a2: ldloc.1
-			IL_00a3: ldc.r8 5
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00b1: stloc.s 8
-			IL_00b3: ldc.i4.0
-			IL_00b4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00b9: brfalse IL_00f6
+			IL_00ab: ldloc.s 5
+			IL_00ad: isinst [System.Runtime]System.String
+			IL_00b2: dup
+			IL_00b3: brtrue IL_00cb
 
-			IL_00be: ldloc.s 6
-			IL_00c0: isinst [System.Runtime]System.String
+			IL_00b8: pop
+			IL_00b9: ldloc.s 5
+			IL_00bb: ldstr "indexOf"
+			IL_00c0: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
 			IL_00c5: dup
-			IL_00c6: brtrue IL_00de
+			IL_00c6: brfalse IL_00e2
 
-			IL_00cb: pop
-			IL_00cc: ldloc.s 6
-			IL_00ce: ldstr "indexOf"
-			IL_00d3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_00d8: dup
-			IL_00d9: brfalse IL_00f5
+			IL_00cb: ldstr "---*/"
+			IL_00d0: ldloc.s 7
+			IL_00d2: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
+			IL_00d7: box [System.Runtime]System.Double
+			IL_00dc: stloc.2
+			IL_00dd: br IL_00f7
 
-			IL_00de: ldstr "---*/"
-			IL_00e3: ldloc.s 8
-			IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
-			IL_00ea: box [System.Runtime]System.Double
-			IL_00ef: stloc.2
-			IL_00f0: br IL_010a
+			IL_00e2: pop
 
-			IL_00f5: pop
+			IL_00e3: ldloc.s 5
+			IL_00e5: ldstr "indexOf"
+			IL_00ea: ldstr "---*/"
+			IL_00ef: ldloc.s 7
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00f6: stloc.2
 
-			IL_00f6: ldloc.s 6
-			IL_00f8: ldstr "indexOf"
-			IL_00fd: ldstr "---*/"
-			IL_0102: ldloc.s 8
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0109: stloc.2
+			IL_00f7: ldloc.2
+			IL_00f8: ldc.r8 0.0
+			IL_0101: box [System.Runtime]System.Double
+			IL_0106: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_010b: stloc.s 6
+			IL_010d: ldloc.s 6
+			IL_010f: brfalse IL_0134
 
-			IL_010a: ldloc.2
-			IL_010b: ldc.r8 0.0
-			IL_0114: box [System.Runtime]System.Double
-			IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_011e: stloc.s 7
-			IL_0120: ldloc.s 7
-			IL_0122: brfalse IL_0147
+			IL_0114: ldstr "Unterminated test262 frontmatter block."
+			IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_011e: stloc.3
+			IL_011f: ldloc.3
+			IL_0120: isinst [System.Runtime]System.Exception
+			IL_0125: dup
+			IL_0126: brtrue IL_0133
 
-			IL_0127: ldstr "Unterminated test262 frontmatter block."
-			IL_012c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0131: stloc.3
-			IL_0132: ldloc.3
-			IL_0133: isinst [System.Runtime]System.Exception
-			IL_0138: dup
-			IL_0139: brtrue IL_0146
+			IL_012b: pop
+			IL_012c: ldloc.3
+			IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0132: throw
 
-			IL_013e: pop
-			IL_013f: ldloc.3
-			IL_0140: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0145: throw
+			IL_0133: throw
 
-			IL_0146: throw
+			IL_0134: ldloc.0
+			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013a: stloc.s 5
+			IL_013c: ldloc.1
+			IL_013d: ldc.r8 5
+			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_014b: stloc.s 7
+			IL_014d: ldc.i4.0
+			IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0153: brfalse IL_0188
 
-			IL_0147: ldloc.0
-			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_014d: stloc.s 6
-			IL_014f: ldloc.1
-			IL_0150: ldc.r8 5
-			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_015e: stloc.s 8
-			IL_0160: ldc.i4.0
-			IL_0161: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0166: brfalse IL_019b
+			IL_0158: ldloc.s 5
+			IL_015a: isinst [System.Runtime]System.String
+			IL_015f: dup
+			IL_0160: brtrue IL_0178
 
-			IL_016b: ldloc.s 6
-			IL_016d: isinst [System.Runtime]System.String
+			IL_0165: pop
+			IL_0166: ldloc.s 5
+			IL_0168: ldstr "substring"
+			IL_016d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
 			IL_0172: dup
-			IL_0173: brtrue IL_018b
+			IL_0173: brfalse IL_0187
 
-			IL_0178: pop
-			IL_0179: ldloc.s 6
-			IL_017b: ldstr "substring"
-			IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0185: dup
-			IL_0186: brfalse IL_019a
+			IL_0178: ldloc.s 7
+			IL_017a: ldloc.2
+			IL_017b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0180: stloc.s 4
+			IL_0182: br IL_0199
 
-			IL_018b: ldloc.s 8
-			IL_018d: ldloc.2
-			IL_018e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_0193: stloc.s 4
-			IL_0195: br IL_01ac
+			IL_0187: pop
 
-			IL_019a: pop
+			IL_0188: ldloc.s 5
+			IL_018a: ldstr "substring"
+			IL_018f: ldloc.s 7
+			IL_0191: ldloc.2
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0197: stloc.s 4
 
-			IL_019b: ldloc.s 6
-			IL_019d: ldstr "substring"
-			IL_01a2: ldloc.s 8
-			IL_01a4: ldloc.2
-			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01aa: stloc.s 4
+			IL_0199: ldloc.s 4
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a0: stloc.s 5
+			IL_01a2: ldc.i4.0
+			IL_01a3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01a8: brfalse IL_01e4
 
-			IL_01ac: ldloc.s 4
-			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b3: stloc.s 6
-			IL_01b5: ldc.i4.0
-			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_01bb: brfalse IL_01f7
+			IL_01ad: ldloc.s 5
+			IL_01af: isinst [System.Runtime]System.String
+			IL_01b4: dup
+			IL_01b5: brtrue IL_01cd
 
-			IL_01c0: ldloc.s 6
-			IL_01c2: isinst [System.Runtime]System.String
+			IL_01ba: pop
+			IL_01bb: ldloc.s 5
+			IL_01bd: ldstr "startsWith"
+			IL_01c2: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
 			IL_01c7: dup
-			IL_01c8: brtrue IL_01e0
+			IL_01c8: brfalse IL_01e3
 
-			IL_01cd: pop
-			IL_01ce: ldloc.s 6
-			IL_01d0: ldstr "startsWith"
-			IL_01d5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_01da: dup
-			IL_01db: brfalse IL_01f6
+			IL_01cd: ldstr "\n"
+			IL_01d2: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_01d7: box [System.Runtime]System.Boolean
+			IL_01dc: stloc.s 5
+			IL_01de: br IL_01f7
 
-			IL_01e0: ldstr "\n"
-			IL_01e5: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-			IL_01ea: box [System.Runtime]System.Boolean
-			IL_01ef: stloc.s 6
-			IL_01f1: br IL_020a
+			IL_01e3: pop
 
-			IL_01f6: pop
+			IL_01e4: ldloc.s 5
+			IL_01e6: ldstr "startsWith"
+			IL_01eb: ldstr "\n"
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01f5: stloc.s 5
 
-			IL_01f7: ldloc.s 6
-			IL_01f9: ldstr "startsWith"
-			IL_01fe: ldstr "\n"
-			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0208: stloc.s 6
+			IL_01f7: ldloc.s 5
+			IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01fe: stloc.s 6
+			IL_0200: ldloc.s 6
+			IL_0202: brfalse IL_0276
 
-			IL_020a: ldloc.s 6
-			IL_020c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0211: stloc.s 7
-			IL_0213: ldloc.s 7
-			IL_0215: brfalse IL_0289
+			IL_0207: ldloc.s 4
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020e: stloc.s 5
+			IL_0210: ldc.i4.0
+			IL_0211: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0216: brfalse IL_0256
 
-			IL_021a: ldloc.s 4
-			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0221: stloc.s 6
-			IL_0223: ldc.i4.0
-			IL_0224: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0229: brfalse IL_0269
+			IL_021b: ldloc.s 5
+			IL_021d: isinst [System.Runtime]System.String
+			IL_0222: dup
+			IL_0223: brtrue IL_023b
 
-			IL_022e: ldloc.s 6
-			IL_0230: isinst [System.Runtime]System.String
+			IL_0228: pop
+			IL_0229: ldloc.s 5
+			IL_022b: ldstr "substring"
+			IL_0230: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
 			IL_0235: dup
-			IL_0236: brtrue IL_024e
+			IL_0236: brfalse IL_0255
 
-			IL_023b: pop
-			IL_023c: ldloc.s 6
-			IL_023e: ldstr "substring"
-			IL_0243: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0248: dup
-			IL_0249: brfalse IL_0268
+			IL_023b: ldc.r8 1
+			IL_0244: box [System.Runtime]System.Double
+			IL_0249: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_024e: stloc.s 5
+			IL_0250: br IL_0272
 
-			IL_024e: ldc.r8 1
-			IL_0257: box [System.Runtime]System.Double
-			IL_025c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_0261: stloc.s 6
-			IL_0263: br IL_0285
+			IL_0255: pop
 
-			IL_0268: pop
+			IL_0256: ldloc.s 5
+			IL_0258: ldstr "substring"
+			IL_025d: ldc.r8 1
+			IL_0266: box [System.Runtime]System.Double
+			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0270: stloc.s 5
 
-			IL_0269: ldloc.s 6
-			IL_026b: ldstr "substring"
-			IL_0270: ldc.r8 1
-			IL_0279: box [System.Runtime]System.Double
-			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0283: stloc.s 6
+			IL_0272: ldloc.s 5
+			IL_0274: stloc.s 4
 
-			IL_0285: ldloc.s 6
-			IL_0287: stloc.s 4
-
-			IL_0289: ldloc.s 4
-			IL_028b: ret
+			IL_0276: ldloc.s 4
+			IL_0278: ret
 		} // end of method extractTest262Frontmatter::__js_call__
 
 	} // end of class extractTest262Frontmatter
@@ -10185,7 +9708,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 468 (0x1d4)
+			// Code size: 432 (0x1b0)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -10198,11 +9721,10 @@
 				[7] object,
 				[8] object,
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[10] object,
-				[11] object[],
-				[12] string,
-				[13] float64,
-				[14] object
+				[10] string,
+				[11] float64,
+				[12] object,
+				[13] object
 			)
 
 			IL_0000: ldarg.2
@@ -10270,132 +9792,112 @@
 			IL_008d: ceq
 			IL_008f: stloc.3
 			IL_0090: ldloc.3
-			IL_0091: brfalse IL_00e9
+			IL_0091: brfalse IL_00d7
 
-			IL_0096: ldarg.0
-			IL_0097: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0096: ldarg.3
+			IL_0097: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_009c: stloc.s 10
-			IL_009e: ldc.i4.1
-			IL_009f: newarr [System.Runtime]System.Object
-			IL_00a4: dup
-			IL_00a5: ldc.i4.0
-			IL_00a6: ldarg.0
-			IL_00a7: stelem.ref
-			IL_00a8: stloc.s 11
-			IL_00aa: ldarg.3
-			IL_00ab: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00b0: stloc.s 12
-			IL_00b2: ldstr "Expected an array for '"
-			IL_00b7: ldloc.s 12
-			IL_00b9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00be: ldstr "'."
-			IL_00c3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c8: stloc.s 12
-			IL_00ca: ldloc.s 10
-			IL_00cc: ldloc.s 11
-			IL_00ce: ldarg.s issues
-			IL_00d0: ldstr "invalid-array"
-			IL_00d5: ldarg.3
-			IL_00d6: ldloc.s 12
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_00dd: pop
-			IL_00de: ldc.i4.0
-			IL_00df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00e4: stloc.s 9
-			IL_00e6: ldloc.s 9
-			IL_00e8: ret
+			IL_009e: ldstr "Expected an array for '"
+			IL_00a3: ldloc.s 10
+			IL_00a5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00aa: ldstr "'."
+			IL_00af: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b4: stloc.s 10
+			IL_00b6: ldnull
+			IL_00b7: ldarg.s issues
+			IL_00b9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00be: ldstr "invalid-array"
+			IL_00c3: ldarg.3
+			IL_00c4: ldloc.s 10
+			IL_00c6: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_00cb: pop
+			IL_00cc: ldc.i4.0
+			IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00d2: stloc.s 9
+			IL_00d4: ldloc.s 9
+			IL_00d6: ret
 
-			IL_00e9: ldc.i4.0
-			IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00ef: stloc.0
-			IL_00f0: ldc.r8 0.0
-			IL_00f9: stloc.1
-			// loop start (head: IL_00fa)
-				IL_00fa: ldloc.1
-				IL_00fb: stloc.s 13
-				IL_00fd: volatile.
-				IL_00ff: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
-				IL_0104: brfalse IL_0119
+			IL_00d7: ldc.i4.0
+			IL_00d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00dd: stloc.0
+			IL_00de: ldc.r8 0.0
+			IL_00e7: stloc.1
+			// loop start (head: IL_00e8)
+				IL_00e8: ldloc.1
+				IL_00e9: stloc.s 11
+				IL_00eb: volatile.
+				IL_00ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
+				IL_00f2: brfalse IL_0107
 
-				IL_0109: ldarg.2
-				IL_010a: ldstr "length"
-				IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0114: br IL_012e
+				IL_00f7: ldarg.2
+				IL_00f8: ldstr "length"
+				IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0102: br IL_011c
 
-				IL_0119: ldarg.2
-				IL_011a: ldstr "length"
-				IL_011f: ldstr "test262/metadataParser:<TwoPhaseDummy_M42>:__js_call__:66"
-				IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
-				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0107: ldarg.2
+				IL_0108: ldstr "length"
+				IL_010d: ldstr "test262/metadataParser:<TwoPhaseDummy_M42>:__js_call__:65"
+				IL_0112: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_168
+				IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_012e: stloc.s 10
-				IL_0130: ldloc.s 13
-				IL_0132: box [System.Runtime]System.Double
-				IL_0137: stloc.s 14
-				IL_0139: ldloc.s 14
-				IL_013b: ldloc.s 10
-				IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-				IL_0142: stloc.3
-				IL_0143: ldloc.3
-				IL_0144: brfalse IL_01d2
+				IL_011c: stloc.s 12
+				IL_011e: ldloc.s 11
+				IL_0120: box [System.Runtime]System.Double
+				IL_0125: stloc.s 13
+				IL_0127: ldloc.s 13
+				IL_0129: ldloc.s 12
+				IL_012b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+				IL_0130: stloc.3
+				IL_0131: ldloc.3
+				IL_0132: brfalse IL_01ae
 
-				IL_0149: ldarg.2
-				IL_014a: ldloc.1
-				IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0150: stloc.2
-				IL_0151: ldloc.2
-				IL_0152: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-				IL_0157: stloc.s 12
-				IL_0159: ldloc.s 12
-				IL_015b: ldstr "string"
-				IL_0160: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_0165: stloc.3
-				IL_0166: ldloc.3
-				IL_0167: brfalse IL_01b9
+				IL_0137: ldarg.2
+				IL_0138: ldloc.1
+				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_013e: stloc.2
+				IL_013f: ldloc.2
+				IL_0140: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+				IL_0145: stloc.s 10
+				IL_0147: ldloc.s 10
+				IL_0149: ldstr "string"
+				IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_0153: stloc.3
+				IL_0154: ldloc.3
+				IL_0155: brfalse IL_0195
 
-				IL_016c: ldarg.0
-				IL_016d: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_0172: stloc.s 10
-				IL_0174: ldc.i4.1
-				IL_0175: newarr [System.Runtime]System.Object
-				IL_017a: dup
-				IL_017b: ldc.i4.0
-				IL_017c: ldarg.0
-				IL_017d: stelem.ref
-				IL_017e: stloc.s 11
-				IL_0180: ldarg.3
-				IL_0181: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0186: stloc.s 12
-				IL_0188: ldstr "Expected string entries for '"
-				IL_018d: ldloc.s 12
-				IL_018f: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0194: ldstr "'."
-				IL_0199: call string [System.Runtime]System.String::Concat(string, string)
-				IL_019e: stloc.s 12
-				IL_01a0: ldloc.s 10
-				IL_01a2: ldloc.s 11
-				IL_01a4: ldarg.s issues
-				IL_01a6: ldstr "invalid-array-entry"
-				IL_01ab: ldarg.3
-				IL_01ac: ldloc.s 12
-				IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-				IL_01b3: pop
-				IL_01b4: br IL_01c1
+				IL_015a: ldarg.3
+				IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0160: stloc.s 10
+				IL_0162: ldstr "Expected string entries for '"
+				IL_0167: ldloc.s 10
+				IL_0169: call string [System.Runtime]System.String::Concat(string, string)
+				IL_016e: ldstr "'."
+				IL_0173: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0178: stloc.s 10
+				IL_017a: ldnull
+				IL_017b: ldarg.s issues
+				IL_017d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0182: ldstr "invalid-array-entry"
+				IL_0187: ldarg.3
+				IL_0188: ldloc.s 10
+				IL_018a: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+				IL_018f: pop
+				IL_0190: br IL_019d
 
-				IL_01b9: ldloc.0
-				IL_01ba: ldloc.2
-				IL_01bb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_01c0: pop
+				IL_0195: ldloc.0
+				IL_0196: ldloc.2
+				IL_0197: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_019c: pop
 
-				IL_01c1: ldloc.1
-				IL_01c2: ldc.r8 1
-				IL_01cb: add
-				IL_01cc: stloc.1
-				IL_01cd: br IL_00fa
+				IL_019d: ldloc.1
+				IL_019e: ldc.r8 1
+				IL_01a7: add
+				IL_01a8: stloc.1
+				IL_01a9: br IL_00e8
 			// end loop
 
-			IL_01d2: ldloc.0
-			IL_01d3: ret
+			IL_01ae: ldloc.0
+			IL_01af: ret
 		} // end of method toStringArray::__js_call__
 
 	} // end of class toStringArray
@@ -10603,7 +10105,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 229 (0xe5)
+			// Code size: 211 (0xd3)
 			.maxstack 8
 			.locals init (
 				[0] bool,
@@ -10612,9 +10114,7 @@
 				[3] object,
 				[4] object,
 				[5] object,
-				[6] string,
-				[7] object,
-				[8] object[]
+				[6] string
 			)
 
 			IL_0000: ldarg.2
@@ -10680,41 +10180,31 @@
 			IL_0088: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 			IL_008d: stloc.0
 			IL_008e: ldloc.0
-			IL_008f: brfalse IL_00e3
+			IL_008f: brfalse IL_00d1
 
-			IL_0094: ldarg.0
-			IL_0095: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_009a: stloc.s 7
-			IL_009c: ldc.i4.1
-			IL_009d: newarr [System.Runtime]System.Object
-			IL_00a2: dup
-			IL_00a3: ldc.i4.0
-			IL_00a4: ldarg.0
-			IL_00a5: stelem.ref
-			IL_00a6: stloc.s 8
-			IL_00a8: ldarg.3
-			IL_00a9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00ae: stloc.s 6
-			IL_00b0: ldstr "Expected a string for '"
-			IL_00b5: ldloc.s 6
-			IL_00b7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00bc: ldstr "'."
-			IL_00c1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c6: stloc.s 6
-			IL_00c8: ldloc.s 7
-			IL_00ca: ldloc.s 8
-			IL_00cc: ldarg.s issues
-			IL_00ce: ldstr "invalid-string"
-			IL_00d3: ldarg.3
-			IL_00d4: ldloc.s 6
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_00db: pop
-			IL_00dc: ldc.i4.0
-			IL_00dd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00e2: ret
+			IL_0094: ldarg.3
+			IL_0095: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_009a: stloc.s 6
+			IL_009c: ldstr "Expected a string for '"
+			IL_00a1: ldloc.s 6
+			IL_00a3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00a8: ldstr "'."
+			IL_00ad: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b2: stloc.s 6
+			IL_00b4: ldnull
+			IL_00b5: ldarg.s issues
+			IL_00b7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00bc: ldstr "invalid-string"
+			IL_00c1: ldarg.3
+			IL_00c2: ldloc.s 6
+			IL_00c4: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_00c9: pop
+			IL_00ca: ldc.i4.0
+			IL_00cb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00d0: ret
 
-			IL_00e3: ldarg.2
-			IL_00e4: ret
+			IL_00d1: ldarg.2
+			IL_00d2: ret
 		} // end of method toNullableString::__js_call__
 
 	} // end of class toNullableString
@@ -11012,7 +10502,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1139 (0x473)
+			// Code size: 1069 (0x42d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -11031,14 +10521,13 @@
 				[13] object,
 				[14] object,
 				[15] object,
-				[16] object[],
-				[17] float64,
+				[16] float64,
+				[17] object,
 				[18] object,
 				[19] object,
-				[20] object,
-				[21] string,
-				[22] object,
-				[23] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[20] string,
+				[21] object,
+				[22] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.2
@@ -11145,331 +10634,289 @@
 			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0109: stloc.s 6
 			IL_010b: ldloc.s 6
-			IL_010d: brfalse IL_0147
+			IL_010d: brfalse IL_0135
 
-			IL_0112: ldarg.0
-			IL_0113: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0118: stloc.s 15
-			IL_011a: ldc.i4.1
-			IL_011b: newarr [System.Runtime]System.Object
-			IL_0120: dup
-			IL_0121: ldc.i4.0
-			IL_0122: ldarg.0
-			IL_0123: stelem.ref
-			IL_0124: stloc.s 16
-			IL_0126: ldloc.s 15
-			IL_0128: ldloc.s 16
-			IL_012a: ldarg.3
-			IL_012b: ldstr "invalid-negative"
-			IL_0130: ldstr "negative"
-			IL_0135: ldstr "Expected an object for the negative frontmatter value."
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_013f: pop
-			IL_0140: ldc.i4.0
-			IL_0141: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0146: ret
+			IL_0112: ldnull
+			IL_0113: ldarg.3
+			IL_0114: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0119: ldstr "invalid-negative"
+			IL_011e: ldstr "negative"
+			IL_0123: ldstr "Expected an object for the negative frontmatter value."
+			IL_0128: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_012d: pop
+			IL_012e: ldc.i4.0
+			IL_012f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0134: ret
 
-			IL_0147: ldarg.0
-			IL_0148: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_014d: ldc.i4.1
-			IL_014e: newarr [System.Runtime]System.Object
-			IL_0153: dup
-			IL_0154: ldc.i4.0
-			IL_0155: ldarg.0
-			IL_0156: stelem.ref
-			IL_0157: stloc.s 16
-			IL_0159: volatile.
-			IL_015b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_169
-			IL_0160: brfalse IL_0175
+			IL_0135: volatile.
+			IL_0137: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_169
+			IL_013c: brfalse IL_0151
 
-			IL_0165: ldarg.2
-			IL_0166: ldstr "phase"
-			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0170: br IL_018a
+			IL_0141: ldarg.2
+			IL_0142: ldstr "phase"
+			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014c: br IL_0166
 
-			IL_0175: ldarg.2
-			IL_0176: ldstr "phase"
-			IL_017b: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:81"
-			IL_0180: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_169
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0151: ldarg.2
+			IL_0152: ldstr "phase"
+			IL_0157: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:78"
+			IL_015c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_169
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_018a: stloc.s 15
-			IL_018c: ldloc.s 16
-			IL_018e: ldloc.s 15
-			IL_0190: ldstr "negative.phase"
-			IL_0195: ldarg.3
-			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_019b: stloc.0
-			IL_019c: ldarg.0
-			IL_019d: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_01a2: ldc.i4.1
-			IL_01a3: newarr [System.Runtime]System.Object
-			IL_01a8: dup
-			IL_01a9: ldc.i4.0
-			IL_01aa: ldarg.0
-			IL_01ab: stelem.ref
-			IL_01ac: stloc.s 16
-			IL_01ae: volatile.
-			IL_01b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_170
-			IL_01b5: brfalse IL_01ca
+			IL_0166: stloc.s 15
+			IL_0168: ldarg.0
+			IL_0169: castclass Modules.test262_metadataParser/Scope
+			IL_016e: ldnull
+			IL_016f: ldloc.s 15
+			IL_0171: ldstr "negative.phase"
+			IL_0176: ldarg.3
+			IL_0177: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_017c: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0181: stloc.0
+			IL_0182: volatile.
+			IL_0184: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_170
+			IL_0189: brfalse IL_019e
 
-			IL_01ba: ldarg.2
-			IL_01bb: ldstr "type"
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c5: br IL_01df
+			IL_018e: ldarg.2
+			IL_018f: ldstr "type"
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0199: br IL_01b3
 
-			IL_01ca: ldarg.2
-			IL_01cb: ldstr "type"
-			IL_01d0: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:91"
-			IL_01d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_170
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_019e: ldarg.2
+			IL_019f: ldstr "type"
+			IL_01a4: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:87"
+			IL_01a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_170
+			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01df: stloc.s 15
-			IL_01e1: ldloc.s 16
-			IL_01e3: ldloc.s 15
-			IL_01e5: ldstr "negative.type"
-			IL_01ea: ldarg.3
-			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_01f0: stloc.1
-			IL_01f1: ldc.i4.3
-			IL_01f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01f7: dup
-			IL_01f8: ldstr "parse"
-			IL_01fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0202: dup
-			IL_0203: ldstr "resolution"
-			IL_0208: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b3: stloc.s 15
+			IL_01b5: ldarg.0
+			IL_01b6: castclass Modules.test262_metadataParser/Scope
+			IL_01bb: ldnull
+			IL_01bc: ldloc.s 15
+			IL_01be: ldstr "negative.type"
+			IL_01c3: ldarg.3
+			IL_01c4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01c9: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01ce: stloc.1
+			IL_01cf: ldc.i4.3
+			IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01d5: dup
+			IL_01d6: ldstr "parse"
+			IL_01db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01e0: dup
+			IL_01e1: ldstr "resolution"
+			IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01eb: dup
+			IL_01ec: ldstr "runtime"
+			IL_01f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01f6: stloc.2
+			IL_01f7: ldloc.0
+			IL_01f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01fd: stloc.s 6
+			IL_01ff: ldloc.s 6
+			IL_0201: brfalse IL_0239
+
+			IL_0206: ldloc.2
+			IL_0207: ldc.i4.1
+			IL_0208: newarr [System.Runtime]System.Object
 			IL_020d: dup
-			IL_020e: ldstr "runtime"
-			IL_0213: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0218: stloc.2
-			IL_0219: ldloc.0
-			IL_021a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_021f: stloc.s 6
-			IL_0221: ldloc.s 6
-			IL_0223: brfalse IL_025b
+			IL_020e: ldc.i4.0
+			IL_020f: ldloc.0
+			IL_0210: stelem.ref
+			IL_0211: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+			IL_0216: stloc.s 16
+			IL_0218: ldloc.s 16
+			IL_021a: ldc.r8 0.0
+			IL_0223: clt
+			IL_0225: stloc.s 6
+			IL_0227: ldloc.s 6
+			IL_0229: box [System.Runtime]System.Boolean
+			IL_022e: stloc.s 7
+			IL_0230: ldloc.s 7
+			IL_0232: stloc.s 17
+			IL_0234: br IL_023c
 
-			IL_0228: ldloc.2
-			IL_0229: ldc.i4.1
-			IL_022a: newarr [System.Runtime]System.Object
-			IL_022f: dup
-			IL_0230: ldc.i4.0
-			IL_0231: ldloc.0
-			IL_0232: stelem.ref
-			IL_0233: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-			IL_0238: stloc.s 17
-			IL_023a: ldloc.s 17
-			IL_023c: ldc.r8 0.0
-			IL_0245: clt
-			IL_0247: stloc.s 6
-			IL_0249: ldloc.s 6
-			IL_024b: box [System.Runtime]System.Boolean
-			IL_0250: stloc.s 7
-			IL_0252: ldloc.s 7
-			IL_0254: stloc.s 18
-			IL_0256: br IL_025e
+			IL_0239: ldloc.0
+			IL_023a: stloc.s 17
 
-			IL_025b: ldloc.0
-			IL_025c: stloc.s 18
+			IL_023c: ldloc.s 17
+			IL_023e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0243: stloc.s 6
+			IL_0245: ldloc.s 6
+			IL_0247: brfalse IL_0285
 
-			IL_025e: ldloc.s 18
-			IL_0260: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0265: stloc.s 6
-			IL_0267: ldloc.s 6
-			IL_0269: brfalse IL_02b9
+			IL_024c: ldloc.0
+			IL_024d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0252: stloc.s 12
+			IL_0254: ldstr "Unsupported negative phase '"
+			IL_0259: ldloc.s 12
+			IL_025b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0260: ldstr "'."
+			IL_0265: call string [System.Runtime]System.String::Concat(string, string)
+			IL_026a: stloc.s 12
+			IL_026c: ldnull
+			IL_026d: ldarg.3
+			IL_026e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0273: ldstr "unknown-negative-phase"
+			IL_0278: ldstr "negative.phase"
+			IL_027d: ldloc.s 12
+			IL_027f: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_0284: pop
 
-			IL_026e: ldarg.0
-			IL_026f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0274: stloc.s 15
-			IL_0276: ldc.i4.1
-			IL_0277: newarr [System.Runtime]System.Object
-			IL_027c: dup
-			IL_027d: ldc.i4.0
-			IL_027e: ldarg.0
-			IL_027f: stelem.ref
-			IL_0280: stloc.s 16
-			IL_0282: ldloc.0
-			IL_0283: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0288: stloc.s 12
-			IL_028a: ldstr "Unsupported negative phase '"
-			IL_028f: ldloc.s 12
-			IL_0291: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0296: ldstr "'."
-			IL_029b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02a0: stloc.s 12
-			IL_02a2: ldloc.s 15
-			IL_02a4: ldloc.s 16
-			IL_02a6: ldarg.3
-			IL_02a7: ldstr "unknown-negative-phase"
-			IL_02ac: ldstr "negative.phase"
-			IL_02b1: ldloc.s 12
-			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_02b8: pop
+			IL_0285: ldarg.2
+			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_028b: stloc.3
+			IL_028c: ldc.r8 0.0
+			IL_0295: stloc.s 4
+			// loop start (head: IL_0297)
+				IL_0297: ldloc.s 4
+				IL_0299: stloc.s 16
+				IL_029b: volatile.
+				IL_029d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_171
+				IL_02a2: brfalse IL_02b7
 
-			IL_02b9: ldarg.2
-			IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_02bf: stloc.3
-			IL_02c0: ldc.r8 0.0
-			IL_02c9: stloc.s 4
-			// loop start (head: IL_02cb)
-				IL_02cb: ldloc.s 4
-				IL_02cd: stloc.s 17
-				IL_02cf: volatile.
-				IL_02d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_171
-				IL_02d6: brfalse IL_02eb
+				IL_02a7: ldloc.3
+				IL_02a8: ldstr "length"
+				IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02b2: br IL_02cc
 
-				IL_02db: ldloc.3
-				IL_02dc: ldstr "length"
-				IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02e6: br IL_0300
+				IL_02b7: ldloc.3
+				IL_02b8: ldstr "length"
+				IL_02bd: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:135"
+				IL_02c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_171
+				IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_02eb: ldloc.3
-				IL_02ec: ldstr "length"
-				IL_02f1: ldstr "test262/metadataParser:<TwoPhaseDummy_M44>:__js_call__:139"
-				IL_02f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_171
-				IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_02cc: stloc.s 15
+				IL_02ce: ldloc.s 16
+				IL_02d0: box [System.Runtime]System.Double
+				IL_02d5: stloc.s 18
+				IL_02d7: ldloc.s 18
+				IL_02d9: ldloc.s 15
+				IL_02db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+				IL_02e0: stloc.s 6
+				IL_02e2: ldloc.s 6
+				IL_02e4: brfalse IL_03af
 
-				IL_0300: stloc.s 15
-				IL_0302: ldloc.s 17
-				IL_0304: box [System.Runtime]System.Double
-				IL_0309: stloc.s 19
-				IL_030b: ldloc.s 19
-				IL_030d: ldloc.s 15
-				IL_030f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-				IL_0314: stloc.s 6
-				IL_0316: ldloc.s 6
-				IL_0318: brfalse IL_03f5
+				IL_02e9: ldloc.3
+				IL_02ea: ldloc.s 4
+				IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02f1: stloc.s 5
+				IL_02f3: ldloc.s 5
+				IL_02f5: ldstr "phase"
+				IL_02fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_02ff: stloc.s 6
+				IL_0301: ldloc.s 6
+				IL_0303: box [System.Runtime]System.Boolean
+				IL_0308: stloc.s 7
+				IL_030a: ldloc.s 7
+				IL_030c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0311: stloc.s 6
+				IL_0313: ldloc.s 6
+				IL_0315: brfalse IL_033a
 
-				IL_031d: ldloc.3
-				IL_031e: ldloc.s 4
-				IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0325: stloc.s 5
-				IL_0327: ldloc.s 5
-				IL_0329: ldstr "phase"
-				IL_032e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_0333: stloc.s 6
-				IL_0335: ldloc.s 6
-				IL_0337: box [System.Runtime]System.Boolean
-				IL_033c: stloc.s 7
-				IL_033e: ldloc.s 7
+				IL_031a: ldloc.s 5
+				IL_031c: ldstr "type"
+				IL_0321: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_0326: stloc.s 6
+				IL_0328: ldloc.s 6
+				IL_032a: box [System.Runtime]System.Boolean
+				IL_032f: stloc.s 8
+				IL_0331: ldloc.s 8
+				IL_0333: stloc.s 19
+				IL_0335: br IL_033e
+
+				IL_033a: ldloc.s 7
+				IL_033c: stloc.s 19
+
+				IL_033e: ldloc.s 19
 				IL_0340: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_0345: stloc.s 6
 				IL_0347: ldloc.s 6
-				IL_0349: brfalse IL_036e
+				IL_0349: brfalse IL_039c
 
 				IL_034e: ldloc.s 5
-				IL_0350: ldstr "type"
-				IL_0355: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_035a: stloc.s 6
-				IL_035c: ldloc.s 6
-				IL_035e: box [System.Runtime]System.Boolean
-				IL_0363: stloc.s 8
-				IL_0365: ldloc.s 8
-				IL_0367: stloc.s 20
-				IL_0369: br IL_0372
+				IL_0350: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0355: stloc.s 12
+				IL_0357: ldstr "negative."
+				IL_035c: ldloc.s 12
+				IL_035e: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0363: stloc.s 12
+				IL_0365: ldloc.s 5
+				IL_0367: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_036c: stloc.s 20
+				IL_036e: ldstr "Unsupported negative metadata key '"
+				IL_0373: ldloc.s 20
+				IL_0375: call string [System.Runtime]System.String::Concat(string, string)
+				IL_037a: ldstr "'."
+				IL_037f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0384: stloc.s 20
+				IL_0386: ldnull
+				IL_0387: ldarg.3
+				IL_0388: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_038d: ldstr "unknown-negative-key"
+				IL_0392: ldloc.s 12
+				IL_0394: ldloc.s 20
+				IL_0396: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+				IL_039b: pop
 
-				IL_036e: ldloc.s 7
-				IL_0370: stloc.s 20
-
-				IL_0372: ldloc.s 20
-				IL_0374: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0379: stloc.s 6
-				IL_037b: ldloc.s 6
-				IL_037d: brfalse IL_03e2
-
-				IL_0382: ldarg.0
-				IL_0383: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_0388: stloc.s 15
-				IL_038a: ldc.i4.1
-				IL_038b: newarr [System.Runtime]System.Object
-				IL_0390: dup
-				IL_0391: ldc.i4.0
-				IL_0392: ldarg.0
-				IL_0393: stelem.ref
-				IL_0394: stloc.s 16
-				IL_0396: ldloc.s 5
-				IL_0398: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_039d: stloc.s 12
-				IL_039f: ldstr "negative."
-				IL_03a4: ldloc.s 12
-				IL_03a6: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03ab: stloc.s 12
-				IL_03ad: ldloc.s 5
-				IL_03af: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_03b4: stloc.s 21
-				IL_03b6: ldstr "Unsupported negative metadata key '"
-				IL_03bb: ldloc.s 21
-				IL_03bd: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03c2: ldstr "'."
-				IL_03c7: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03cc: stloc.s 21
-				IL_03ce: ldloc.s 15
-				IL_03d0: ldloc.s 16
-				IL_03d2: ldarg.3
-				IL_03d3: ldstr "unknown-negative-key"
-				IL_03d8: ldloc.s 12
-				IL_03da: ldloc.s 21
-				IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-				IL_03e1: pop
-
-				IL_03e2: ldloc.s 4
-				IL_03e4: ldc.r8 1
-				IL_03ed: add
-				IL_03ee: stloc.s 4
-				IL_03f0: br IL_02cb
+				IL_039c: ldloc.s 4
+				IL_039e: ldc.r8 1
+				IL_03a7: add
+				IL_03a8: stloc.s 4
+				IL_03aa: br IL_0297
 			// end loop
 
-			IL_03f5: ldloc.0
-			IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_03fb: ldc.i4.0
-			IL_03fc: ceq
-			IL_03fe: stloc.s 6
-			IL_0400: ldloc.s 6
-			IL_0402: box [System.Runtime]System.Boolean
-			IL_0407: stloc.s 7
-			IL_0409: ldloc.s 7
-			IL_040b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0410: stloc.s 6
-			IL_0412: ldloc.s 6
-			IL_0414: brtrue IL_0436
+			IL_03af: ldloc.0
+			IL_03b0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03b5: ldc.i4.0
+			IL_03b6: ceq
+			IL_03b8: stloc.s 6
+			IL_03ba: ldloc.s 6
+			IL_03bc: box [System.Runtime]System.Boolean
+			IL_03c1: stloc.s 7
+			IL_03c3: ldloc.s 7
+			IL_03c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03ca: stloc.s 6
+			IL_03cc: ldloc.s 6
+			IL_03ce: brtrue IL_03f0
 
-			IL_0419: ldloc.1
-			IL_041a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_041f: ldc.i4.0
-			IL_0420: ceq
-			IL_0422: stloc.s 6
-			IL_0424: ldloc.s 6
-			IL_0426: box [System.Runtime]System.Boolean
-			IL_042b: stloc.s 8
-			IL_042d: ldloc.s 8
-			IL_042f: stloc.s 22
-			IL_0431: br IL_043a
+			IL_03d3: ldloc.1
+			IL_03d4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03d9: ldc.i4.0
+			IL_03da: ceq
+			IL_03dc: stloc.s 6
+			IL_03de: ldloc.s 6
+			IL_03e0: box [System.Runtime]System.Boolean
+			IL_03e5: stloc.s 8
+			IL_03e7: ldloc.s 8
+			IL_03e9: stloc.s 21
+			IL_03eb: br IL_03f4
 
-			IL_0436: ldloc.s 7
-			IL_0438: stloc.s 22
+			IL_03f0: ldloc.s 7
+			IL_03f2: stloc.s 21
 
-			IL_043a: ldloc.s 22
-			IL_043c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0441: stloc.s 6
-			IL_0443: ldloc.s 6
-			IL_0445: brfalse IL_0451
+			IL_03f4: ldloc.s 21
+			IL_03f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03fb: stloc.s 6
+			IL_03fd: ldloc.s 6
+			IL_03ff: brfalse IL_040b
 
-			IL_044a: ldc.i4.0
-			IL_044b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0450: ret
+			IL_0404: ldc.i4.0
+			IL_0405: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_040a: ret
 
-			IL_0451: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0456: dup
-			IL_0457: ldstr "phase"
-			IL_045c: ldloc.0
-			IL_045d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0462: dup
-			IL_0463: ldstr "type"
-			IL_0468: ldloc.1
-			IL_0469: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_046e: stloc.s 23
-			IL_0470: ldloc.s 23
-			IL_0472: ret
+			IL_040b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0410: dup
+			IL_0411: ldstr "phase"
+			IL_0416: ldloc.0
+			IL_0417: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_041c: dup
+			IL_041d: ldstr "type"
+			IL_0422: ldloc.1
+			IL_0423: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0428: stloc.s 22
+			IL_042a: ldloc.s 22
+			IL_042c: ret
 		} // end of method normalizeNegative::__js_call__
 
 	} // end of class normalizeNegative
@@ -11877,7 +11324,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1695 (0x69f)
+			// Code size: 1467 (0x5bb)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -11901,657 +11348,548 @@
 				[18] object,
 				[19] object,
 				[20] object,
-				[21] object[],
-				[22] object,
+				[21] object,
+				[22] float64,
 				[23] float64,
-				[24] float64,
-				[25] bool,
+				[24] bool,
+				[25] object,
 				[26] object,
 				[27] object,
 				[28] object,
-				[29] object,
-				[30] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[31] object,
-				[32] string,
-				[33] object,
-				[34] bool,
+				[29] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[30] object,
+				[31] string,
+				[32] object,
+				[33] bool,
+				[34] object,
 				[35] object,
 				[36] object,
-				[37] object,
-				[38] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[37] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.s 21
-			IL_0012: ldloc.s 21
-			IL_0014: ldarg.2
-			IL_0015: ldstr "module"
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_001f: stloc.0
-			IL_0020: ldarg.0
-			IL_0021: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0026: ldc.i4.1
-			IL_0027: newarr [System.Runtime]System.Object
-			IL_002c: dup
-			IL_002d: ldc.i4.0
-			IL_002e: ldarg.0
-			IL_002f: stelem.ref
-			IL_0030: stloc.s 21
-			IL_0032: ldloc.s 21
-			IL_0034: ldarg.2
-			IL_0035: ldstr "raw"
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_003f: stloc.1
-			IL_0040: ldarg.0
-			IL_0041: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0046: ldc.i4.1
-			IL_0047: newarr [System.Runtime]System.Object
-			IL_004c: dup
-			IL_004d: ldc.i4.0
-			IL_004e: ldarg.0
-			IL_004f: stelem.ref
-			IL_0050: stloc.s 21
-			IL_0052: ldloc.s 21
-			IL_0054: ldarg.2
-			IL_0055: ldstr "async"
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_005f: stloc.2
-			IL_0060: ldarg.0
-			IL_0061: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0066: ldc.i4.1
-			IL_0067: newarr [System.Runtime]System.Object
-			IL_006c: dup
-			IL_006d: ldc.i4.0
-			IL_006e: ldarg.0
-			IL_006f: stelem.ref
-			IL_0070: stloc.s 21
-			IL_0072: ldloc.s 21
-			IL_0074: ldarg.2
-			IL_0075: ldstr "generated"
-			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_007f: stloc.3
-			IL_0080: ldarg.0
-			IL_0081: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0086: ldc.i4.1
-			IL_0087: newarr [System.Runtime]System.Object
-			IL_008c: dup
-			IL_008d: ldc.i4.0
-			IL_008e: ldarg.0
-			IL_008f: stelem.ref
-			IL_0090: stloc.s 21
-			IL_0092: ldloc.s 21
-			IL_0094: ldarg.2
-			IL_0095: ldstr "non-deterministic"
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_009f: stloc.s 4
-			IL_00a1: ldarg.s fileName
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a8: stloc.s 22
-			IL_00aa: ldc.i4.0
-			IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00b0: brfalse IL_00ec
+			IL_0000: ldnull
+			IL_0001: ldarg.2
+			IL_0002: ldstr "module"
+			IL_0007: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_000c: stloc.0
+			IL_000d: ldnull
+			IL_000e: ldarg.2
+			IL_000f: ldstr "raw"
+			IL_0014: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_0019: stloc.1
+			IL_001a: ldnull
+			IL_001b: ldarg.2
+			IL_001c: ldstr "async"
+			IL_0021: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_0026: stloc.2
+			IL_0027: ldnull
+			IL_0028: ldarg.2
+			IL_0029: ldstr "generated"
+			IL_002e: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_0033: stloc.3
+			IL_0034: ldnull
+			IL_0035: ldarg.2
+			IL_0036: ldstr "non-deterministic"
+			IL_003b: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_0040: stloc.s 4
+			IL_0042: ldarg.s fileName
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0049: stloc.s 21
+			IL_004b: ldc.i4.0
+			IL_004c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0051: brfalse IL_008d
 
-			IL_00b5: ldloc.s 22
-			IL_00b7: isinst [System.Runtime]System.String
-			IL_00bc: dup
-			IL_00bd: brtrue IL_00d5
+			IL_0056: ldloc.s 21
+			IL_0058: isinst [System.Runtime]System.String
+			IL_005d: dup
+			IL_005e: brtrue IL_0076
 
-			IL_00c2: pop
-			IL_00c3: ldloc.s 22
-			IL_00c5: ldstr "indexOf"
-			IL_00ca: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_00cf: dup
-			IL_00d0: brfalse IL_00eb
+			IL_0063: pop
+			IL_0064: ldloc.s 21
+			IL_0066: ldstr "indexOf"
+			IL_006b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0070: dup
+			IL_0071: brfalse IL_008c
 
-			IL_00d5: ldstr "_FIXTURE"
-			IL_00da: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_00df: box [System.Runtime]System.Double
-			IL_00e4: stloc.s 22
-			IL_00e6: br IL_00ff
+			IL_0076: ldstr "_FIXTURE"
+			IL_007b: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0080: box [System.Runtime]System.Double
+			IL_0085: stloc.s 21
+			IL_0087: br IL_00a0
 
-			IL_00eb: pop
+			IL_008c: pop
 
-			IL_00ec: ldloc.s 22
-			IL_00ee: ldstr "indexOf"
-			IL_00f3: ldstr "_FIXTURE"
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00fd: stloc.s 22
+			IL_008d: ldloc.s 21
+			IL_008f: ldstr "indexOf"
+			IL_0094: ldstr "_FIXTURE"
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_009e: stloc.s 21
 
-			IL_00ff: ldloc.s 22
-			IL_0101: ldc.r8 0.0
-			IL_010a: box [System.Runtime]System.Double
-			IL_010f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
-			IL_0114: stloc.s 5
-			IL_0116: ldc.i4.0
-			IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_011c: stloc.s 6
-			IL_011e: ldc.i4.4
-			IL_011f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0124: dup
-			IL_0125: ldstr "onlyStrict"
-			IL_012a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_012f: dup
-			IL_0130: ldstr "noStrict"
-			IL_0135: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_013a: dup
-			IL_013b: ldstr "module"
-			IL_0140: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0145: dup
-			IL_0146: ldstr "raw"
-			IL_014b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0150: stloc.s 7
-			IL_0152: ldc.r8 0.0
-			IL_015b: stloc.s 8
-			// loop start (head: IL_015d)
-				IL_015d: ldloc.s 8
-				IL_015f: stloc.s 23
-				IL_0161: ldloc.s 7
-				IL_0163: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-				IL_0168: stloc.s 24
-				IL_016a: ldloc.s 23
-				IL_016c: ldloc.s 24
-				IL_016e: clt
-				IL_0170: brfalse IL_01d0
+			IL_00a0: ldloc.s 21
+			IL_00a2: ldc.r8 0.0
+			IL_00ab: box [System.Runtime]System.Double
+			IL_00b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
+			IL_00b5: stloc.s 5
+			IL_00b7: ldc.i4.0
+			IL_00b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00bd: stloc.s 6
+			IL_00bf: ldc.i4.4
+			IL_00c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00c5: dup
+			IL_00c6: ldstr "onlyStrict"
+			IL_00cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00d0: dup
+			IL_00d1: ldstr "noStrict"
+			IL_00d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00db: dup
+			IL_00dc: ldstr "module"
+			IL_00e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00e6: dup
+			IL_00e7: ldstr "raw"
+			IL_00ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00f1: stloc.s 7
+			IL_00f3: ldc.r8 0.0
+			IL_00fc: stloc.s 8
+			// loop start (head: IL_00fe)
+				IL_00fe: ldloc.s 8
+				IL_0100: stloc.s 22
+				IL_0102: ldloc.s 7
+				IL_0104: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0109: stloc.s 23
+				IL_010b: ldloc.s 22
+				IL_010d: ldloc.s 23
+				IL_010f: clt
+				IL_0111: brfalse IL_015e
 
-				IL_0175: ldloc.s 7
-				IL_0177: ldloc.s 8
-				IL_0179: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_017e: castclass [System.Runtime]System.String
-				IL_0183: stloc.s 9
-				IL_0185: ldarg.0
-				IL_0186: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_018b: ldc.i4.1
-				IL_018c: newarr [System.Runtime]System.Object
-				IL_0191: dup
-				IL_0192: ldc.i4.0
-				IL_0193: ldarg.0
-				IL_0194: stelem.ref
-				IL_0195: stloc.s 21
-				IL_0197: ldloc.s 21
-				IL_0199: ldarg.2
-				IL_019a: ldloc.s 9
-				IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_01a1: stloc.s 22
-				IL_01a3: ldloc.s 22
-				IL_01a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01aa: stloc.s 25
-				IL_01ac: ldloc.s 25
-				IL_01ae: brfalse IL_01bd
+				IL_0116: ldloc.s 7
+				IL_0118: ldloc.s 8
+				IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_011f: castclass [System.Runtime]System.String
+				IL_0124: stloc.s 9
+				IL_0126: ldnull
+				IL_0127: ldarg.2
+				IL_0128: ldloc.s 9
+				IL_012a: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+				IL_012f: stloc.s 21
+				IL_0131: ldloc.s 21
+				IL_0133: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0138: stloc.s 24
+				IL_013a: ldloc.s 24
+				IL_013c: brfalse IL_014b
 
-				IL_01b3: ldloc.s 6
-				IL_01b5: ldloc.s 9
-				IL_01b7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_01bc: pop
+				IL_0141: ldloc.s 6
+				IL_0143: ldloc.s 9
+				IL_0145: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_014a: pop
 
-				IL_01bd: ldloc.s 8
-				IL_01bf: ldc.r8 1
-				IL_01c8: add
-				IL_01c9: stloc.s 8
-				IL_01cb: br IL_015d
+				IL_014b: ldloc.s 8
+				IL_014d: ldc.r8 1
+				IL_0156: add
+				IL_0157: stloc.s 8
+				IL_0159: br IL_00fe
 			// end loop
 
-			IL_01d0: ldstr "strict-and-non-strict"
-			IL_01d5: stloc.s 10
-			IL_01d7: ldloc.s 6
-			IL_01d9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_01de: ldc.r8 1
-			IL_01e7: ceq
-			IL_01e9: brfalse IL_02a9
+			IL_015e: ldstr "strict-and-non-strict"
+			IL_0163: stloc.s 10
+			IL_0165: ldloc.s 6
+			IL_0167: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_016c: ldc.r8 1
+			IL_0175: ceq
+			IL_0177: brfalse IL_0237
 
-			IL_01ee: ldloc.s 6
-			IL_01f0: ldc.r8 0.0
-			IL_01f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01fe: stloc.s 11
-			IL_0200: ldloc.s 11
-			IL_0202: ldstr "onlyStrict"
-			IL_0207: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_020c: stloc.s 25
-			IL_020e: ldloc.s 25
-			IL_0210: brfalse IL_0221
+			IL_017c: ldloc.s 6
+			IL_017e: ldc.r8 0.0
+			IL_0187: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_018c: stloc.s 11
+			IL_018e: ldloc.s 11
+			IL_0190: ldstr "onlyStrict"
+			IL_0195: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_019a: stloc.s 24
+			IL_019c: ldloc.s 24
+			IL_019e: brfalse IL_01af
 
-			IL_0215: ldstr "strict-only"
-			IL_021a: stloc.s 10
-			IL_021c: br IL_02a4
+			IL_01a3: ldstr "strict-only"
+			IL_01a8: stloc.s 10
+			IL_01aa: br IL_0232
 
-			IL_0221: ldloc.s 11
-			IL_0223: ldstr "noStrict"
-			IL_0228: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_022d: stloc.s 25
-			IL_022f: ldloc.s 25
-			IL_0231: box [System.Runtime]System.Boolean
-			IL_0236: stloc.s 26
-			IL_0238: ldloc.s 26
-			IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_023f: stloc.s 25
-			IL_0241: ldloc.s 25
-			IL_0243: brtrue IL_0268
+			IL_01af: ldloc.s 11
+			IL_01b1: ldstr "noStrict"
+			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01bb: stloc.s 24
+			IL_01bd: ldloc.s 24
+			IL_01bf: box [System.Runtime]System.Boolean
+			IL_01c4: stloc.s 25
+			IL_01c6: ldloc.s 25
+			IL_01c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01cd: stloc.s 24
+			IL_01cf: ldloc.s 24
+			IL_01d1: brtrue IL_01f6
 
-			IL_0248: ldloc.s 11
-			IL_024a: ldstr "raw"
-			IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0254: stloc.s 25
-			IL_0256: ldloc.s 25
-			IL_0258: box [System.Runtime]System.Boolean
-			IL_025d: stloc.s 27
-			IL_025f: ldloc.s 27
-			IL_0261: stloc.s 29
-			IL_0263: br IL_026c
+			IL_01d6: ldloc.s 11
+			IL_01d8: ldstr "raw"
+			IL_01dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01e2: stloc.s 24
+			IL_01e4: ldloc.s 24
+			IL_01e6: box [System.Runtime]System.Boolean
+			IL_01eb: stloc.s 26
+			IL_01ed: ldloc.s 26
+			IL_01ef: stloc.s 28
+			IL_01f1: br IL_01fa
 
-			IL_0268: ldloc.s 26
+			IL_01f6: ldloc.s 25
+			IL_01f8: stloc.s 28
+
+			IL_01fa: ldloc.s 28
+			IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0201: stloc.s 24
+			IL_0203: ldloc.s 24
+			IL_0205: brfalse IL_0216
+
+			IL_020a: ldstr "non-strict-only"
+			IL_020f: stloc.s 10
+			IL_0211: br IL_0232
+
+			IL_0216: ldloc.s 11
+			IL_0218: ldstr "module"
+			IL_021d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0222: stloc.s 24
+			IL_0224: ldloc.s 24
+			IL_0226: brfalse IL_0232
+
+			IL_022b: ldstr "module"
+			IL_0230: stloc.s 10
+
+			IL_0232: br IL_0255
+
+			IL_0237: ldloc.s 6
+			IL_0239: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_023e: ldc.r8 1
+			IL_0247: cgt
+			IL_0249: brfalse IL_0255
+
+			IL_024e: ldstr "conflicting-flags"
+			IL_0253: stloc.s 10
+
+			IL_0255: ldloc.1
+			IL_0256: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_025b: stloc.s 24
+			IL_025d: ldloc.s 24
+			IL_025f: brfalse IL_0275
+
+			IL_0264: ldc.i4.0
+			IL_0265: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_026a: stloc.s 29
-
 			IL_026c: ldloc.s 29
-			IL_026e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0273: stloc.s 25
-			IL_0275: ldloc.s 25
-			IL_0277: brfalse IL_0288
+			IL_026e: stloc.s 12
+			IL_0270: br IL_0286
 
-			IL_027c: ldstr "non-strict-only"
-			IL_0281: stloc.s 10
-			IL_0283: br IL_02a4
+			IL_0275: ldarg.0
+			IL_0276: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
+			IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_0280: stloc.s 21
+			IL_0282: ldloc.s 21
+			IL_0284: stloc.s 12
 
-			IL_0288: ldloc.s 11
-			IL_028a: ldstr "module"
-			IL_028f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0294: stloc.s 25
-			IL_0296: ldloc.s 25
-			IL_0298: brfalse IL_02a4
+			IL_0286: ldloc.s 12
+			IL_0288: stloc.s 13
+			IL_028a: ldloc.s 13
+			IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0291: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0296: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_029b: stloc.s 29
+			IL_029d: ldloc.s 29
+			IL_029f: stloc.s 14
+			IL_02a1: ldloc.2
+			IL_02a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02a7: stloc.s 24
+			IL_02a9: ldloc.s 24
+			IL_02ab: brfalse IL_02cd
 
-			IL_029d: ldstr "module"
-			IL_02a2: stloc.s 10
+			IL_02b0: ldloc.1
+			IL_02b1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02b6: ldc.i4.0
+			IL_02b7: ceq
+			IL_02b9: stloc.s 24
+			IL_02bb: ldloc.s 24
+			IL_02bd: box [System.Runtime]System.Boolean
+			IL_02c2: stloc.s 25
+			IL_02c4: ldloc.s 25
+			IL_02c6: stloc.s 30
+			IL_02c8: br IL_02d0
 
-			IL_02a4: br IL_02c7
+			IL_02cd: ldloc.2
+			IL_02ce: stloc.s 30
 
-			IL_02a9: ldloc.s 6
-			IL_02ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_02b0: ldc.r8 1
-			IL_02b9: cgt
-			IL_02bb: brfalse IL_02c7
+			IL_02d0: ldloc.s 30
+			IL_02d2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02d7: stloc.s 24
+			IL_02d9: ldloc.s 24
+			IL_02db: brfalse IL_0312
 
-			IL_02c0: ldstr "conflicting-flags"
-			IL_02c5: stloc.s 10
+			IL_02e0: ldarg.0
+			IL_02e1: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_02e6: stloc.s 31
+			IL_02e8: ldnull
+			IL_02e9: ldloc.s 14
+			IL_02eb: ldloc.s 31
+			IL_02ed: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_02f2: stloc.s 21
+			IL_02f4: ldloc.s 21
+			IL_02f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02fb: ldc.i4.0
+			IL_02fc: ceq
+			IL_02fe: stloc.s 24
+			IL_0300: ldloc.s 24
+			IL_0302: box [System.Runtime]System.Boolean
+			IL_0307: stloc.s 25
+			IL_0309: ldloc.s 25
+			IL_030b: stloc.s 30
+			IL_030d: br IL_0312
 
-			IL_02c7: ldloc.1
-			IL_02c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02cd: stloc.s 25
-			IL_02cf: ldloc.s 25
-			IL_02d1: brfalse IL_02e7
-
-			IL_02d6: ldc.i4.0
-			IL_02d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02dc: stloc.s 30
-			IL_02de: ldloc.s 30
-			IL_02e0: stloc.s 12
-			IL_02e2: br IL_02f8
-
-			IL_02e7: ldarg.0
-			IL_02e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
-			IL_02ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
-			IL_02f2: stloc.s 22
-			IL_02f4: ldloc.s 22
-			IL_02f6: stloc.s 12
-
-			IL_02f8: ldloc.s 12
-			IL_02fa: stloc.s 13
-			IL_02fc: ldloc.s 13
-			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0303: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0308: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
-			IL_030d: stloc.s 30
-			IL_030f: ldloc.s 30
-			IL_0311: stloc.s 14
-			IL_0313: ldloc.2
+			IL_0312: ldloc.s 30
 			IL_0314: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0319: stloc.s 25
-			IL_031b: ldloc.s 25
-			IL_031d: brfalse IL_033f
+			IL_0319: stloc.s 24
+			IL_031b: ldloc.s 24
+			IL_031d: brfalse IL_0342
 
-			IL_0322: ldloc.1
-			IL_0323: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0328: ldc.i4.0
-			IL_0329: ceq
-			IL_032b: stloc.s 25
-			IL_032d: ldloc.s 25
-			IL_032f: box [System.Runtime]System.Boolean
-			IL_0334: stloc.s 26
-			IL_0336: ldloc.s 26
-			IL_0338: stloc.s 31
-			IL_033a: br IL_0342
+			IL_0322: ldloc.s 14
+			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0329: stloc.s 21
+			IL_032b: ldarg.0
+			IL_032c: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_0331: stloc.s 31
+			IL_0333: ldloc.s 21
+			IL_0335: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_033a: ldloc.s 31
+			IL_033c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0341: pop
 
-			IL_033f: ldloc.2
-			IL_0340: stloc.s 31
+			IL_0342: ldc.r8 0.0
+			IL_034b: stloc.s 15
+			// loop start (head: IL_034d)
+				IL_034d: ldloc.s 15
+				IL_034f: stloc.s 23
+				IL_0351: ldarg.3
+				IL_0352: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0357: stloc.s 22
+				IL_0359: ldloc.s 23
+				IL_035b: ldloc.s 22
+				IL_035d: clt
+				IL_035f: brfalse IL_03be
 
-			IL_0342: ldloc.s 31
-			IL_0344: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0349: stloc.s 25
-			IL_034b: ldloc.s 25
-			IL_034d: brfalse IL_0397
+				IL_0364: ldarg.3
+				IL_0365: ldloc.s 15
+				IL_0367: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_036c: stloc.s 21
+				IL_036e: ldnull
+				IL_036f: ldloc.s 14
+				IL_0371: ldloc.s 21
+				IL_0373: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+				IL_0378: stloc.s 21
+				IL_037a: ldloc.s 21
+				IL_037c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0381: ldc.i4.0
+				IL_0382: ceq
+				IL_0384: stloc.s 24
+				IL_0386: ldloc.s 24
+				IL_0388: brfalse IL_03ab
 
-			IL_0352: ldarg.0
-			IL_0353: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0358: ldc.i4.1
-			IL_0359: newarr [System.Runtime]System.Object
-			IL_035e: dup
-			IL_035f: ldc.i4.0
-			IL_0360: ldarg.0
-			IL_0361: stelem.ref
-			IL_0362: stloc.s 21
-			IL_0364: ldarg.0
-			IL_0365: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_036a: stloc.s 32
-			IL_036c: ldloc.s 21
-			IL_036e: ldloc.s 14
-			IL_0370: ldloc.s 32
-			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0377: stloc.s 22
-			IL_0379: ldloc.s 22
-			IL_037b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0380: ldc.i4.0
-			IL_0381: ceq
-			IL_0383: stloc.s 25
-			IL_0385: ldloc.s 25
-			IL_0387: box [System.Runtime]System.Boolean
-			IL_038c: stloc.s 26
-			IL_038e: ldloc.s 26
-			IL_0390: stloc.s 31
-			IL_0392: br IL_0397
+				IL_038d: ldloc.s 14
+				IL_038f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0394: ldarg.3
+				IL_0395: ldloc.s 15
+				IL_0397: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_039c: stloc.s 21
+				IL_039e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_03a3: ldloc.s 21
+				IL_03a5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_03aa: pop
 
-			IL_0397: ldloc.s 31
-			IL_0399: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_039e: stloc.s 25
-			IL_03a0: ldloc.s 25
-			IL_03a2: brfalse IL_03c7
-
-			IL_03a7: ldloc.s 14
-			IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ae: stloc.s 22
-			IL_03b0: ldarg.0
-			IL_03b1: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_03b6: stloc.s 32
-			IL_03b8: ldloc.s 22
-			IL_03ba: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_03bf: ldloc.s 32
-			IL_03c1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_03c6: pop
-
-			IL_03c7: ldc.r8 0.0
-			IL_03d0: stloc.s 15
-			// loop start (head: IL_03d2)
-				IL_03d2: ldloc.s 15
-				IL_03d4: stloc.s 24
-				IL_03d6: ldarg.3
-				IL_03d7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-				IL_03dc: stloc.s 23
-				IL_03de: ldloc.s 24
-				IL_03e0: ldloc.s 23
-				IL_03e2: clt
-				IL_03e4: brfalse IL_0456
-
-				IL_03e9: ldarg.0
-				IL_03ea: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_03ef: ldc.i4.1
-				IL_03f0: newarr [System.Runtime]System.Object
-				IL_03f5: dup
-				IL_03f6: ldc.i4.0
-				IL_03f7: ldarg.0
-				IL_03f8: stelem.ref
-				IL_03f9: stloc.s 21
-				IL_03fb: ldarg.3
-				IL_03fc: ldloc.s 15
-				IL_03fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0403: stloc.s 22
-				IL_0405: ldloc.s 21
-				IL_0407: ldloc.s 14
-				IL_0409: ldloc.s 22
-				IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0410: stloc.s 22
-				IL_0412: ldloc.s 22
-				IL_0414: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0419: ldc.i4.0
-				IL_041a: ceq
-				IL_041c: stloc.s 25
-				IL_041e: ldloc.s 25
-				IL_0420: brfalse IL_0443
-
-				IL_0425: ldloc.s 14
-				IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_042c: ldarg.3
-				IL_042d: ldloc.s 15
-				IL_042f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0434: stloc.s 22
-				IL_0436: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_043b: ldloc.s 22
-				IL_043d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0442: pop
-
-				IL_0443: ldloc.s 15
-				IL_0445: ldc.r8 1
-				IL_044e: add
-				IL_044f: stloc.s 15
-				IL_0451: br IL_03d2
+				IL_03ab: ldloc.s 15
+				IL_03ad: ldc.r8 1
+				IL_03b6: add
+				IL_03b7: stloc.s 15
+				IL_03b9: br IL_034d
 			// end loop
 
-			IL_0456: ldarg.0
-			IL_0457: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_045c: ldc.i4.1
-			IL_045d: newarr [System.Runtime]System.Object
-			IL_0462: dup
-			IL_0463: ldc.i4.0
-			IL_0464: ldarg.0
-			IL_0465: stelem.ref
-			IL_0466: stloc.s 21
-			IL_0468: ldloc.s 21
-			IL_046a: ldarg.3
-			IL_046b: ldstr "agent.js"
-			IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0475: stloc.s 16
-			IL_0477: ldarg.0
-			IL_0478: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_047d: ldc.i4.1
-			IL_047e: newarr [System.Runtime]System.Object
-			IL_0483: dup
-			IL_0484: ldc.i4.0
-			IL_0485: ldarg.0
-			IL_0486: stelem.ref
-			IL_0487: stloc.s 21
-			IL_0489: ldloc.s 21
-			IL_048b: ldarg.2
-			IL_048c: ldstr "CanBlockIsFalse"
-			IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0496: stloc.s 22
-			IL_0498: ldloc.s 22
-			IL_049a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_049f: stloc.s 25
-			IL_04a1: ldloc.s 25
-			IL_04a3: brfalse IL_04b4
+			IL_03be: ldnull
+			IL_03bf: ldarg.3
+			IL_03c0: ldstr "agent.js"
+			IL_03c5: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_03ca: stloc.s 16
+			IL_03cc: ldnull
+			IL_03cd: ldarg.2
+			IL_03ce: ldstr "CanBlockIsFalse"
+			IL_03d3: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_03d8: stloc.s 21
+			IL_03da: ldloc.s 21
+			IL_03dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03e1: stloc.s 24
+			IL_03e3: ldloc.s 24
+			IL_03e5: brfalse IL_03f6
 
-			IL_04a8: ldstr "false"
-			IL_04ad: stloc.s 17
-			IL_04af: br IL_04fc
+			IL_03ea: ldstr "false"
+			IL_03ef: stloc.s 17
+			IL_03f1: br IL_042b
 
-			IL_04b4: ldarg.0
-			IL_04b5: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_04ba: ldc.i4.1
-			IL_04bb: newarr [System.Runtime]System.Object
-			IL_04c0: dup
-			IL_04c1: ldc.i4.0
-			IL_04c2: ldarg.0
-			IL_04c3: stelem.ref
-			IL_04c4: stloc.s 21
-			IL_04c6: ldloc.s 21
-			IL_04c8: ldarg.2
-			IL_04c9: ldstr "CanBlockIsTrue"
-			IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04d3: stloc.s 22
-			IL_04d5: ldloc.s 22
-			IL_04d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04dc: stloc.s 25
-			IL_04de: ldloc.s 25
-			IL_04e0: brfalse IL_04f1
+			IL_03f6: ldnull
+			IL_03f7: ldarg.2
+			IL_03f8: ldstr "CanBlockIsTrue"
+			IL_03fd: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_0402: stloc.s 21
+			IL_0404: ldloc.s 21
+			IL_0406: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_040b: stloc.s 24
+			IL_040d: ldloc.s 24
+			IL_040f: brfalse IL_0420
 
-			IL_04e5: ldstr "true"
-			IL_04ea: stloc.s 18
-			IL_04ec: br IL_04f8
+			IL_0414: ldstr "true"
+			IL_0419: stloc.s 18
+			IL_041b: br IL_0427
 
-			IL_04f1: ldstr "unspecified"
-			IL_04f6: stloc.s 18
+			IL_0420: ldstr "unspecified"
+			IL_0425: stloc.s 18
 
-			IL_04f8: ldloc.s 18
-			IL_04fa: stloc.s 17
+			IL_0427: ldloc.s 18
+			IL_0429: stloc.s 17
 
-			IL_04fc: ldloc.s 17
-			IL_04fe: stloc.s 19
-			IL_0500: ldloc.0
-			IL_0501: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0506: stloc.s 25
-			IL_0508: ldloc.s 25
-			IL_050a: brfalse IL_051b
+			IL_042b: ldloc.s 17
+			IL_042d: stloc.s 19
+			IL_042f: ldloc.0
+			IL_0430: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0435: stloc.s 24
+			IL_0437: ldloc.s 24
+			IL_0439: brfalse IL_044a
 
-			IL_050f: ldstr "module"
-			IL_0514: stloc.s 20
-			IL_0516: br IL_0522
+			IL_043e: ldstr "module"
+			IL_0443: stloc.s 20
+			IL_0445: br IL_0451
 
-			IL_051b: ldstr "script"
-			IL_0520: stloc.s 20
+			IL_044a: ldstr "script"
+			IL_044f: stloc.s 20
 
-			IL_0522: volatile.
-			IL_0524: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_172
-			IL_0529: brfalse IL_053f
+			IL_0451: volatile.
+			IL_0453: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_172
+			IL_0458: brfalse IL_046e
 
-			IL_052e: ldloc.s 13
-			IL_0530: ldstr "length"
-			IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_053a: br IL_0555
+			IL_045d: ldloc.s 13
+			IL_045f: ldstr "length"
+			IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0469: br IL_0484
 
-			IL_053f: ldloc.s 13
-			IL_0541: ldstr "length"
-			IL_0546: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:271"
-			IL_054b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_172
-			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_046e: ldloc.s 13
+			IL_0470: ldstr "length"
+			IL_0475: ldstr "test262/metadataParser:<TwoPhaseDummy_M45>:__js_call__:260"
+			IL_047a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_172
+			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0555: stloc.s 22
-			IL_0557: ldloc.s 22
-			IL_0559: ldc.r8 0.0
-			IL_0562: box [System.Runtime]System.Double
-			IL_0567: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThan(object, object)
-			IL_056c: stloc.s 25
-			IL_056e: ldloc.2
-			IL_056f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0574: stloc.s 34
-			IL_0576: ldloc.s 34
-			IL_0578: brtrue IL_05ac
+			IL_0484: stloc.s 21
+			IL_0486: ldloc.s 21
+			IL_0488: ldc.r8 0.0
+			IL_0491: box [System.Runtime]System.Double
+			IL_0496: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThan(object, object)
+			IL_049b: stloc.s 24
+			IL_049d: ldloc.2
+			IL_049e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04a3: stloc.s 33
+			IL_04a5: ldloc.s 33
+			IL_04a7: brtrue IL_04c8
 
-			IL_057d: ldarg.0
-			IL_057e: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0583: ldc.i4.1
-			IL_0584: newarr [System.Runtime]System.Object
-			IL_0589: dup
-			IL_058a: ldc.i4.0
-			IL_058b: ldarg.0
-			IL_058c: stelem.ref
-			IL_058d: stloc.s 21
-			IL_058f: ldarg.0
-			IL_0590: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0595: stloc.s 32
-			IL_0597: ldloc.s 21
-			IL_0599: ldarg.3
-			IL_059a: ldloc.s 32
-			IL_059c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05a1: stloc.s 22
-			IL_05a3: ldloc.s 22
-			IL_05a5: stloc.s 35
-			IL_05a7: br IL_05af
+			IL_04ac: ldarg.0
+			IL_04ad: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_04b2: stloc.s 31
+			IL_04b4: ldnull
+			IL_04b5: ldarg.3
+			IL_04b6: ldloc.s 31
+			IL_04b8: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_04bd: stloc.s 21
+			IL_04bf: ldloc.s 21
+			IL_04c1: stloc.s 34
+			IL_04c3: br IL_04cb
 
-			IL_05ac: ldloc.2
-			IL_05ad: stloc.s 35
+			IL_04c8: ldloc.2
+			IL_04c9: stloc.s 34
 
-			IL_05af: ldloc.s 16
-			IL_05b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05b6: stloc.s 34
-			IL_05b8: ldloc.s 34
-			IL_05ba: brtrue IL_05df
+			IL_04cb: ldloc.s 16
+			IL_04cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04d2: stloc.s 33
+			IL_04d4: ldloc.s 33
+			IL_04d6: brtrue IL_04fb
 
-			IL_05bf: ldloc.s 19
-			IL_05c1: ldstr "unspecified"
-			IL_05c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_05cb: stloc.s 34
-			IL_05cd: ldloc.s 34
-			IL_05cf: box [System.Runtime]System.Boolean
-			IL_05d4: stloc.s 26
-			IL_05d6: ldloc.s 26
-			IL_05d8: stloc.s 37
-			IL_05da: br IL_05e3
+			IL_04db: ldloc.s 19
+			IL_04dd: ldstr "unspecified"
+			IL_04e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_04e7: stloc.s 33
+			IL_04e9: ldloc.s 33
+			IL_04eb: box [System.Runtime]System.Boolean
+			IL_04f0: stloc.s 25
+			IL_04f2: ldloc.s 25
+			IL_04f4: stloc.s 36
+			IL_04f6: br IL_04ff
 
-			IL_05df: ldloc.s 16
-			IL_05e1: stloc.s 37
+			IL_04fb: ldloc.s 16
+			IL_04fd: stloc.s 36
 
-			IL_05e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05e8: dup
-			IL_05e9: ldstr "sourceType"
-			IL_05ee: ldloc.s 20
-			IL_05f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05f5: dup
-			IL_05f6: ldstr "strictMode"
-			IL_05fb: ldloc.s 10
-			IL_05fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0602: dup
-			IL_0603: ldstr "defaultHarnessIncludes"
-			IL_0608: ldloc.s 13
-			IL_060a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_060f: dup
-			IL_0610: ldstr "harnessIncludes"
-			IL_0615: ldloc.s 14
-			IL_0617: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_061c: dup
-			IL_061d: ldstr "requiresDefaultHarness"
-			IL_0622: ldloc.s 25
-			IL_0624: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0629: dup
-			IL_062a: ldstr "requiresAsyncHarness"
-			IL_062f: ldloc.s 35
-			IL_0631: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0636: dup
-			IL_0637: ldstr "requiresAgent"
-			IL_063c: ldloc.s 37
-			IL_063e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0643: dup
-			IL_0644: ldstr "canBlock"
-			IL_0649: ldloc.s 19
-			IL_064b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0650: dup
-			IL_0651: ldstr "isModule"
-			IL_0656: ldloc.0
-			IL_0657: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_065c: dup
-			IL_065d: ldstr "isRaw"
-			IL_0662: ldloc.1
-			IL_0663: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0668: dup
-			IL_0669: ldstr "isAsync"
-			IL_066e: ldloc.2
-			IL_066f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0674: dup
-			IL_0675: ldstr "isGenerated"
-			IL_067a: ldloc.3
-			IL_067b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0680: dup
-			IL_0681: ldstr "isNonDeterministic"
-			IL_0686: ldloc.s 4
-			IL_0688: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_068d: dup
-			IL_068e: ldstr "isFixture"
-			IL_0693: ldloc.s 5
-			IL_0695: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_069a: stloc.s 38
-			IL_069c: ldloc.s 38
-			IL_069e: ret
+			IL_04ff: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0504: dup
+			IL_0505: ldstr "sourceType"
+			IL_050a: ldloc.s 20
+			IL_050c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0511: dup
+			IL_0512: ldstr "strictMode"
+			IL_0517: ldloc.s 10
+			IL_0519: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_051e: dup
+			IL_051f: ldstr "defaultHarnessIncludes"
+			IL_0524: ldloc.s 13
+			IL_0526: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_052b: dup
+			IL_052c: ldstr "harnessIncludes"
+			IL_0531: ldloc.s 14
+			IL_0533: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0538: dup
+			IL_0539: ldstr "requiresDefaultHarness"
+			IL_053e: ldloc.s 24
+			IL_0540: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0545: dup
+			IL_0546: ldstr "requiresAsyncHarness"
+			IL_054b: ldloc.s 34
+			IL_054d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0552: dup
+			IL_0553: ldstr "requiresAgent"
+			IL_0558: ldloc.s 36
+			IL_055a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_055f: dup
+			IL_0560: ldstr "canBlock"
+			IL_0565: ldloc.s 19
+			IL_0567: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_056c: dup
+			IL_056d: ldstr "isModule"
+			IL_0572: ldloc.0
+			IL_0573: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0578: dup
+			IL_0579: ldstr "isRaw"
+			IL_057e: ldloc.1
+			IL_057f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0584: dup
+			IL_0585: ldstr "isAsync"
+			IL_058a: ldloc.2
+			IL_058b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0590: dup
+			IL_0591: ldstr "isGenerated"
+			IL_0596: ldloc.3
+			IL_0597: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_059c: dup
+			IL_059d: ldstr "isNonDeterministic"
+			IL_05a2: ldloc.s 4
+			IL_05a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05a9: dup
+			IL_05aa: ldstr "isFixture"
+			IL_05af: ldloc.s 5
+			IL_05b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05b6: stloc.s 37
+			IL_05b8: ldloc.s 37
+			IL_05ba: ret
 		} // end of method buildExecutionMetadata::__js_call__
 
 	} // end of class buildExecutionMetadata
@@ -12850,20 +12188,18 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 954 (0x3ba)
+			// Code size: 840 (0x348)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[1] object,
 				[2] object,
 				[3] bool,
-				[4] object[],
+				[4] object,
 				[5] object,
-				[6] object,
+				[6] string,
 				[7] object,
-				[8] string,
-				[9] object,
-				[10] object
+				[8] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -12889,346 +12225,276 @@
 			IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0041: stloc.3
 			IL_0042: ldloc.3
-			IL_0043: brfalse IL_008d
+			IL_0043: brfalse IL_007d
 
-			IL_0048: ldarg.0
-			IL_0049: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_004e: stloc.2
-			IL_004f: ldc.i4.1
-			IL_0050: newarr [System.Runtime]System.Object
-			IL_0055: dup
-			IL_0056: ldc.i4.0
-			IL_0057: ldarg.0
-			IL_0058: stelem.ref
-			IL_0059: stloc.s 4
-			IL_005b: ldarg.2
-			IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0061: stloc.3
-			IL_0062: ldloc.3
-			IL_0063: brtrue IL_0074
+			IL_0048: ldarg.2
+			IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_004e: stloc.3
+			IL_004f: ldloc.3
+			IL_0050: brtrue IL_0061
 
-			IL_0068: ldstr "<anonymous>"
-			IL_006d: stloc.s 6
-			IL_006f: br IL_0077
+			IL_0055: ldstr "<anonymous>"
+			IL_005a: stloc.s 5
+			IL_005c: br IL_0064
 
-			IL_0074: ldarg.2
-			IL_0075: stloc.s 6
+			IL_0061: ldarg.2
+			IL_0062: stloc.s 5
 
-			IL_0077: ldloc.2
-			IL_0078: ldloc.s 4
-			IL_007a: ldloc.0
-			IL_007b: ldstr "fixture-file"
-			IL_0080: ldloc.s 6
-			IL_0082: ldstr "Files whose names include `_FIXTURE` are support files, not standalone MVP tests."
-			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_008c: pop
+			IL_0064: ldnull
+			IL_0065: ldloc.0
+			IL_0066: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_006b: ldstr "fixture-file"
+			IL_0070: ldloc.s 5
+			IL_0072: ldstr "Files whose names include `_FIXTURE` are support files, not standalone MVP tests."
+			IL_0077: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_007c: pop
 
-			IL_008d: volatile.
-			IL_008f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_174
-			IL_0094: brfalse IL_00aa
+			IL_007d: volatile.
+			IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_174
+			IL_0084: brfalse IL_009a
 
-			IL_0099: ldarg.s execution
-			IL_009b: ldstr "isModule"
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a5: br IL_00c0
+			IL_0089: ldarg.s execution
+			IL_008b: ldstr "isModule"
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0095: br IL_00b0
 
-			IL_00aa: ldarg.s execution
-			IL_00ac: ldstr "isModule"
-			IL_00b1: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:28"
-			IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_174
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_009a: ldarg.s execution
+			IL_009c: ldstr "isModule"
+			IL_00a1: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:27"
+			IL_00a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_174
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00c0: stloc.2
-			IL_00c1: ldloc.2
-			IL_00c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00c7: stloc.3
-			IL_00c8: ldloc.3
-			IL_00c9: brfalse IL_00fa
+			IL_00b0: stloc.2
+			IL_00b1: ldloc.2
+			IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00b7: stloc.3
+			IL_00b8: ldloc.3
+			IL_00b9: brfalse IL_00da
 
-			IL_00ce: ldarg.0
-			IL_00cf: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_00d4: stloc.2
-			IL_00d5: ldc.i4.1
-			IL_00d6: newarr [System.Runtime]System.Object
-			IL_00db: dup
-			IL_00dc: ldc.i4.0
-			IL_00dd: ldarg.0
-			IL_00de: stelem.ref
-			IL_00df: stloc.s 4
-			IL_00e1: ldloc.2
-			IL_00e2: ldloc.s 4
-			IL_00e4: ldloc.0
-			IL_00e5: ldstr "module-flag"
-			IL_00ea: ldstr "flags:module"
-			IL_00ef: ldstr "Module tests are outside the plain synchronous script MVP."
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_00f9: pop
+			IL_00be: ldnull
+			IL_00bf: ldloc.0
+			IL_00c0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00c5: ldstr "module-flag"
+			IL_00ca: ldstr "flags:module"
+			IL_00cf: ldstr "Module tests are outside the plain synchronous script MVP."
+			IL_00d4: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_00d9: pop
 
-			IL_00fa: volatile.
-			IL_00fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_175
-			IL_0101: brfalse IL_0117
+			IL_00da: volatile.
+			IL_00dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_175
+			IL_00e1: brfalse IL_00f7
 
-			IL_0106: ldarg.s execution
-			IL_0108: ldstr "isRaw"
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0112: br IL_012d
+			IL_00e6: ldarg.s execution
+			IL_00e8: ldstr "isRaw"
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f2: br IL_010d
 
-			IL_0117: ldarg.s execution
-			IL_0119: ldstr "isRaw"
-			IL_011e: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:42"
-			IL_0123: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_175
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00f7: ldarg.s execution
+			IL_00f9: ldstr "isRaw"
+			IL_00fe: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:40"
+			IL_0103: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_175
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_012d: stloc.2
-			IL_012e: ldloc.2
-			IL_012f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0134: stloc.3
-			IL_0135: ldloc.3
-			IL_0136: brfalse IL_0167
+			IL_010d: stloc.2
+			IL_010e: ldloc.2
+			IL_010f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0114: stloc.3
+			IL_0115: ldloc.3
+			IL_0116: brfalse IL_0137
 
-			IL_013b: ldarg.0
-			IL_013c: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0141: stloc.2
-			IL_0142: ldc.i4.1
-			IL_0143: newarr [System.Runtime]System.Object
-			IL_0148: dup
-			IL_0149: ldc.i4.0
-			IL_014a: ldarg.0
-			IL_014b: stelem.ref
-			IL_014c: stloc.s 4
-			IL_014e: ldloc.2
-			IL_014f: ldloc.s 4
-			IL_0151: ldloc.0
-			IL_0152: ldstr "raw-flag"
-			IL_0157: ldstr "flags:raw"
-			IL_015c: ldstr "Raw tests bypass default harness injection and are outside the initial MVP."
-			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0166: pop
+			IL_011b: ldnull
+			IL_011c: ldloc.0
+			IL_011d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0122: ldstr "raw-flag"
+			IL_0127: ldstr "flags:raw"
+			IL_012c: ldstr "Raw tests bypass default harness injection and are outside the initial MVP."
+			IL_0131: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_0136: pop
 
-			IL_0167: volatile.
-			IL_0169: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_176
-			IL_016e: brfalse IL_0184
+			IL_0137: volatile.
+			IL_0139: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_176
+			IL_013e: brfalse IL_0154
 
-			IL_0173: ldarg.s execution
-			IL_0175: ldstr "requiresAsyncHarness"
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_017f: br IL_019a
+			IL_0143: ldarg.s execution
+			IL_0145: ldstr "requiresAsyncHarness"
+			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014f: br IL_016a
 
-			IL_0184: ldarg.s execution
-			IL_0186: ldstr "requiresAsyncHarness"
-			IL_018b: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:56"
-			IL_0190: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_176
-			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0154: ldarg.s execution
+			IL_0156: ldstr "requiresAsyncHarness"
+			IL_015b: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:53"
+			IL_0160: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_176
+			IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_019a: stloc.2
-			IL_019b: ldloc.2
-			IL_019c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01a1: stloc.3
-			IL_01a2: ldloc.3
-			IL_01a3: brfalse IL_01d4
+			IL_016a: stloc.2
+			IL_016b: ldloc.2
+			IL_016c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0171: stloc.3
+			IL_0172: ldloc.3
+			IL_0173: brfalse IL_0194
 
-			IL_01a8: ldarg.0
-			IL_01a9: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_01ae: stloc.2
-			IL_01af: ldc.i4.1
-			IL_01b0: newarr [System.Runtime]System.Object
-			IL_01b5: dup
-			IL_01b6: ldc.i4.0
-			IL_01b7: ldarg.0
-			IL_01b8: stelem.ref
-			IL_01b9: stloc.s 4
-			IL_01bb: ldloc.2
-			IL_01bc: ldloc.s 4
-			IL_01be: ldloc.0
-			IL_01bf: ldstr "async-requirement"
-			IL_01c4: ldstr "flags/includes"
-			IL_01c9: ldstr "Async tests and async harness requirements are outside the initial MVP."
-			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_01d3: pop
+			IL_0178: ldnull
+			IL_0179: ldloc.0
+			IL_017a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_017f: ldstr "async-requirement"
+			IL_0184: ldstr "flags/includes"
+			IL_0189: ldstr "Async tests and async harness requirements are outside the initial MVP."
+			IL_018e: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_0193: pop
 
-			IL_01d4: volatile.
-			IL_01d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_177
-			IL_01db: brfalse IL_01f1
+			IL_0194: volatile.
+			IL_0196: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_177
+			IL_019b: brfalse IL_01b1
 
-			IL_01e0: ldarg.s execution
-			IL_01e2: ldstr "requiresAgent"
-			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ec: br IL_0207
+			IL_01a0: ldarg.s execution
+			IL_01a2: ldstr "requiresAgent"
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ac: br IL_01c7
 
-			IL_01f1: ldarg.s execution
-			IL_01f3: ldstr "requiresAgent"
-			IL_01f8: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:70"
-			IL_01fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_177
-			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01b1: ldarg.s execution
+			IL_01b3: ldstr "requiresAgent"
+			IL_01b8: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:66"
+			IL_01bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_177
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0207: stloc.2
-			IL_0208: ldloc.2
-			IL_0209: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_020e: stloc.3
-			IL_020f: ldloc.3
-			IL_0210: brfalse IL_0241
+			IL_01c7: stloc.2
+			IL_01c8: ldloc.2
+			IL_01c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01ce: stloc.3
+			IL_01cf: ldloc.3
+			IL_01d0: brfalse IL_01f1
 
-			IL_0215: ldarg.0
-			IL_0216: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_021b: stloc.2
-			IL_021c: ldc.i4.1
-			IL_021d: newarr [System.Runtime]System.Object
-			IL_0222: dup
-			IL_0223: ldc.i4.0
-			IL_0224: ldarg.0
-			IL_0225: stelem.ref
-			IL_0226: stloc.s 4
-			IL_0228: ldloc.2
-			IL_0229: ldloc.s 4
-			IL_022b: ldloc.0
-			IL_022c: ldstr "agent-requirement"
-			IL_0231: ldstr "flags/includes"
-			IL_0236: ldstr "Agent-sensitive tests are outside the initial MVP."
-			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0240: pop
+			IL_01d5: ldnull
+			IL_01d6: ldloc.0
+			IL_01d7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01dc: ldstr "agent-requirement"
+			IL_01e1: ldstr "flags/includes"
+			IL_01e6: ldstr "Agent-sensitive tests are outside the initial MVP."
+			IL_01eb: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_01f0: pop
 
-			IL_0241: volatile.
-			IL_0243: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_178
-			IL_0248: brfalse IL_025e
+			IL_01f1: volatile.
+			IL_01f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_178
+			IL_01f8: brfalse IL_020e
 
-			IL_024d: ldarg.s execution
-			IL_024f: ldstr "canBlock"
-			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0259: br IL_0274
+			IL_01fd: ldarg.s execution
+			IL_01ff: ldstr "canBlock"
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0209: br IL_0224
 
-			IL_025e: ldarg.s execution
-			IL_0260: ldstr "canBlock"
-			IL_0265: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:84"
-			IL_026a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_178
-			IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_020e: ldarg.s execution
+			IL_0210: ldstr "canBlock"
+			IL_0215: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:79"
+			IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_178
+			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0274: stloc.2
-			IL_0275: ldloc.2
-			IL_0276: ldstr "unspecified"
-			IL_027b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0280: stloc.3
-			IL_0281: ldloc.3
-			IL_0282: brfalse IL_031f
+			IL_0224: stloc.2
+			IL_0225: ldloc.2
+			IL_0226: ldstr "unspecified"
+			IL_022b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0230: stloc.3
+			IL_0231: ldloc.3
+			IL_0232: brfalse IL_02bd
 
-			IL_0287: ldarg.0
-			IL_0288: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_028d: stloc.2
-			IL_028e: ldc.i4.1
-			IL_028f: newarr [System.Runtime]System.Object
-			IL_0294: dup
-			IL_0295: ldc.i4.0
-			IL_0296: ldarg.0
-			IL_0297: stelem.ref
-			IL_0298: stloc.s 4
-			IL_029a: volatile.
-			IL_029c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_179
-			IL_02a1: brfalse IL_02b7
+			IL_0237: volatile.
+			IL_0239: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_179
+			IL_023e: brfalse IL_0254
 
-			IL_02a6: ldarg.s execution
-			IL_02a8: ldstr "canBlock"
-			IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b2: br IL_02cd
+			IL_0243: ldarg.s execution
+			IL_0245: ldstr "canBlock"
+			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_024f: br IL_026a
 
-			IL_02b7: ldarg.s execution
-			IL_02b9: ldstr "canBlock"
-			IL_02be: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:95"
-			IL_02c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_179
-			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0254: ldarg.s execution
+			IL_0256: ldstr "canBlock"
+			IL_025b: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:88"
+			IL_0260: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_179
+			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02cd: stloc.s 7
-			IL_02cf: ldloc.s 7
-			IL_02d1: ldstr "true"
-			IL_02d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_02db: stloc.3
-			IL_02dc: ldloc.3
-			IL_02dd: brfalse IL_02ed
+			IL_026a: stloc.2
+			IL_026b: ldloc.2
+			IL_026c: ldstr "true"
+			IL_0271: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0276: stloc.3
+			IL_0277: ldloc.3
+			IL_0278: brfalse IL_0288
 
-			IL_02e2: ldstr "True"
-			IL_02e7: stloc.1
-			IL_02e8: br IL_02f3
+			IL_027d: ldstr "True"
+			IL_0282: stloc.1
+			IL_0283: br IL_028e
 
-			IL_02ed: ldstr "False"
-			IL_02f2: stloc.1
+			IL_0288: ldstr "False"
+			IL_028d: stloc.1
 
-			IL_02f3: ldloc.1
-			IL_02f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02f9: stloc.s 8
-			IL_02fb: ldstr "flags:CanBlockIs"
-			IL_0300: ldloc.s 8
-			IL_0302: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0307: stloc.s 8
-			IL_0309: ldloc.2
-			IL_030a: ldloc.s 4
-			IL_030c: ldloc.0
-			IL_030d: ldstr "can-block-requirement"
-			IL_0312: ldloc.s 8
-			IL_0314: ldstr "Tests requiring a specific [[CanBlock]] mode are outside the initial MVP."
-			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_031e: pop
+			IL_028e: ldloc.1
+			IL_028f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0294: stloc.s 6
+			IL_0296: ldstr "flags:CanBlockIs"
+			IL_029b: ldloc.s 6
+			IL_029d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02a2: stloc.s 6
+			IL_02a4: ldnull
+			IL_02a5: ldloc.0
+			IL_02a6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02ab: ldstr "can-block-requirement"
+			IL_02b0: ldloc.s 6
+			IL_02b2: ldstr "Tests requiring a specific [[CanBlock]] mode are outside the initial MVP."
+			IL_02b7: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_02bc: pop
 
-			IL_031f: ldarg.3
-			IL_0320: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0325: stloc.3
-			IL_0326: ldloc.3
-			IL_0327: brfalse IL_037b
+			IL_02bd: ldarg.3
+			IL_02be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02c3: stloc.3
+			IL_02c4: ldloc.3
+			IL_02c5: brfalse IL_0319
 
-			IL_032c: volatile.
-			IL_032e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_180
-			IL_0333: brfalse IL_0348
+			IL_02ca: volatile.
+			IL_02cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_180
+			IL_02d1: brfalse IL_02e6
 
-			IL_0338: ldarg.3
-			IL_0339: ldstr "phase"
-			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0343: br IL_035d
+			IL_02d6: ldarg.3
+			IL_02d7: ldstr "phase"
+			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e1: br IL_02fb
 
-			IL_0348: ldarg.3
-			IL_0349: ldstr "phase"
-			IL_034e: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:117"
-			IL_0353: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_180
-			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02e6: ldarg.3
+			IL_02e7: ldstr "phase"
+			IL_02ec: ldstr "test262/metadataParser:<TwoPhaseDummy_M46>:__js_call__:111"
+			IL_02f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_180
+			IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_035d: stloc.2
-			IL_035e: ldloc.2
-			IL_035f: ldstr "resolution"
-			IL_0364: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0369: stloc.3
-			IL_036a: ldloc.3
-			IL_036b: box [System.Runtime]System.Boolean
-			IL_0370: stloc.s 9
-			IL_0372: ldloc.s 9
-			IL_0374: stloc.s 10
-			IL_0376: br IL_037e
+			IL_02fb: stloc.2
+			IL_02fc: ldloc.2
+			IL_02fd: ldstr "resolution"
+			IL_0302: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0307: stloc.3
+			IL_0308: ldloc.3
+			IL_0309: box [System.Runtime]System.Boolean
+			IL_030e: stloc.s 7
+			IL_0310: ldloc.s 7
+			IL_0312: stloc.s 8
+			IL_0314: br IL_031c
 
-			IL_037b: ldarg.3
-			IL_037c: stloc.s 10
+			IL_0319: ldarg.3
+			IL_031a: stloc.s 8
 
-			IL_037e: ldloc.s 10
-			IL_0380: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0385: stloc.3
-			IL_0386: ldloc.3
-			IL_0387: brfalse IL_03b8
+			IL_031c: ldloc.s 8
+			IL_031e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0323: stloc.3
+			IL_0324: ldloc.3
+			IL_0325: brfalse IL_0346
 
-			IL_038c: ldarg.0
-			IL_038d: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0392: stloc.2
-			IL_0393: ldc.i4.1
-			IL_0394: newarr [System.Runtime]System.Object
-			IL_0399: dup
-			IL_039a: ldc.i4.0
-			IL_039b: ldarg.0
-			IL_039c: stelem.ref
-			IL_039d: stloc.s 4
-			IL_039f: ldloc.2
-			IL_03a0: ldloc.s 4
-			IL_03a2: ldloc.0
-			IL_03a3: ldstr "resolution-negative"
-			IL_03a8: ldstr "negative.phase"
-			IL_03ad: ldstr "Module resolution failures are outside the plain script MVP."
-			IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_03b7: pop
+			IL_032a: ldnull
+			IL_032b: ldloc.0
+			IL_032c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0331: ldstr "resolution-negative"
+			IL_0336: ldstr "negative.phase"
+			IL_033b: ldstr "Module resolution failures are outside the plain script MVP."
+			IL_0340: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_0345: pop
 
-			IL_03b8: ldloc.0
-			IL_03b9: ret
+			IL_0346: ldloc.0
+			IL_0347: ret
 		} // end of method buildMvpBlockers::__js_call__
 
 	} // end of class buildMvpBlockers
@@ -13528,7 +12794,7 @@
 				74 61 54 6f 6b 65 6e 39 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2345 (0x929)
+			// Code size: 2127 (0x84f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -13543,11 +12809,11 @@
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[10] float64,
 				[11] object,
-				[12] object,
-				[13] object,
-				[14] object,
-				[15] object,
-				[16] object,
+				[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[13] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[14] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[16] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[17] object,
 				[18] float64,
 				[19] object,
@@ -13556,22 +12822,21 @@
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] object[],
-				[26] object,
+				[25] object,
+				[26] float64,
 				[27] object,
-				[28] float64,
-				[29] object,
+				[28] string,
+				[29] float64,
 				[30] string,
-				[31] float64,
-				[32] string,
+				[31] object,
+				[32] object,
 				[33] object,
 				[34] object,
 				[35] object,
 				[36] object,
 				[37] object,
 				[38] object,
-				[39] object,
-				[40] object
+				[39] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.3
@@ -13591,835 +12856,695 @@
 
 			IL_0022: ldloc.s 23
 			IL_0024: stloc.0
-			IL_0025: ldarg.0
-			IL_0026: ldfld object Modules.test262_metadataParser/Scope::normalizePath
-			IL_002b: stloc.s 24
-			IL_002d: ldc.i4.1
-			IL_002e: newarr [System.Runtime]System.Object
-			IL_0033: dup
-			IL_0034: ldc.i4.0
-			IL_0035: ldarg.0
-			IL_0036: stelem.ref
-			IL_0037: stloc.s 25
-			IL_0039: volatile.
-			IL_003b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_181
-			IL_0040: brfalse IL_0055
+			IL_0025: volatile.
+			IL_0027: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_181
+			IL_002c: brfalse IL_0041
 
-			IL_0045: ldloc.0
-			IL_0046: ldstr "filePath"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0050: br IL_006a
+			IL_0031: ldloc.0
+			IL_0032: ldstr "filePath"
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003c: br IL_0056
 
-			IL_0055: ldloc.0
-			IL_0056: ldstr "filePath"
-			IL_005b: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:15"
-			IL_0060: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_181
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0041: ldloc.0
+			IL_0042: ldstr "filePath"
+			IL_0047: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:13"
+			IL_004c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_181
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_006a: stloc.s 26
-			IL_006c: ldloc.s 26
-			IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0073: stloc.s 20
-			IL_0075: ldloc.s 20
-			IL_0077: brtrue IL_0088
+			IL_0056: stloc.s 24
+			IL_0058: ldloc.s 24
+			IL_005a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005f: stloc.s 20
+			IL_0061: ldloc.s 20
+			IL_0063: brtrue IL_0074
 
-			IL_007c: ldstr ""
-			IL_0081: stloc.s 27
-			IL_0083: br IL_008c
+			IL_0068: ldstr ""
+			IL_006d: stloc.s 25
+			IL_006f: br IL_0078
 
-			IL_0088: ldloc.s 26
-			IL_008a: stloc.s 27
+			IL_0074: ldloc.s 24
+			IL_0076: stloc.s 25
 
-			IL_008c: ldloc.s 24
-			IL_008e: ldloc.s 25
-			IL_0090: ldloc.s 27
-			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0097: stloc.1
-			IL_0098: ldarg.0
-			IL_0099: ldfld object Modules.test262_metadataParser/Scope::getFileName
-			IL_009e: ldc.i4.1
-			IL_009f: newarr [System.Runtime]System.Object
-			IL_00a4: dup
-			IL_00a5: ldc.i4.0
-			IL_00a6: ldarg.0
-			IL_00a7: stelem.ref
-			IL_00a8: ldloc.1
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00ae: stloc.2
-			IL_00af: ldarg.0
-			IL_00b0: ldfld object Modules.test262_metadataParser/Scope::extractTest262Frontmatter
-			IL_00b5: ldc.i4.1
-			IL_00b6: newarr [System.Runtime]System.Object
-			IL_00bb: dup
-			IL_00bc: ldc.i4.0
-			IL_00bd: ldarg.0
-			IL_00be: stelem.ref
-			IL_00bf: stloc.s 25
-			IL_00c1: ldloc.s 25
-			IL_00c3: ldarg.2
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00c9: stloc.3
-			IL_00ca: ldc.i4.0
-			IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00d0: stloc.s 4
-			IL_00d2: ldloc.3
-			IL_00d3: ldc.i4.0
-			IL_00d4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00de: stloc.s 5
-			IL_00e0: ldloc.s 5
-			IL_00e2: brfalse IL_0108
+			IL_0078: ldnull
+			IL_0079: ldloc.s 25
+			IL_007b: call object Modules.test262_metadataParser/normalizePath::__js_call__(object, object)
+			IL_0080: stloc.1
+			IL_0081: ldnull
+			IL_0082: ldloc.1
+			IL_0083: call object Modules.test262_metadataParser/getFileName::__js_call__(object, object)
+			IL_0088: stloc.2
+			IL_0089: ldarg.0
+			IL_008a: castclass Modules.test262_metadataParser/Scope
+			IL_008f: ldnull
+			IL_0090: ldarg.2
+			IL_0091: call object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_0096: stloc.3
+			IL_0097: ldc.i4.0
+			IL_0098: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_009d: stloc.s 4
+			IL_009f: ldloc.3
+			IL_00a0: ldc.i4.0
+			IL_00a1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00ab: stloc.s 5
+			IL_00ad: ldloc.s 5
+			IL_00af: brfalse IL_00cc
 
-			IL_00e7: ldarg.0
-			IL_00e8: ldfld object Modules.test262_metadataParser/Scope::parseTest262Frontmatter
-			IL_00ed: ldc.i4.1
-			IL_00ee: newarr [System.Runtime]System.Object
-			IL_00f3: dup
-			IL_00f4: ldc.i4.0
-			IL_00f5: ldarg.0
-			IL_00f6: stelem.ref
-			IL_00f7: ldloc.3
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00fd: stloc.s 24
-			IL_00ff: ldloc.s 24
-			IL_0101: stloc.s 6
-			IL_0103: br IL_0113
+			IL_00b4: ldarg.0
+			IL_00b5: castclass Modules.test262_metadataParser/Scope
+			IL_00ba: ldnull
+			IL_00bb: ldloc.3
+			IL_00bc: call object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_00c1: stloc.s 24
+			IL_00c3: ldloc.s 24
+			IL_00c5: stloc.s 6
+			IL_00c7: br IL_00d7
 
-			IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_010d: stloc.s 21
-			IL_010f: ldloc.s 21
-			IL_0111: stloc.s 6
+			IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00d1: stloc.s 21
+			IL_00d3: ldloc.s 21
+			IL_00d5: stloc.s 6
 
-			IL_0113: ldloc.s 6
-			IL_0115: stloc.s 7
-			IL_0117: ldloc.s 7
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_011e: stloc.s 8
-			IL_0120: ldc.i4.0
-			IL_0121: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0126: stloc.s 9
-			IL_0128: ldc.r8 0.0
-			IL_0131: stloc.s 10
-			// loop start (head: IL_0133)
-				IL_0133: ldloc.s 10
-				IL_0135: stloc.s 28
-				IL_0137: volatile.
-				IL_0139: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_182
-				IL_013e: brfalse IL_0154
+			IL_00d7: ldloc.s 6
+			IL_00d9: stloc.s 7
+			IL_00db: ldloc.s 7
+			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_00e2: stloc.s 8
+			IL_00e4: ldc.i4.0
+			IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00ea: stloc.s 9
+			IL_00ec: ldc.r8 0.0
+			IL_00f5: stloc.s 10
+			// loop start (head: IL_00f7)
+				IL_00f7: ldloc.s 10
+				IL_00f9: stloc.s 26
+				IL_00fb: volatile.
+				IL_00fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_182
+				IL_0102: brfalse IL_0118
 
-				IL_0143: ldloc.s 8
-				IL_0145: ldstr "length"
-				IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_014f: br IL_016a
+				IL_0107: ldloc.s 8
+				IL_0109: ldstr "length"
+				IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0113: br IL_012e
 
-				IL_0154: ldloc.s 8
-				IL_0156: ldstr "length"
-				IL_015b: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:69"
-				IL_0160: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_182
-				IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0118: ldloc.s 8
+				IL_011a: ldstr "length"
+				IL_011f: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:65"
+				IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_182
+				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_016a: stloc.s 24
-				IL_016c: ldloc.s 28
-				IL_016e: box [System.Runtime]System.Double
-				IL_0173: stloc.s 29
-				IL_0175: ldloc.s 29
-				IL_0177: ldloc.s 24
-				IL_0179: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-				IL_017e: stloc.s 20
-				IL_0180: ldloc.s 20
-				IL_0182: brfalse IL_0223
+				IL_012e: stloc.s 24
+				IL_0130: ldloc.s 26
+				IL_0132: box [System.Runtime]System.Double
+				IL_0137: stloc.s 27
+				IL_0139: ldloc.s 27
+				IL_013b: ldloc.s 24
+				IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+				IL_0142: stloc.s 20
+				IL_0144: ldloc.s 20
+				IL_0146: brfalse IL_01d5
 
-				IL_0187: ldloc.s 8
-				IL_0189: ldloc.s 10
-				IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0190: stloc.s 11
-				IL_0192: ldarg.0
-				IL_0193: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
-				IL_0198: ldc.i4.1
-				IL_0199: newarr [System.Runtime]System.Object
-				IL_019e: dup
-				IL_019f: ldc.i4.0
-				IL_01a0: ldloc.s 11
-				IL_01a2: stelem.ref
-				IL_01a3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-				IL_01a8: stloc.s 28
-				IL_01aa: ldloc.s 28
-				IL_01ac: ldc.r8 0.0
-				IL_01b5: clt
-				IL_01b7: brfalse IL_0210
+				IL_014b: ldloc.s 8
+				IL_014d: ldloc.s 10
+				IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0154: stloc.s 11
+				IL_0156: ldarg.0
+				IL_0157: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
+				IL_015c: ldc.i4.1
+				IL_015d: newarr [System.Runtime]System.Object
+				IL_0162: dup
+				IL_0163: ldc.i4.0
+				IL_0164: ldloc.s 11
+				IL_0166: stelem.ref
+				IL_0167: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_016c: stloc.s 26
+				IL_016e: ldloc.s 26
+				IL_0170: ldc.r8 0.0
+				IL_0179: clt
+				IL_017b: brfalse IL_01c2
 
-				IL_01bc: ldloc.s 9
-				IL_01be: ldloc.s 11
-				IL_01c0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_01c5: pop
-				IL_01c6: ldarg.0
-				IL_01c7: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_01cc: stloc.s 24
-				IL_01ce: ldc.i4.1
-				IL_01cf: newarr [System.Runtime]System.Object
-				IL_01d4: dup
-				IL_01d5: ldc.i4.0
-				IL_01d6: ldarg.0
-				IL_01d7: stelem.ref
-				IL_01d8: stloc.s 25
-				IL_01da: ldloc.s 11
-				IL_01dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01e1: stloc.s 30
-				IL_01e3: ldstr "Unsupported frontmatter key '"
-				IL_01e8: ldloc.s 30
-				IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01ef: ldstr "'."
-				IL_01f4: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01f9: stloc.s 30
-				IL_01fb: ldloc.s 24
-				IL_01fd: ldloc.s 25
-				IL_01ff: ldloc.s 4
-				IL_0201: ldstr "unknown-frontmatter-key"
-				IL_0206: ldloc.s 11
-				IL_0208: ldloc.s 30
-				IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-				IL_020f: pop
+				IL_0180: ldloc.s 9
+				IL_0182: ldloc.s 11
+				IL_0184: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0189: pop
+				IL_018a: ldloc.s 11
+				IL_018c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0191: stloc.s 28
+				IL_0193: ldstr "Unsupported frontmatter key '"
+				IL_0198: ldloc.s 28
+				IL_019a: call string [System.Runtime]System.String::Concat(string, string)
+				IL_019f: ldstr "'."
+				IL_01a4: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01a9: stloc.s 28
+				IL_01ab: ldnull
+				IL_01ac: ldloc.s 4
+				IL_01ae: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_01b3: ldstr "unknown-frontmatter-key"
+				IL_01b8: ldloc.s 11
+				IL_01ba: ldloc.s 28
+				IL_01bc: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+				IL_01c1: pop
 
-				IL_0210: ldloc.s 10
-				IL_0212: ldc.r8 1
-				IL_021b: add
-				IL_021c: stloc.s 10
-				IL_021e: br IL_0133
+				IL_01c2: ldloc.s 10
+				IL_01c4: ldc.r8 1
+				IL_01cd: add
+				IL_01ce: stloc.s 10
+				IL_01d0: br IL_00f7
 			// end loop
 
-			IL_0223: ldarg.0
-			IL_0224: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_0229: ldc.i4.1
-			IL_022a: newarr [System.Runtime]System.Object
-			IL_022f: dup
-			IL_0230: ldc.i4.0
-			IL_0231: ldarg.0
-			IL_0232: stelem.ref
-			IL_0233: stloc.s 25
-			IL_0235: volatile.
-			IL_0237: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_183
-			IL_023c: brfalse IL_0252
+			IL_01d5: volatile.
+			IL_01d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_183
+			IL_01dc: brfalse IL_01f2
 
-			IL_0241: ldloc.s 7
-			IL_0243: ldstr "includes"
-			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_024d: br IL_0268
+			IL_01e1: ldloc.s 7
+			IL_01e3: ldstr "includes"
+			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ed: br IL_0208
 
-			IL_0252: ldloc.s 7
-			IL_0254: ldstr "includes"
-			IL_0259: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:105"
-			IL_025e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_183
-			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01f2: ldloc.s 7
+			IL_01f4: ldstr "includes"
+			IL_01f9: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:98"
+			IL_01fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_183
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0268: stloc.s 24
-			IL_026a: ldloc.s 25
-			IL_026c: ldloc.s 24
-			IL_026e: ldstr "includes"
-			IL_0273: ldloc.s 4
-			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_027a: stloc.s 12
-			IL_027c: ldarg.0
-			IL_027d: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_0282: ldc.i4.1
-			IL_0283: newarr [System.Runtime]System.Object
-			IL_0288: dup
-			IL_0289: ldc.i4.0
-			IL_028a: ldarg.0
-			IL_028b: stelem.ref
-			IL_028c: stloc.s 25
-			IL_028e: volatile.
-			IL_0290: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_184
-			IL_0295: brfalse IL_02ab
+			IL_0208: stloc.s 24
+			IL_020a: ldarg.0
+			IL_020b: castclass Modules.test262_metadataParser/Scope
+			IL_0210: ldnull
+			IL_0211: ldloc.s 24
+			IL_0213: ldstr "includes"
+			IL_0218: ldloc.s 4
+			IL_021a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_021f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0224: stloc.s 12
+			IL_0226: volatile.
+			IL_0228: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_184
+			IL_022d: brfalse IL_0243
 
-			IL_029a: ldloc.s 7
-			IL_029c: ldstr "flags"
-			IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a6: br IL_02c1
+			IL_0232: ldloc.s 7
+			IL_0234: ldstr "flags"
+			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023e: br IL_0259
 
-			IL_02ab: ldloc.s 7
-			IL_02ad: ldstr "flags"
-			IL_02b2: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:113"
-			IL_02b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_184
-			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0243: ldloc.s 7
+			IL_0245: ldstr "flags"
+			IL_024a: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:105"
+			IL_024f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_184
+			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02c1: stloc.s 24
-			IL_02c3: ldloc.s 25
-			IL_02c5: ldloc.s 24
-			IL_02c7: ldstr "flags"
-			IL_02cc: ldloc.s 4
-			IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_02d3: stloc.s 13
-			IL_02d5: ldarg.0
-			IL_02d6: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_02db: ldc.i4.1
-			IL_02dc: newarr [System.Runtime]System.Object
-			IL_02e1: dup
-			IL_02e2: ldc.i4.0
-			IL_02e3: ldarg.0
-			IL_02e4: stelem.ref
-			IL_02e5: stloc.s 25
-			IL_02e7: volatile.
-			IL_02e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_185
-			IL_02ee: brfalse IL_0304
+			IL_0259: stloc.s 24
+			IL_025b: ldarg.0
+			IL_025c: castclass Modules.test262_metadataParser/Scope
+			IL_0261: ldnull
+			IL_0262: ldloc.s 24
+			IL_0264: ldstr "flags"
+			IL_0269: ldloc.s 4
+			IL_026b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0270: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0275: stloc.s 13
+			IL_0277: volatile.
+			IL_0279: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_185
+			IL_027e: brfalse IL_0294
 
-			IL_02f3: ldloc.s 7
-			IL_02f5: ldstr "features"
-			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ff: br IL_031a
+			IL_0283: ldloc.s 7
+			IL_0285: ldstr "features"
+			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028f: br IL_02aa
 
-			IL_0304: ldloc.s 7
-			IL_0306: ldstr "features"
-			IL_030b: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:121"
-			IL_0310: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_185
-			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0294: ldloc.s 7
+			IL_0296: ldstr "features"
+			IL_029b: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:112"
+			IL_02a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_185
+			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_031a: stloc.s 24
-			IL_031c: ldloc.s 25
-			IL_031e: ldloc.s 24
-			IL_0320: ldstr "features"
-			IL_0325: ldloc.s 4
-			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_032c: stloc.s 14
-			IL_032e: ldarg.0
-			IL_032f: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_0334: ldc.i4.1
-			IL_0335: newarr [System.Runtime]System.Object
-			IL_033a: dup
-			IL_033b: ldc.i4.0
-			IL_033c: ldarg.0
-			IL_033d: stelem.ref
-			IL_033e: stloc.s 25
-			IL_0340: volatile.
-			IL_0342: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_186
-			IL_0347: brfalse IL_035d
+			IL_02aa: stloc.s 24
+			IL_02ac: ldarg.0
+			IL_02ad: castclass Modules.test262_metadataParser/Scope
+			IL_02b2: ldnull
+			IL_02b3: ldloc.s 24
+			IL_02b5: ldstr "features"
+			IL_02ba: ldloc.s 4
+			IL_02bc: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02c1: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_02c6: stloc.s 14
+			IL_02c8: volatile.
+			IL_02ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_186
+			IL_02cf: brfalse IL_02e5
 
-			IL_034c: ldloc.s 7
-			IL_034e: ldstr "locale"
-			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0358: br IL_0373
+			IL_02d4: ldloc.s 7
+			IL_02d6: ldstr "locale"
+			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e0: br IL_02fb
 
-			IL_035d: ldloc.s 7
-			IL_035f: ldstr "locale"
-			IL_0364: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:129"
-			IL_0369: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_186
-			IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02e5: ldloc.s 7
+			IL_02e7: ldstr "locale"
+			IL_02ec: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:119"
+			IL_02f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_186
+			IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0373: stloc.s 24
-			IL_0375: ldloc.s 25
-			IL_0377: ldloc.s 24
-			IL_0379: ldstr "locale"
-			IL_037e: ldloc.s 4
-			IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0385: stloc.s 15
-			IL_0387: ldarg.0
-			IL_0388: ldfld object Modules.test262_metadataParser/Scope::toStringArray
-			IL_038d: ldc.i4.1
-			IL_038e: newarr [System.Runtime]System.Object
-			IL_0393: dup
-			IL_0394: ldc.i4.0
-			IL_0395: ldarg.0
-			IL_0396: stelem.ref
-			IL_0397: stloc.s 25
-			IL_0399: volatile.
-			IL_039b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_187
-			IL_03a0: brfalse IL_03b6
+			IL_02fb: stloc.s 24
+			IL_02fd: ldarg.0
+			IL_02fe: castclass Modules.test262_metadataParser/Scope
+			IL_0303: ldnull
+			IL_0304: ldloc.s 24
+			IL_0306: ldstr "locale"
+			IL_030b: ldloc.s 4
+			IL_030d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0312: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0317: stloc.s 15
+			IL_0319: volatile.
+			IL_031b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_187
+			IL_0320: brfalse IL_0336
 
-			IL_03a5: ldloc.s 7
-			IL_03a7: ldstr "defines"
-			IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b1: br IL_03cc
+			IL_0325: ldloc.s 7
+			IL_0327: ldstr "defines"
+			IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0331: br IL_034c
 
-			IL_03b6: ldloc.s 7
-			IL_03b8: ldstr "defines"
-			IL_03bd: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:137"
-			IL_03c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_187
-			IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0336: ldloc.s 7
+			IL_0338: ldstr "defines"
+			IL_033d: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:126"
+			IL_0342: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_187
+			IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03cc: stloc.s 24
-			IL_03ce: ldloc.s 25
-			IL_03d0: ldloc.s 24
-			IL_03d2: ldstr "defines"
-			IL_03d7: ldloc.s 4
-			IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_03de: stloc.s 16
-			IL_03e0: ldarg.0
-			IL_03e1: ldfld object Modules.test262_metadataParser/Scope::normalizeNegative
-			IL_03e6: ldc.i4.1
-			IL_03e7: newarr [System.Runtime]System.Object
-			IL_03ec: dup
-			IL_03ed: ldc.i4.0
-			IL_03ee: ldarg.0
-			IL_03ef: stelem.ref
-			IL_03f0: stloc.s 25
-			IL_03f2: volatile.
-			IL_03f4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_188
-			IL_03f9: brfalse IL_040f
+			IL_034c: stloc.s 24
+			IL_034e: ldarg.0
+			IL_034f: castclass Modules.test262_metadataParser/Scope
+			IL_0354: ldnull
+			IL_0355: ldloc.s 24
+			IL_0357: ldstr "defines"
+			IL_035c: ldloc.s 4
+			IL_035e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0363: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0368: stloc.s 16
+			IL_036a: volatile.
+			IL_036c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_188
+			IL_0371: brfalse IL_0387
 
-			IL_03fe: ldloc.s 7
-			IL_0400: ldstr "negative"
-			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_040a: br IL_0425
+			IL_0376: ldloc.s 7
+			IL_0378: ldstr "negative"
+			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0382: br IL_039d
 
-			IL_040f: ldloc.s 7
-			IL_0411: ldstr "negative"
-			IL_0416: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:145"
-			IL_041b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_188
-			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0387: ldloc.s 7
+			IL_0389: ldstr "negative"
+			IL_038e: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:133"
+			IL_0393: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_188
+			IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0425: stloc.s 24
-			IL_0427: ldloc.s 25
-			IL_0429: ldloc.s 24
-			IL_042b: ldloc.s 4
-			IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0432: stloc.s 17
-			IL_0434: ldc.r8 0.0
-			IL_043d: stloc.s 18
-			// loop start (head: IL_043f)
-				IL_043f: ldloc.s 18
-				IL_0441: stloc.s 28
-				IL_0443: ldloc.s 13
-				IL_0445: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-				IL_044a: stloc.s 31
-				IL_044c: ldloc.s 28
-				IL_044e: ldloc.s 31
-				IL_0450: clt
-				IL_0452: brfalse IL_0516
+			IL_039d: stloc.s 24
+			IL_039f: ldarg.0
+			IL_03a0: castclass Modules.test262_metadataParser/Scope
+			IL_03a5: ldnull
+			IL_03a6: ldloc.s 24
+			IL_03a8: ldloc.s 4
+			IL_03aa: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_03af: call object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_03b4: stloc.s 17
+			IL_03b6: ldc.r8 0.0
+			IL_03bf: stloc.s 18
+			// loop start (head: IL_03c1)
+				IL_03c1: ldloc.s 18
+				IL_03c3: stloc.s 26
+				IL_03c5: ldloc.s 13
+				IL_03c7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_03cc: stloc.s 29
+				IL_03ce: ldloc.s 26
+				IL_03d0: ldloc.s 29
+				IL_03d2: clt
+				IL_03d4: brfalse IL_0486
 
-				IL_0457: ldarg.0
-				IL_0458: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
-				IL_045d: ldloc.s 13
-				IL_045f: ldloc.s 18
-				IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0466: stloc.s 24
-				IL_0468: ldc.i4.1
-				IL_0469: newarr [System.Runtime]System.Object
-				IL_046e: dup
-				IL_046f: ldc.i4.0
-				IL_0470: ldloc.s 24
-				IL_0472: stelem.ref
-				IL_0473: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-				IL_0478: stloc.s 31
-				IL_047a: ldloc.s 31
-				IL_047c: ldc.r8 0.0
-				IL_0485: clt
-				IL_0487: brfalse IL_0503
+				IL_03d9: ldarg.0
+				IL_03da: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
+				IL_03df: ldloc.s 13
+				IL_03e1: ldloc.s 18
+				IL_03e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_03e8: stloc.s 24
+				IL_03ea: ldc.i4.1
+				IL_03eb: newarr [System.Runtime]System.Object
+				IL_03f0: dup
+				IL_03f1: ldc.i4.0
+				IL_03f2: ldloc.s 24
+				IL_03f4: stelem.ref
+				IL_03f5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_03fa: stloc.s 29
+				IL_03fc: ldloc.s 29
+				IL_03fe: ldc.r8 0.0
+				IL_0407: clt
+				IL_0409: brfalse IL_0473
 
-				IL_048c: ldarg.0
-				IL_048d: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-				IL_0492: stloc.s 24
-				IL_0494: ldc.i4.1
-				IL_0495: newarr [System.Runtime]System.Object
-				IL_049a: dup
-				IL_049b: ldc.i4.0
-				IL_049c: ldarg.0
-				IL_049d: stelem.ref
-				IL_049e: stloc.s 25
-				IL_04a0: ldloc.s 13
-				IL_04a2: ldloc.s 18
-				IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_04a9: stloc.s 26
-				IL_04ab: ldloc.s 26
-				IL_04ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_04b2: stloc.s 30
-				IL_04b4: ldstr "flags:"
-				IL_04b9: ldloc.s 30
-				IL_04bb: call string [System.Runtime]System.String::Concat(string, string)
-				IL_04c0: stloc.s 30
-				IL_04c2: ldloc.s 13
-				IL_04c4: ldloc.s 18
-				IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_04cb: stloc.s 26
-				IL_04cd: ldloc.s 26
-				IL_04cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_04d4: stloc.s 32
-				IL_04d6: ldstr "Unsupported flag '"
-				IL_04db: ldloc.s 32
-				IL_04dd: call string [System.Runtime]System.String::Concat(string, string)
-				IL_04e2: ldstr "'."
-				IL_04e7: call string [System.Runtime]System.String::Concat(string, string)
-				IL_04ec: stloc.s 32
-				IL_04ee: ldloc.s 24
-				IL_04f0: ldloc.s 25
-				IL_04f2: ldloc.s 4
-				IL_04f4: ldstr "unknown-flag"
-				IL_04f9: ldloc.s 30
-				IL_04fb: ldloc.s 32
-				IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-				IL_0502: pop
+				IL_040e: ldloc.s 13
+				IL_0410: ldloc.s 18
+				IL_0412: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0417: stloc.s 24
+				IL_0419: ldloc.s 24
+				IL_041b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0420: stloc.s 28
+				IL_0422: ldstr "flags:"
+				IL_0427: ldloc.s 28
+				IL_0429: call string [System.Runtime]System.String::Concat(string, string)
+				IL_042e: stloc.s 28
+				IL_0430: ldloc.s 13
+				IL_0432: ldloc.s 18
+				IL_0434: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0439: stloc.s 24
+				IL_043b: ldloc.s 24
+				IL_043d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0442: stloc.s 30
+				IL_0444: ldstr "Unsupported flag '"
+				IL_0449: ldloc.s 30
+				IL_044b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0450: ldstr "'."
+				IL_0455: call string [System.Runtime]System.String::Concat(string, string)
+				IL_045a: stloc.s 30
+				IL_045c: ldnull
+				IL_045d: ldloc.s 4
+				IL_045f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0464: ldstr "unknown-flag"
+				IL_0469: ldloc.s 28
+				IL_046b: ldloc.s 30
+				IL_046d: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+				IL_0472: pop
 
-				IL_0503: ldloc.s 18
-				IL_0505: ldc.r8 1
-				IL_050e: add
-				IL_050f: stloc.s 18
-				IL_0511: br IL_043f
+				IL_0473: ldloc.s 18
+				IL_0475: ldc.r8 1
+				IL_047e: add
+				IL_047f: stloc.s 18
+				IL_0481: br IL_03c1
 			// end loop
 
-			IL_0516: ldarg.0
-			IL_0517: ldfld object Modules.test262_metadataParser/Scope::buildExecutionMetadata
-			IL_051c: ldc.i4.1
-			IL_051d: newarr [System.Runtime]System.Object
-			IL_0522: dup
-			IL_0523: ldc.i4.0
-			IL_0524: ldarg.0
-			IL_0525: stelem.ref
-			IL_0526: ldloc.s 13
-			IL_0528: ldloc.s 12
-			IL_052a: ldloc.2
-			IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0530: stloc.s 19
-			IL_0532: volatile.
-			IL_0534: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_189
-			IL_0539: brfalse IL_054f
+			IL_0486: ldarg.0
+			IL_0487: castclass Modules.test262_metadataParser/Scope
+			IL_048c: ldnull
+			IL_048d: ldloc.s 13
+			IL_048f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0494: ldloc.s 12
+			IL_0496: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_049b: ldloc.2
+			IL_049c: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+			IL_04a1: stloc.s 19
+			IL_04a3: volatile.
+			IL_04a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_189
+			IL_04aa: brfalse IL_04c0
 
-			IL_053e: ldloc.s 19
-			IL_0540: ldstr "strictMode"
-			IL_0545: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_054a: br IL_0565
+			IL_04af: ldloc.s 19
+			IL_04b1: ldstr "strictMode"
+			IL_04b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04bb: br IL_04d6
 
-			IL_054f: ldloc.s 19
-			IL_0551: ldstr "strictMode"
-			IL_0556: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:192"
-			IL_055b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_189
-			IL_0560: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04c0: ldloc.s 19
+			IL_04c2: ldstr "strictMode"
+			IL_04c7: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:179"
+			IL_04cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_189
+			IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0565: stloc.s 24
-			IL_0567: ldloc.s 24
-			IL_0569: ldstr "conflicting-flags"
-			IL_056e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0573: stloc.s 20
-			IL_0575: ldloc.s 20
-			IL_0577: brfalse IL_05ab
+			IL_04d6: stloc.s 24
+			IL_04d8: ldloc.s 24
+			IL_04da: ldstr "conflicting-flags"
+			IL_04df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_04e4: stloc.s 20
+			IL_04e6: ldloc.s 20
+			IL_04e8: brfalse IL_050a
 
-			IL_057c: ldarg.0
-			IL_057d: ldfld object Modules.test262_metadataParser/Scope::pushIssue
-			IL_0582: stloc.s 24
-			IL_0584: ldc.i4.1
-			IL_0585: newarr [System.Runtime]System.Object
-			IL_058a: dup
-			IL_058b: ldc.i4.0
-			IL_058c: ldarg.0
-			IL_058d: stelem.ref
-			IL_058e: stloc.s 25
-			IL_0590: ldloc.s 24
-			IL_0592: ldloc.s 25
-			IL_0594: ldloc.s 4
-			IL_0596: ldstr "conflicting-strictness-flags"
-			IL_059b: ldstr "flags"
-			IL_05a0: ldstr "Multiple strictness/source-type flags were declared together."
-			IL_05a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_05aa: pop
+			IL_04ed: ldnull
+			IL_04ee: ldloc.s 4
+			IL_04f0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_04f5: ldstr "conflicting-strictness-flags"
+			IL_04fa: ldstr "flags"
+			IL_04ff: ldstr "Multiple strictness/source-type flags were declared together."
+			IL_0504: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+			IL_0509: pop
 
-			IL_05ab: ldloc.1
-			IL_05ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05b1: stloc.s 20
-			IL_05b3: ldloc.s 20
-			IL_05b5: brtrue IL_05c7
+			IL_050a: ldloc.1
+			IL_050b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0510: stloc.s 20
+			IL_0512: ldloc.s 20
+			IL_0514: brtrue IL_0526
 
-			IL_05ba: ldc.i4.0
-			IL_05bb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_05c0: stloc.s 33
-			IL_05c2: br IL_05ca
+			IL_0519: ldc.i4.0
+			IL_051a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_051f: stloc.s 31
+			IL_0521: br IL_0529
 
-			IL_05c7: ldloc.1
-			IL_05c8: stloc.s 33
+			IL_0526: ldloc.1
+			IL_0527: stloc.s 31
 
-			IL_05ca: ldloc.2
-			IL_05cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05d0: stloc.s 20
-			IL_05d2: ldloc.s 20
-			IL_05d4: brtrue IL_05e6
+			IL_0529: ldloc.2
+			IL_052a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_052f: stloc.s 20
+			IL_0531: ldloc.s 20
+			IL_0533: brtrue IL_0545
 
-			IL_05d9: ldc.i4.0
-			IL_05da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_05df: stloc.s 35
-			IL_05e1: br IL_05e9
+			IL_0538: ldc.i4.0
+			IL_0539: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_053e: stloc.s 33
+			IL_0540: br IL_0548
 
-			IL_05e6: ldloc.2
-			IL_05e7: stloc.s 35
+			IL_0545: ldloc.2
+			IL_0546: stloc.s 33
 
-			IL_05e9: ldarg.0
-			IL_05ea: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_05ef: ldc.i4.1
-			IL_05f0: newarr [System.Runtime]System.Object
-			IL_05f5: dup
-			IL_05f6: ldc.i4.0
-			IL_05f7: ldarg.0
-			IL_05f8: stelem.ref
-			IL_05f9: stloc.s 25
-			IL_05fb: volatile.
-			IL_05fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_190
-			IL_0602: brfalse IL_0618
+			IL_0548: volatile.
+			IL_054a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_190
+			IL_054f: brfalse IL_0565
+
+			IL_0554: ldloc.s 7
+			IL_0556: ldstr "description"
+			IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0560: br IL_057b
+
+			IL_0565: ldloc.s 7
+			IL_0567: ldstr "description"
+			IL_056c: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:210"
+			IL_0571: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_190
+			IL_0576: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_057b: stloc.s 24
+			IL_057d: ldarg.0
+			IL_057e: castclass Modules.test262_metadataParser/Scope
+			IL_0583: ldnull
+			IL_0584: ldloc.s 24
+			IL_0586: ldstr "description"
+			IL_058b: ldloc.s 4
+			IL_058d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0592: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0597: stloc.s 24
+			IL_0599: volatile.
+			IL_059b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_191
+			IL_05a0: brfalse IL_05b6
+
+			IL_05a5: ldloc.s 7
+			IL_05a7: ldstr "info"
+			IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b1: br IL_05cc
+
+			IL_05b6: ldloc.s 7
+			IL_05b8: ldstr "info"
+			IL_05bd: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:215"
+			IL_05c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_191
+			IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_05cc: stloc.s 34
+			IL_05ce: ldarg.0
+			IL_05cf: castclass Modules.test262_metadataParser/Scope
+			IL_05d4: ldnull
+			IL_05d5: ldloc.s 34
+			IL_05d7: ldstr "info"
+			IL_05dc: ldloc.s 4
+			IL_05de: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_05e3: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_05e8: stloc.s 34
+			IL_05ea: volatile.
+			IL_05ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_192
+			IL_05f1: brfalse IL_0607
+
+			IL_05f6: ldloc.s 7
+			IL_05f8: ldstr "esid"
+			IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0602: br IL_061d
 
 			IL_0607: ldloc.s 7
-			IL_0609: ldstr "description"
-			IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0613: br IL_062e
+			IL_0609: ldstr "esid"
+			IL_060e: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:220"
+			IL_0613: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_192
+			IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0618: ldloc.s 7
-			IL_061a: ldstr "description"
-			IL_061f: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:226"
-			IL_0624: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_190
-			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_061d: stloc.s 35
+			IL_061f: ldarg.0
+			IL_0620: castclass Modules.test262_metadataParser/Scope
+			IL_0625: ldnull
+			IL_0626: ldloc.s 35
+			IL_0628: ldstr "esid"
+			IL_062d: ldloc.s 4
+			IL_062f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0634: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0639: stloc.s 35
+			IL_063b: volatile.
+			IL_063d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_193
+			IL_0642: brfalse IL_0658
 
-			IL_062e: stloc.s 24
-			IL_0630: ldloc.s 25
-			IL_0632: ldloc.s 24
-			IL_0634: ldstr "description"
-			IL_0639: ldloc.s 4
-			IL_063b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0640: stloc.s 24
-			IL_0642: ldarg.0
-			IL_0643: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_0648: ldc.i4.1
-			IL_0649: newarr [System.Runtime]System.Object
-			IL_064e: dup
-			IL_064f: ldc.i4.0
-			IL_0650: ldarg.0
-			IL_0651: stelem.ref
-			IL_0652: stloc.s 25
-			IL_0654: volatile.
-			IL_0656: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_191
-			IL_065b: brfalse IL_0671
+			IL_0647: ldloc.s 7
+			IL_0649: ldstr "es5id"
+			IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0653: br IL_066e
 
-			IL_0660: ldloc.s 7
-			IL_0662: ldstr "info"
-			IL_0667: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_066c: br IL_0687
+			IL_0658: ldloc.s 7
+			IL_065a: ldstr "es5id"
+			IL_065f: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:225"
+			IL_0664: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_193
+			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0671: ldloc.s 7
-			IL_0673: ldstr "info"
-			IL_0678: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:232"
-			IL_067d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_191
-			IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_066e: stloc.s 36
+			IL_0670: ldarg.0
+			IL_0671: castclass Modules.test262_metadataParser/Scope
+			IL_0676: ldnull
+			IL_0677: ldloc.s 36
+			IL_0679: ldstr "es5id"
+			IL_067e: ldloc.s 4
+			IL_0680: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0685: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_068a: stloc.s 36
+			IL_068c: volatile.
+			IL_068e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_194
+			IL_0693: brfalse IL_06a9
 
-			IL_0687: stloc.s 26
-			IL_0689: ldloc.s 25
-			IL_068b: ldloc.s 26
-			IL_068d: ldstr "info"
-			IL_0692: ldloc.s 4
-			IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0699: stloc.s 26
-			IL_069b: ldarg.0
-			IL_069c: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_06a1: ldc.i4.1
-			IL_06a2: newarr [System.Runtime]System.Object
-			IL_06a7: dup
-			IL_06a8: ldc.i4.0
-			IL_06a9: ldarg.0
-			IL_06aa: stelem.ref
-			IL_06ab: stloc.s 25
-			IL_06ad: volatile.
-			IL_06af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_192
-			IL_06b4: brfalse IL_06ca
+			IL_0698: ldloc.s 7
+			IL_069a: ldstr "es6id"
+			IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06a4: br IL_06bf
 
-			IL_06b9: ldloc.s 7
-			IL_06bb: ldstr "esid"
-			IL_06c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06c5: br IL_06e0
+			IL_06a9: ldloc.s 7
+			IL_06ab: ldstr "es6id"
+			IL_06b0: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:230"
+			IL_06b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_194
+			IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06ca: ldloc.s 7
-			IL_06cc: ldstr "esid"
-			IL_06d1: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:238"
-			IL_06d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_192
-			IL_06db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06bf: stloc.s 37
+			IL_06c1: ldarg.0
+			IL_06c2: castclass Modules.test262_metadataParser/Scope
+			IL_06c7: ldnull
+			IL_06c8: ldloc.s 37
+			IL_06ca: ldstr "es6id"
+			IL_06cf: ldloc.s 4
+			IL_06d1: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_06d6: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_06db: stloc.s 37
+			IL_06dd: volatile.
+			IL_06df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_195
+			IL_06e4: brfalse IL_06fa
 
-			IL_06e0: stloc.s 36
-			IL_06e2: ldloc.s 25
-			IL_06e4: ldloc.s 36
-			IL_06e6: ldstr "esid"
-			IL_06eb: ldloc.s 4
-			IL_06ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_06f2: stloc.s 36
-			IL_06f4: ldarg.0
-			IL_06f5: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_06fa: ldc.i4.1
-			IL_06fb: newarr [System.Runtime]System.Object
-			IL_0700: dup
-			IL_0701: ldc.i4.0
-			IL_0702: ldarg.0
-			IL_0703: stelem.ref
-			IL_0704: stloc.s 25
-			IL_0706: volatile.
-			IL_0708: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_193
-			IL_070d: brfalse IL_0723
+			IL_06e9: ldloc.s 7
+			IL_06eb: ldstr "author"
+			IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06f5: br IL_0710
 
-			IL_0712: ldloc.s 7
-			IL_0714: ldstr "es5id"
-			IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_071e: br IL_0739
+			IL_06fa: ldloc.s 7
+			IL_06fc: ldstr "author"
+			IL_0701: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:235"
+			IL_0706: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_195
+			IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0723: ldloc.s 7
-			IL_0725: ldstr "es5id"
-			IL_072a: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:244"
-			IL_072f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_193
-			IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0739: stloc.s 37
-			IL_073b: ldloc.s 25
-			IL_073d: ldloc.s 37
-			IL_073f: ldstr "es5id"
-			IL_0744: ldloc.s 4
-			IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_074b: stloc.s 37
-			IL_074d: ldarg.0
-			IL_074e: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_0753: ldc.i4.1
-			IL_0754: newarr [System.Runtime]System.Object
-			IL_0759: dup
-			IL_075a: ldc.i4.0
-			IL_075b: ldarg.0
-			IL_075c: stelem.ref
-			IL_075d: stloc.s 25
-			IL_075f: volatile.
-			IL_0761: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_194
-			IL_0766: brfalse IL_077c
-
-			IL_076b: ldloc.s 7
-			IL_076d: ldstr "es6id"
-			IL_0772: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0777: br IL_0792
-
-			IL_077c: ldloc.s 7
-			IL_077e: ldstr "es6id"
-			IL_0783: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:250"
-			IL_0788: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_194
-			IL_078d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_0792: stloc.s 38
-			IL_0794: ldloc.s 25
-			IL_0796: ldloc.s 38
-			IL_0798: ldstr "es6id"
-			IL_079d: ldloc.s 4
-			IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_07a4: stloc.s 38
-			IL_07a6: ldarg.0
-			IL_07a7: ldfld object Modules.test262_metadataParser/Scope::toNullableString
-			IL_07ac: ldc.i4.1
-			IL_07ad: newarr [System.Runtime]System.Object
-			IL_07b2: dup
-			IL_07b3: ldc.i4.0
-			IL_07b4: ldarg.0
-			IL_07b5: stelem.ref
-			IL_07b6: stloc.s 25
-			IL_07b8: volatile.
-			IL_07ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_195
-			IL_07bf: brfalse IL_07d5
-
-			IL_07c4: ldloc.s 7
-			IL_07c6: ldstr "author"
-			IL_07cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07d0: br IL_07eb
-
-			IL_07d5: ldloc.s 7
-			IL_07d7: ldstr "author"
-			IL_07dc: ldstr "test262/metadataParser:<TwoPhaseDummy_M47>:__js_call__:256"
-			IL_07e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_195
-			IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_07eb: stloc.s 39
-			IL_07ed: ldloc.s 25
-			IL_07ef: ldloc.s 39
-			IL_07f1: ldstr "author"
-			IL_07f6: ldloc.s 4
-			IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_07fd: stloc.s 39
-			IL_07ff: ldarg.0
-			IL_0800: ldfld object Modules.test262_metadataParser/Scope::buildMvpBlockers
-			IL_0805: ldc.i4.1
-			IL_0806: newarr [System.Runtime]System.Object
-			IL_080b: dup
-			IL_080c: ldc.i4.0
-			IL_080d: ldarg.0
-			IL_080e: stelem.ref
-			IL_080f: ldloc.1
-			IL_0810: ldloc.s 17
-			IL_0812: ldloc.s 19
-			IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0819: stloc.s 40
-			IL_081b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0820: dup
-			IL_0821: ldstr "filePath"
-			IL_0826: ldloc.s 33
-			IL_0828: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_082d: dup
-			IL_082e: ldstr "fileName"
-			IL_0833: ldloc.s 35
-			IL_0835: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_083a: dup
-			IL_083b: ldstr "hasFrontmatter"
-			IL_0840: ldloc.s 5
-			IL_0842: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0847: dup
-			IL_0848: ldstr "frontmatter"
-			IL_084d: ldloc.s 7
-			IL_084f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0854: dup
-			IL_0855: ldstr "unknownKeys"
-			IL_085a: ldloc.s 9
-			IL_085c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0861: dup
-			IL_0862: ldstr "description"
-			IL_0867: ldloc.s 24
-			IL_0869: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_086e: dup
-			IL_086f: ldstr "info"
-			IL_0874: ldloc.s 26
-			IL_0876: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_087b: dup
-			IL_087c: ldstr "esid"
-			IL_0881: ldloc.s 36
-			IL_0883: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0888: dup
-			IL_0889: ldstr "es5id"
-			IL_088e: ldloc.s 37
-			IL_0890: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0895: dup
-			IL_0896: ldstr "es6id"
-			IL_089b: ldloc.s 38
-			IL_089d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08a2: dup
-			IL_08a3: ldstr "author"
-			IL_08a8: ldloc.s 39
-			IL_08aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08af: dup
-			IL_08b0: ldstr "includes"
-			IL_08b5: ldloc.s 12
-			IL_08b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08bc: dup
-			IL_08bd: ldstr "flags"
-			IL_08c2: ldloc.s 13
-			IL_08c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08c9: dup
-			IL_08ca: ldstr "features"
-			IL_08cf: ldloc.s 14
-			IL_08d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08d6: dup
-			IL_08d7: ldstr "locale"
-			IL_08dc: ldloc.s 15
-			IL_08de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08e3: dup
-			IL_08e4: ldstr "defines"
-			IL_08e9: ldloc.s 16
-			IL_08eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08f0: dup
-			IL_08f1: ldstr "negative"
-			IL_08f6: ldloc.s 17
-			IL_08f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_08fd: dup
-			IL_08fe: ldstr "execution"
-			IL_0903: ldloc.s 19
-			IL_0905: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_090a: dup
-			IL_090b: ldstr "mvpBlockers"
-			IL_0910: ldloc.s 40
-			IL_0912: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0917: dup
-			IL_0918: ldstr "unsupported"
-			IL_091d: ldloc.s 4
-			IL_091f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0924: stloc.s 21
-			IL_0926: ldloc.s 21
-			IL_0928: ret
+			IL_0710: stloc.s 38
+			IL_0712: ldarg.0
+			IL_0713: castclass Modules.test262_metadataParser/Scope
+			IL_0718: ldnull
+			IL_0719: ldloc.s 38
+			IL_071b: ldstr "author"
+			IL_0720: ldloc.s 4
+			IL_0722: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0727: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_072c: stloc.s 38
+			IL_072e: ldarg.0
+			IL_072f: castclass Modules.test262_metadataParser/Scope
+			IL_0734: ldnull
+			IL_0735: ldloc.1
+			IL_0736: ldloc.s 17
+			IL_0738: ldloc.s 19
+			IL_073a: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_073f: stloc.s 39
+			IL_0741: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0746: dup
+			IL_0747: ldstr "filePath"
+			IL_074c: ldloc.s 31
+			IL_074e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0753: dup
+			IL_0754: ldstr "fileName"
+			IL_0759: ldloc.s 33
+			IL_075b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0760: dup
+			IL_0761: ldstr "hasFrontmatter"
+			IL_0766: ldloc.s 5
+			IL_0768: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_076d: dup
+			IL_076e: ldstr "frontmatter"
+			IL_0773: ldloc.s 7
+			IL_0775: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_077a: dup
+			IL_077b: ldstr "unknownKeys"
+			IL_0780: ldloc.s 9
+			IL_0782: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0787: dup
+			IL_0788: ldstr "description"
+			IL_078d: ldloc.s 24
+			IL_078f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0794: dup
+			IL_0795: ldstr "info"
+			IL_079a: ldloc.s 34
+			IL_079c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_07a1: dup
+			IL_07a2: ldstr "esid"
+			IL_07a7: ldloc.s 35
+			IL_07a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_07ae: dup
+			IL_07af: ldstr "es5id"
+			IL_07b4: ldloc.s 36
+			IL_07b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_07bb: dup
+			IL_07bc: ldstr "es6id"
+			IL_07c1: ldloc.s 37
+			IL_07c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_07c8: dup
+			IL_07c9: ldstr "author"
+			IL_07ce: ldloc.s 38
+			IL_07d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_07d5: dup
+			IL_07d6: ldstr "includes"
+			IL_07db: ldloc.s 12
+			IL_07dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_07e2: dup
+			IL_07e3: ldstr "flags"
+			IL_07e8: ldloc.s 13
+			IL_07ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_07ef: dup
+			IL_07f0: ldstr "features"
+			IL_07f5: ldloc.s 14
+			IL_07f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_07fc: dup
+			IL_07fd: ldstr "locale"
+			IL_0802: ldloc.s 15
+			IL_0804: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0809: dup
+			IL_080a: ldstr "defines"
+			IL_080f: ldloc.s 16
+			IL_0811: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0816: dup
+			IL_0817: ldstr "negative"
+			IL_081c: ldloc.s 17
+			IL_081e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0823: dup
+			IL_0824: ldstr "execution"
+			IL_0829: ldloc.s 19
+			IL_082b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0830: dup
+			IL_0831: ldstr "mvpBlockers"
+			IL_0836: ldloc.s 39
+			IL_0838: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_083d: dup
+			IL_083e: ldstr "unsupported"
+			IL_0843: ldloc.s 4
+			IL_0845: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_084a: stloc.s 21
+			IL_084c: ldloc.s 21
+			IL_084e: ret
 		} // end of method parseTest262Metadata::__js_call__
 
 	} // end of class parseTest262Metadata

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_AsArray_Ternary.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_AsArray_Ternary.verified.txt
@@ -280,7 +280,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 248 (0xf8)
+		// Code size: 230 (0xe6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_AsArray_Ternary/Scope,
@@ -312,72 +312,66 @@
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
-		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002d: stloc.s 4
-		IL_002f: ldc.i4.1
-		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0035: dup
-		IL_0036: ldc.r8 1
-		IL_003f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0044: stloc.s 5
-		IL_0046: ldloc.1
-		IL_0047: ldloc.s 4
-		IL_0049: ldloc.s 5
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0050: stloc.2
-		IL_0051: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0056: stloc.s 4
-		IL_0058: ldloc.1
-		IL_0059: ldloc.s 4
-		IL_005b: ldc.r8 0.0
-		IL_0064: box [System.Runtime]System.Double
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_006e: stloc.3
-		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0074: stloc.s 6
-		IL_0076: volatile.
-		IL_0078: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_007d: brfalse IL_0092
+		IL_0028: ldc.i4.1
+		IL_0029: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_002e: dup
+		IL_002f: ldc.r8 1
+		IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_003d: stloc.s 5
+		IL_003f: ldnull
+		IL_0040: ldloc.s 5
+		IL_0042: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
+		IL_0047: stloc.2
+		IL_0048: ldnull
+		IL_0049: ldc.r8 0.0
+		IL_0052: box [System.Runtime]System.Double
+		IL_0057: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
+		IL_005c: stloc.3
+		IL_005d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0062: stloc.s 6
+		IL_0064: volatile.
+		IL_0066: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_006b: brfalse IL_0080
 
-		IL_0082: ldloc.2
-		IL_0083: ldstr "length"
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008d: br IL_00a7
+		IL_0070: ldloc.2
+		IL_0071: ldstr "length"
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007b: br IL_0095
 
-		IL_0092: ldloc.2
-		IL_0093: ldstr "length"
-		IL_0098: ldstr "Array_AsArray_Ternary:Modules.Array_AsArray_Ternary:__js_module_init__:22"
-		IL_009d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0080: ldloc.2
+		IL_0081: ldstr "length"
+		IL_0086: ldstr "Array_AsArray_Ternary:Modules.Array_AsArray_Ternary:__js_module_init__:22"
+		IL_008b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00a7: stloc.s 7
-		IL_00a9: ldloc.s 6
-		IL_00ab: ldloc.s 7
-		IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b2: pop
-		IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b8: stloc.s 6
-		IL_00ba: volatile.
-		IL_00bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00c1: brfalse IL_00d6
+		IL_0095: stloc.s 7
+		IL_0097: ldloc.s 6
+		IL_0099: ldloc.s 7
+		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a0: pop
+		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a6: stloc.s 6
+		IL_00a8: volatile.
+		IL_00aa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00af: brfalse IL_00c4
 
-		IL_00c6: ldloc.3
-		IL_00c7: ldstr "length"
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d1: br IL_00eb
+		IL_00b4: ldloc.3
+		IL_00b5: ldstr "length"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bf: br IL_00d9
 
-		IL_00d6: ldloc.3
-		IL_00d7: ldstr "length"
-		IL_00dc: ldstr "Array_AsArray_Ternary:Modules.Array_AsArray_Ternary:__js_module_init__:27"
-		IL_00e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00c4: ldloc.3
+		IL_00c5: ldstr "length"
+		IL_00ca: ldstr "Array_AsArray_Ternary:Modules.Array_AsArray_Ternary:__js_module_init__:27"
+		IL_00cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00eb: stloc.s 7
-		IL_00ed: ldloc.s 6
-		IL_00ef: ldloc.s 7
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f6: pop
-		IL_00f7: ret
+		IL_00d9: stloc.s 7
+		IL_00db: ldloc.s 6
+		IL_00dd: ldloc.s 7
+		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e4: pop
+		IL_00e5: ret
 	} // end of method Array_AsArray_Ternary::__js_module_init__
 
 } // end of class Modules.Array_AsArray_Ternary

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
@@ -2836,10 +2836,10 @@
 		IL_1171: ldc.r8 2
 		IL_117a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_117f: stloc.s 52
-		IL_1181: ldloc.1
-		IL_1182: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1187: ldloc.s 52
-		IL_1189: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1181: ldnull
+		IL_1182: ldloc.s 52
+		IL_1184: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_1189: call object Modules.Array_Exotic_Property_Descriptors/clearArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 		IL_118e: pop
 		IL_118f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_1194: stloc.s 65

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_IntrinsicGuard_HoistedLoop.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_IntrinsicGuard_HoistedLoop.verified.txt
@@ -1637,7 +1637,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 374 (0x176)
+			// Code size: 355 (0x163)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Array_IntrinsicGuard_HoistedLoop/appendWithUnknownMutation/Scope,
@@ -1708,7 +1708,7 @@
 				IL_006e: ldloc.s 9
 				IL_0070: ldc.r8 3
 				IL_0079: clt
-				IL_007b: brfalse IL_0174
+				IL_007b: brfalse IL_0161
 
 				IL_0080: ldarg.3
 				IL_0081: box [System.Runtime]System.Boolean
@@ -1738,74 +1738,65 @@
 				IL_00c3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_00c8: stloc.s 10
 				IL_00ca: ldloc.s 10
-				IL_00cc: brfalse IL_00eb
+				IL_00cc: brfalse IL_00d8
 
-				IL_00d1: ldarg.0
-				IL_00d2: ldfld object Modules.Array_IntrinsicGuard_HoistedLoop/Scope::mutateArrayPrototype
-				IL_00d7: stloc.s 14
-				IL_00d9: ldloc.s 14
-				IL_00db: ldc.i4.1
-				IL_00dc: newarr [System.Runtime]System.Object
-				IL_00e1: dup
-				IL_00e2: ldc.i4.0
-				IL_00e3: ldarg.0
-				IL_00e4: stelem.ref
-				IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_00ea: pop
+				IL_00d1: ldnull
+				IL_00d2: call object Modules.Array_IntrinsicGuard_HoistedLoop/mutateArrayPrototype::__js_call__(object)
+				IL_00d7: pop
 
-				IL_00eb: ldloc.2
-				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00f1: stloc.s 14
-				IL_00f3: ldloc.s 4
-				IL_00f5: box [System.Runtime]System.Double
-				IL_00fa: stloc.s 15
-				IL_00fc: ldc.i4.1
-				IL_00fd: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0102: brfalse IL_014e
+				IL_00d8: ldloc.2
+				IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00de: stloc.s 14
+				IL_00e0: ldloc.s 4
+				IL_00e2: box [System.Runtime]System.Double
+				IL_00e7: stloc.s 15
+				IL_00e9: ldc.i4.1
+				IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00ef: brfalse IL_013b
 
-				IL_0107: ldloc.s 14
-				IL_0109: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_010e: dup
-				IL_010f: brfalse IL_014d
+				IL_00f4: ldloc.s 14
+				IL_00f6: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_00fb: dup
+				IL_00fc: brfalse IL_013a
 
-				IL_0114: pop
-				IL_0115: ldloc.s 14
-				IL_0117: ldstr "push"
-				IL_011c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-				IL_0121: brtrue IL_014e
+				IL_0101: pop
+				IL_0102: ldloc.s 14
+				IL_0104: ldstr "push"
+				IL_0109: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+				IL_010e: brtrue IL_013b
 
-				IL_0126: ldloc.s 14
-				IL_0128: ldc.i4.1
-				IL_0129: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_012e: brfalse IL_014e
+				IL_0113: ldloc.s 14
+				IL_0115: ldc.i4.1
+				IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_011b: brfalse IL_013b
 
-				IL_0133: ldloc.s 14
-				IL_0135: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_013a: ldloc.s 15
-				IL_013c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0141: box [System.Runtime]System.Double
-				IL_0146: stloc.s 14
-				IL_0148: br IL_015e
+				IL_0120: ldloc.s 14
+				IL_0122: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0127: ldloc.s 15
+				IL_0129: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_012e: box [System.Runtime]System.Double
+				IL_0133: stloc.s 14
+				IL_0135: br IL_014b
 
-				IL_014d: pop
+				IL_013a: pop
 
-				IL_014e: ldloc.s 14
-				IL_0150: ldstr "push"
-				IL_0155: ldloc.s 15
-				IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_015c: stloc.s 14
+				IL_013b: ldloc.s 14
+				IL_013d: ldstr "push"
+				IL_0142: ldloc.s 15
+				IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0149: stloc.s 14
 
-				IL_015e: ldloc.s 14
-				IL_0160: stloc.3
-				IL_0161: ldloc.s 4
-				IL_0163: ldc.r8 1
-				IL_016c: add
-				IL_016d: stloc.s 4
-				IL_016f: br IL_006a
+				IL_014b: ldloc.s 14
+				IL_014d: stloc.3
+				IL_014e: ldloc.s 4
+				IL_0150: ldc.r8 1
+				IL_0159: add
+				IL_015a: stloc.s 4
+				IL_015c: br IL_006a
 			// end loop
 
-			IL_0174: ldloc.3
-			IL_0175: ret
+			IL_0161: ldloc.3
+			IL_0162: ret
 		} // end of method appendWithUnknownMutation::__js_call__
 
 	} // end of class appendWithUnknownMutation
@@ -1856,7 +1847,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 666 (0x29a)
+		// Code size: 600 (0x258)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_IntrinsicGuard_HoistedLoop/Scope,
@@ -1933,175 +1924,159 @@
 		IL_0087: nop
 		IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_008d: stloc.s 6
-		IL_008f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0094: stloc.s 4
-		IL_0096: ldloc.1
-		IL_0097: ldloc.s 4
-		IL_0099: ldc.i4.1
-		IL_009a: box [System.Runtime]System.Boolean
-		IL_009f: ldstr "default"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00a9: stloc.s 7
-		IL_00ab: ldloc.s 6
-		IL_00ad: ldloc.s 7
-		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b4: pop
-		IL_00b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ba: stloc.s 6
-		IL_00bc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00c1: stloc.s 4
-		IL_00c3: ldloc.1
-		IL_00c4: ldloc.s 4
-		IL_00c6: ldc.i4.1
-		IL_00c7: box [System.Runtime]System.Boolean
-		IL_00cc: ldstr "own"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00d6: stloc.s 7
-		IL_00d8: ldloc.s 6
-		IL_00da: ldloc.s 7
-		IL_00dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e1: pop
-		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e7: stloc.s 6
-		IL_00e9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ee: stloc.s 4
-		IL_00f0: ldloc.1
-		IL_00f1: ldloc.s 4
-		IL_00f3: ldc.i4.1
-		IL_00f4: box [System.Runtime]System.Boolean
-		IL_00f9: ldstr "custom"
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0103: stloc.s 7
-		IL_0105: ldloc.s 6
-		IL_0107: ldloc.s 7
-		IL_0109: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010e: pop
-		IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0114: stloc.s 6
-		IL_0116: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_011b: stloc.s 4
-		IL_011d: ldloc.1
-		IL_011e: ldloc.s 4
-		IL_0120: ldc.i4.0
-		IL_0121: box [System.Runtime]System.Boolean
-		IL_0126: ldstr "default"
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0130: stloc.s 7
-		IL_0132: ldloc.s 6
-		IL_0134: ldloc.s 7
-		IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013b: pop
-		IL_013c: ldstr "Array"
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0146: volatile.
-		IL_0148: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_014d: brfalse IL_0161
+		IL_008f: ldloc.0
+		IL_0090: castclass Modules.Array_IntrinsicGuard_HoistedLoop/Scope
+		IL_0095: ldnull
+		IL_0096: ldc.i4.1
+		IL_0097: ldstr "default"
+		IL_009c: call object Modules.Array_IntrinsicGuard_HoistedLoop/append::__js_call__(class Modules.Array_IntrinsicGuard_HoistedLoop/Scope, object, bool, string)
+		IL_00a1: stloc.s 7
+		IL_00a3: ldloc.s 6
+		IL_00a5: ldloc.s 7
+		IL_00a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ac: pop
+		IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b2: stloc.s 6
+		IL_00b4: ldloc.0
+		IL_00b5: castclass Modules.Array_IntrinsicGuard_HoistedLoop/Scope
+		IL_00ba: ldnull
+		IL_00bb: ldc.i4.1
+		IL_00bc: ldstr "own"
+		IL_00c1: call object Modules.Array_IntrinsicGuard_HoistedLoop/append::__js_call__(class Modules.Array_IntrinsicGuard_HoistedLoop/Scope, object, bool, string)
+		IL_00c6: stloc.s 7
+		IL_00c8: ldloc.s 6
+		IL_00ca: ldloc.s 7
+		IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d1: pop
+		IL_00d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d7: stloc.s 6
+		IL_00d9: ldloc.0
+		IL_00da: castclass Modules.Array_IntrinsicGuard_HoistedLoop/Scope
+		IL_00df: ldnull
+		IL_00e0: ldc.i4.1
+		IL_00e1: ldstr "custom"
+		IL_00e6: call object Modules.Array_IntrinsicGuard_HoistedLoop/append::__js_call__(class Modules.Array_IntrinsicGuard_HoistedLoop/Scope, object, bool, string)
+		IL_00eb: stloc.s 7
+		IL_00ed: ldloc.s 6
+		IL_00ef: ldloc.s 7
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f6: pop
+		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fc: stloc.s 6
+		IL_00fe: ldloc.0
+		IL_00ff: castclass Modules.Array_IntrinsicGuard_HoistedLoop/Scope
+		IL_0104: ldnull
+		IL_0105: ldc.i4.0
+		IL_0106: ldstr "default"
+		IL_010b: call object Modules.Array_IntrinsicGuard_HoistedLoop/append::__js_call__(class Modules.Array_IntrinsicGuard_HoistedLoop/Scope, object, bool, string)
+		IL_0110: stloc.s 7
+		IL_0112: ldloc.s 6
+		IL_0114: ldloc.s 7
+		IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011b: pop
+		IL_011c: ldstr "Array"
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0126: volatile.
+		IL_0128: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_012d: brfalse IL_0141
 
-		IL_0152: ldstr "prototype"
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015c: br IL_0175
+		IL_0132: ldstr "prototype"
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013c: br IL_0155
 
-		IL_0161: ldstr "prototype"
-		IL_0166: ldstr "Array_IntrinsicGuard_HoistedLoop:Modules.Array_IntrinsicGuard_HoistedLoop:__js_module_init__:49"
-		IL_016b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0141: ldstr "prototype"
+		IL_0146: ldstr "Array_IntrinsicGuard_HoistedLoop:Modules.Array_IntrinsicGuard_HoistedLoop:__js_module_init__:49"
+		IL_014b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0175: stloc.s 7
-		IL_0177: volatile.
-		IL_0179: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_017e: brfalse IL_0194
+		IL_0155: stloc.s 7
+		IL_0157: volatile.
+		IL_0159: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_015e: brfalse IL_0174
 
-		IL_0183: ldloc.s 7
-		IL_0185: ldstr "push"
-		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018f: br IL_01aa
+		IL_0163: ldloc.s 7
+		IL_0165: ldstr "push"
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016f: br IL_018a
 
-		IL_0194: ldloc.s 7
-		IL_0196: ldstr "push"
-		IL_019b: ldstr "Array_IntrinsicGuard_HoistedLoop:Modules.Array_IntrinsicGuard_HoistedLoop:__js_module_init__:51"
-		IL_01a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0174: ldloc.s 7
+		IL_0176: ldstr "push"
+		IL_017b: ldstr "Array_IntrinsicGuard_HoistedLoop:Modules.Array_IntrinsicGuard_HoistedLoop:__js_module_init__:51"
+		IL_0180: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01aa: stloc.3
-		IL_01ab: nop
-		IL_01ac: nop
-		IL_01ad: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b2: stloc.s 4
-		IL_01b4: ldloc.2
-		IL_01b5: ldloc.s 4
-		IL_01b7: ldc.i4.0
-		IL_01b8: box [System.Runtime]System.Boolean
-		IL_01bd: ldc.i4.0
-		IL_01be: box [System.Runtime]System.Boolean
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01c8: pop
-		IL_01c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ce: stloc.s 6
-		IL_01d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01d5: stloc.s 4
-		IL_01d7: ldloc.2
-		IL_01d8: ldloc.s 4
-		IL_01da: ldc.i4.1
-		IL_01db: box [System.Runtime]System.Boolean
-		IL_01e0: ldc.i4.1
-		IL_01e1: box [System.Runtime]System.Boolean
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01eb: stloc.s 7
-		IL_01ed: ldloc.s 6
-		IL_01ef: ldloc.s 7
-		IL_01f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01f6: pop
-		IL_01f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fc: stloc.s 6
-		IL_01fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0203: stloc.s 4
-		IL_0205: ldloc.1
-		IL_0206: ldloc.s 4
-		IL_0208: ldc.i4.1
-		IL_0209: box [System.Runtime]System.Boolean
-		IL_020e: ldstr "default"
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0218: stloc.s 7
-		IL_021a: ldloc.s 6
-		IL_021c: ldloc.s 7
-		IL_021e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0223: pop
-		IL_0224: ldstr "Array"
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_022e: volatile.
-		IL_0230: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0235: brfalse IL_0249
+		IL_018a: stloc.3
+		IL_018b: nop
+		IL_018c: nop
+		IL_018d: ldloc.0
+		IL_018e: castclass Modules.Array_IntrinsicGuard_HoistedLoop/Scope
+		IL_0193: ldnull
+		IL_0194: ldc.i4.0
+		IL_0195: ldc.i4.0
+		IL_0196: call object Modules.Array_IntrinsicGuard_HoistedLoop/appendWithUnknownMutation::__js_call__(class Modules.Array_IntrinsicGuard_HoistedLoop/Scope, object, bool, bool)
+		IL_019b: pop
+		IL_019c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a1: stloc.s 6
+		IL_01a3: ldloc.0
+		IL_01a4: castclass Modules.Array_IntrinsicGuard_HoistedLoop/Scope
+		IL_01a9: ldnull
+		IL_01aa: ldc.i4.1
+		IL_01ab: ldc.i4.1
+		IL_01ac: call object Modules.Array_IntrinsicGuard_HoistedLoop/appendWithUnknownMutation::__js_call__(class Modules.Array_IntrinsicGuard_HoistedLoop/Scope, object, bool, bool)
+		IL_01b1: stloc.s 7
+		IL_01b3: ldloc.s 6
+		IL_01b5: ldloc.s 7
+		IL_01b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01bc: pop
+		IL_01bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c2: stloc.s 6
+		IL_01c4: ldloc.0
+		IL_01c5: castclass Modules.Array_IntrinsicGuard_HoistedLoop/Scope
+		IL_01ca: ldnull
+		IL_01cb: ldc.i4.1
+		IL_01cc: ldstr "default"
+		IL_01d1: call object Modules.Array_IntrinsicGuard_HoistedLoop/append::__js_call__(class Modules.Array_IntrinsicGuard_HoistedLoop/Scope, object, bool, string)
+		IL_01d6: stloc.s 7
+		IL_01d8: ldloc.s 6
+		IL_01da: ldloc.s 7
+		IL_01dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01e1: pop
+		IL_01e2: ldstr "Array"
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01ec: volatile.
+		IL_01ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01f3: brfalse IL_0207
 
-		IL_023a: ldstr "prototype"
-		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0244: br IL_025d
+		IL_01f8: ldstr "prototype"
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0202: br IL_021b
 
-		IL_0249: ldstr "prototype"
-		IL_024e: ldstr "Array_IntrinsicGuard_HoistedLoop:Modules.Array_IntrinsicGuard_HoistedLoop:__js_module_init__:83"
-		IL_0253: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0207: ldstr "prototype"
+		IL_020c: ldstr "Array_IntrinsicGuard_HoistedLoop:Modules.Array_IntrinsicGuard_HoistedLoop:__js_module_init__:83"
+		IL_0211: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_025d: stloc.s 7
-		IL_025f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0264: dup
-		IL_0265: ldstr "configurable"
-		IL_026a: ldc.i4.1
-		IL_026b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0270: dup
-		IL_0271: ldstr "writable"
-		IL_0276: ldc.i4.1
-		IL_0277: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_027c: dup
-		IL_027d: ldstr "value"
-		IL_0282: ldloc.3
-		IL_0283: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0288: stloc.s 8
-		IL_028a: ldloc.s 7
-		IL_028c: ldstr "push"
-		IL_0291: ldloc.s 8
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0298: pop
-		IL_0299: ret
+		IL_021b: stloc.s 7
+		IL_021d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0222: dup
+		IL_0223: ldstr "configurable"
+		IL_0228: ldc.i4.1
+		IL_0229: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_022e: dup
+		IL_022f: ldstr "writable"
+		IL_0234: ldc.i4.1
+		IL_0235: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_023a: dup
+		IL_023b: ldstr "value"
+		IL_0240: ldloc.3
+		IL_0241: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0246: stloc.s 8
+		IL_0248: ldloc.s 7
+		IL_024a: ldstr "push"
+		IL_024f: ldloc.s 8
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0256: pop
+		IL_0257: ret
 	} // end of method Array_IntrinsicGuard_HoistedLoop::__js_module_init__
 
 } // end of class Modules.Array_IntrinsicGuard_HoistedLoop

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -692,7 +692,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 243 (0xf3)
+		// Code size: 240 (0xf0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Map_NestedParam/Scope,
@@ -731,74 +731,73 @@
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
-		IL_0031: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0036: stloc.s 4
-		IL_0038: ldc.i4.3
-		IL_0039: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_003e: dup
-		IL_003f: ldstr "a"
-		IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0049: dup
-		IL_004a: ldstr "bb"
-		IL_004f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0054: dup
-		IL_0055: ldstr "ccc"
-		IL_005a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_005f: stloc.s 5
-		IL_0061: ldloc.1
-		IL_0062: ldloc.s 4
-		IL_0064: ldloc.s 5
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_006b: stloc.2
-		IL_006c: ldc.r8 0.0
-		IL_0075: stloc.3
-		// loop start (head: IL_0076)
-			IL_0076: ldloc.3
-			IL_0077: stloc.s 6
-			IL_0079: volatile.
-			IL_007b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_0080: brfalse IL_0095
+		IL_0031: ldc.i4.3
+		IL_0032: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0037: dup
+		IL_0038: ldstr "a"
+		IL_003d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0042: dup
+		IL_0043: ldstr "bb"
+		IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_004d: dup
+		IL_004e: ldstr "ccc"
+		IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0058: stloc.s 5
+		IL_005a: ldloc.0
+		IL_005b: castclass Modules.Array_Map_NestedParam/Scope
+		IL_0060: ldnull
+		IL_0061: ldloc.s 5
+		IL_0063: call object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
+		IL_0068: stloc.2
+		IL_0069: ldc.r8 0.0
+		IL_0072: stloc.3
+		// loop start (head: IL_0073)
+			IL_0073: ldloc.3
+			IL_0074: stloc.s 6
+			IL_0076: volatile.
+			IL_0078: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_007d: brfalse IL_0092
 
-			IL_0085: ldloc.2
-			IL_0086: ldstr "length"
-			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0090: br IL_00aa
+			IL_0082: ldloc.2
+			IL_0083: ldstr "length"
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008d: br IL_00a7
 
-			IL_0095: ldloc.2
-			IL_0096: ldstr "length"
-			IL_009b: ldstr "Array_Map_NestedParam:Modules.Array_Map_NestedParam:__js_module_init__:21"
-			IL_00a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0092: ldloc.2
+			IL_0093: ldstr "length"
+			IL_0098: ldstr "Array_Map_NestedParam:Modules.Array_Map_NestedParam:__js_module_init__:21"
+			IL_009d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00aa: stloc.s 7
-			IL_00ac: ldloc.s 6
-			IL_00ae: box [System.Runtime]System.Double
-			IL_00b3: stloc.s 8
-			IL_00b5: ldloc.s 8
-			IL_00b7: ldloc.s 7
-			IL_00b9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_00be: stloc.s 9
-			IL_00c0: ldloc.s 9
-			IL_00c2: brfalse IL_00f2
+			IL_00a7: stloc.s 7
+			IL_00a9: ldloc.s 6
+			IL_00ab: box [System.Runtime]System.Double
+			IL_00b0: stloc.s 8
+			IL_00b2: ldloc.s 8
+			IL_00b4: ldloc.s 7
+			IL_00b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_00bb: stloc.s 9
+			IL_00bd: ldloc.s 9
+			IL_00bf: brfalse IL_00ef
 
-			IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00cc: stloc.s 10
-			IL_00ce: ldloc.2
-			IL_00cf: ldloc.3
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00d5: stloc.s 7
-			IL_00d7: ldloc.s 10
-			IL_00d9: ldloc.s 7
-			IL_00db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00e0: pop
-			IL_00e1: ldloc.3
-			IL_00e2: ldc.r8 1
-			IL_00eb: add
-			IL_00ec: stloc.3
-			IL_00ed: br IL_0076
+			IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00c9: stloc.s 10
+			IL_00cb: ldloc.2
+			IL_00cc: ldloc.3
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00d2: stloc.s 7
+			IL_00d4: ldloc.s 10
+			IL_00d6: ldloc.s 7
+			IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00dd: pop
+			IL_00de: ldloc.3
+			IL_00df: ldc.r8 1
+			IL_00e8: add
+			IL_00e9: stloc.3
+			IL_00ea: br IL_0073
 		// end loop
 
-		IL_00f2: ret
+		IL_00ef: ret
 	} // end of method Array_Map_NestedParam::__js_module_init__
 
 } // end of class Modules.Array_Map_NestedParam

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
@@ -453,7 +453,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 181 (0xb5)
+		// Code size: 175 (0xaf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope,
@@ -487,48 +487,46 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.3
-		IL_0035: ldloc.1
-		IL_0036: ldloc.3
-		IL_0037: ldc.r8 10
-		IL_0040: box [System.Runtime]System.Double
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004a: stloc.2
-		IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0050: stloc.s 4
-		IL_0052: ldloc.2
-		IL_0053: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_005d: stloc.s 5
-		IL_005f: ldloc.s 4
-		IL_0061: ldstr "First increment:"
-		IL_0066: ldloc.s 5
-		IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_006d: pop
-		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.2
-		IL_0076: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0080: stloc.s 5
-		IL_0082: ldloc.s 4
-		IL_0084: ldstr "Second increment:"
-		IL_0089: ldloc.s 5
-		IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0090: pop
-		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0096: stloc.s 4
-		IL_0098: ldloc.2
-		IL_0099: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00a3: stloc.s 5
-		IL_00a5: ldloc.s 4
-		IL_00a7: ldstr "Third increment:"
-		IL_00ac: ldloc.s 5
-		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00b3: pop
-		IL_00b4: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope
+		IL_0035: ldnull
+		IL_0036: ldc.r8 10
+		IL_003f: call object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, float64)
+		IL_0044: stloc.2
+		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004a: stloc.s 4
+		IL_004c: ldloc.2
+		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0057: stloc.s 5
+		IL_0059: ldloc.s 4
+		IL_005b: ldstr "First increment:"
+		IL_0060: ldloc.s 5
+		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0067: pop
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: stloc.s 4
+		IL_006f: ldloc.2
+		IL_0070: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_007a: stloc.s 5
+		IL_007c: ldloc.s 4
+		IL_007e: ldstr "Second increment:"
+		IL_0083: ldloc.s 5
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008a: pop
+		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0090: stloc.s 4
+		IL_0092: ldloc.2
+		IL_0093: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_009d: stloc.s 5
+		IL_009f: ldloc.s 4
+		IL_00a1: ldstr "Third increment:"
+		IL_00a6: ldloc.s 5
+		IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00ad: pop
+		IL_00ae: ret
 	} // end of method ArrowFunction_ClosureMutatesOuterVariable::__js_module_init__
 
 } // end of class Modules.ArrowFunction_ClosureMutatesOuterVariable

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
@@ -328,14 +328,13 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 343 (0x157)
+			// Code size: 300 (0x12c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_Calls_Module_Function_Before_Await/main/Scope,
 				[1] object,
-				[2] object[],
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.Console
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.Console
 			)
 
 			IL_0000: ldarg.0
@@ -373,14 +372,14 @@
 			IL_0057: brtrue IL_0068
 
 			IL_005c: ldloc.0
-			IL_005d: ldc.i4.4
+			IL_005d: ldc.i4.3
 			IL_005e: newarr [System.Runtime]System.Object
 			IL_0063: stfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 
 			IL_0068: ldloc.0
 			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_006e: ldc.i4.0
-			IL_006f: ble IL_0096
+			IL_006f: ble IL_008c
 
 			IL_0074: ldloc.0
 			IL_0075: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
@@ -391,103 +390,80 @@
 			IL_007e: dup
 			IL_007f: ldc.i4.1
 			IL_0080: ldelem.ref
-			IL_0081: castclass object[]
-			IL_0086: stloc.2
-			IL_0087: dup
-			IL_0088: ldc.i4.2
-			IL_0089: ldelem.ref
+			IL_0081: stloc.2
+			IL_0082: dup
+			IL_0083: ldc.i4.2
+			IL_0084: ldelem.ref
+			IL_0085: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
 			IL_008a: stloc.3
-			IL_008b: dup
-			IL_008c: ldc.i4.3
-			IL_008d: ldelem.ref
-			IL_008e: castclass [JavaScriptRuntime]JavaScriptRuntime.Console
-			IL_0093: stloc.s 4
-			IL_0095: pop
+			IL_008b: pop
 
-			IL_0096: ldloc.0
-			IL_0097: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_009c: switch (IL_00a9, IL_0115)
+			IL_008c: ldloc.0
+			IL_008d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0092: switch (IL_009f, IL_00ec)
 
-			IL_00a9: ldarg.0
-			IL_00aa: ldc.i4.1
-			IL_00ab: ldelem.ref
-			IL_00ac: castclass Modules.Async_Calls_Module_Function_Before_Await/Scope
-			IL_00b1: ldfld object Modules.Async_Calls_Module_Function_Before_Await/Scope::formatSection
-			IL_00b6: ldc.i4.1
-			IL_00b7: newarr [System.Runtime]System.Object
-			IL_00bc: dup
-			IL_00bd: ldc.i4.0
-			IL_00be: ldarg.0
-			IL_00bf: ldc.i4.1
-			IL_00c0: ldelem.ref
-			IL_00c1: stelem.ref
-			IL_00c2: stloc.2
-			IL_00c3: ldloc.2
-			IL_00c4: ldstr "27.3"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00ce: stloc.1
-			IL_00cf: ldc.i4.0
-			IL_00d0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_00da: stloc.3
-			IL_00db: ldloc.0
-			IL_00dc: ldc.i4.1
-			IL_00dd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00e2: ldloc.0
-			IL_00e3: ldloc.3
-			IL_00e4: ldarg.0
-			IL_00e5: ldc.i4.1
-			IL_00e6: ldloc.0
-			IL_00e7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_00f1: ldloc.0
-			IL_00f2: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00f7: dup
-			IL_00f8: ldc.i4.0
-			IL_00f9: ldloc.1
-			IL_00fa: stelem.ref
-			IL_00fb: dup
-			IL_00fc: ldc.i4.1
-			IL_00fd: ldloc.2
-			IL_00fe: stelem.ref
-			IL_00ff: dup
-			IL_0100: ldc.i4.2
-			IL_0101: ldloc.3
-			IL_0102: stelem.ref
-			IL_0103: dup
-			IL_0104: ldc.i4.3
-			IL_0105: ldloc.s 4
-			IL_0107: stelem.ref
-			IL_0108: pop
-			IL_0109: ldloc.0
-			IL_010a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_010f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0114: ret
+			IL_009f: ldnull
+			IL_00a0: ldstr "27.3"
+			IL_00a5: call object Modules.Async_Calls_Module_Function_Before_Await/formatSection::__js_call__(object, string)
+			IL_00aa: stloc.1
+			IL_00ab: ldc.i4.0
+			IL_00ac: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_00b6: stloc.2
+			IL_00b7: ldloc.0
+			IL_00b8: ldc.i4.1
+			IL_00b9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00be: ldloc.0
+			IL_00bf: ldloc.2
+			IL_00c0: ldarg.0
+			IL_00c1: ldc.i4.1
+			IL_00c2: ldloc.0
+			IL_00c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_00cd: ldloc.0
+			IL_00ce: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00d3: dup
+			IL_00d4: ldc.i4.0
+			IL_00d5: ldloc.1
+			IL_00d6: stelem.ref
+			IL_00d7: dup
+			IL_00d8: ldc.i4.1
+			IL_00d9: ldloc.2
+			IL_00da: stelem.ref
+			IL_00db: dup
+			IL_00dc: ldc.i4.2
+			IL_00dd: ldloc.3
+			IL_00de: stelem.ref
+			IL_00df: pop
+			IL_00e0: ldloc.0
+			IL_00e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00eb: ret
 
-			IL_0115: ldloc.0
-			IL_0116: ldfld object Modules.Async_Calls_Module_Function_Before_Await/main/Scope::_awaited1
-			IL_011b: pop
-			IL_011c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0121: stloc.s 4
-			IL_0123: ldloc.s 4
-			IL_0125: ldloc.1
-			IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_012b: pop
-			IL_012c: ldloc.0
-			IL_012d: ldc.i4.m1
-			IL_012e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0133: ldloc.0
-			IL_0134: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_013e: ldarg.0
-			IL_013f: ldc.i4.1
-			IL_0140: newarr [System.Runtime]System.Object
-			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_014a: pop
-			IL_014b: ldloc.0
-			IL_014c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0151: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0156: ret
+			IL_00ec: ldloc.0
+			IL_00ed: ldfld object Modules.Async_Calls_Module_Function_Before_Await/main/Scope::_awaited1
+			IL_00f2: pop
+			IL_00f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00f8: stloc.3
+			IL_00f9: ldloc.3
+			IL_00fa: ldloc.1
+			IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0100: pop
+			IL_0101: ldloc.0
+			IL_0102: ldc.i4.m1
+			IL_0103: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0108: ldloc.0
+			IL_0109: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_010e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0113: ldarg.0
+			IL_0114: ldc.i4.1
+			IL_0115: newarr [System.Runtime]System.Object
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_011f: pop
+			IL_0120: ldloc.0
+			IL_0121: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0126: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_012b: ret
 		} // end of method main::__js_call__
 
 	} // end of class main

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
@@ -873,7 +873,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 181 (0xb5)
+		// Code size: 182 (0xb6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_RealSuspension_SetTimeout/Scope,
@@ -913,48 +913,49 @@
 		IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_003f: pop
 		IL_0040: nop
-		IL_0041: ldloc.1
-		IL_0042: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_004c: stloc.s 4
-		IL_004e: ldloc.s 4
-		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0055: stloc.s 4
-		IL_0057: ldc.i4.1
-		IL_0058: newarr [System.Runtime]System.Object
-		IL_005d: dup
-		IL_005e: ldc.i4.0
-		IL_005f: ldloc.0
-		IL_0060: stelem.ref
-		IL_0061: stloc.2
-		IL_0062: newobj instance void Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12/FunctionObject::.ctor()
-		IL_0067: ldc.i4.0
-		IL_0068: conv.r8
-		IL_0069: ldstr ""
-		IL_006e: ldc.i4.0
+		IL_0041: ldloc.0
+		IL_0042: castclass Modules.Async_RealSuspension_SetTimeout/Scope
+		IL_0047: ldnull
+		IL_0048: call object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
+		IL_004d: stloc.s 4
+		IL_004f: ldloc.s 4
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0056: stloc.s 4
+		IL_0058: ldc.i4.1
+		IL_0059: newarr [System.Runtime]System.Object
+		IL_005e: dup
+		IL_005f: ldc.i4.0
+		IL_0060: ldloc.0
+		IL_0061: stelem.ref
+		IL_0062: stloc.2
+		IL_0063: newobj instance void Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12/FunctionObject::.ctor()
+		IL_0068: ldc.i4.0
+		IL_0069: conv.r8
+		IL_006a: ldstr ""
 		IL_006f: ldc.i4.0
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12/FunctionObject>(!!0)
-		IL_007a: stloc.s 5
-		IL_007c: volatile.
-		IL_007e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0083: brfalse IL_009b
+		IL_0070: ldc.i4.0
+		IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12/FunctionObject>(!!0)
+		IL_007b: stloc.s 5
+		IL_007d: volatile.
+		IL_007f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0084: brfalse IL_009c
 
-		IL_0088: ldloc.s 4
-		IL_008a: ldstr "then"
-		IL_008f: ldloc.s 5
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0096: br IL_00b3
+		IL_0089: ldloc.s 4
+		IL_008b: ldstr "then"
+		IL_0090: ldloc.s 5
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0097: br IL_00b4
 
-		IL_009b: ldloc.s 4
-		IL_009d: ldstr "then"
-		IL_00a2: ldloc.s 5
-		IL_00a4: ldstr "Async_RealSuspension_SetTimeout:Modules.Async_RealSuspension_SetTimeout:__js_module_init__:17"
-		IL_00a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_009c: ldloc.s 4
+		IL_009e: ldstr "then"
+		IL_00a3: ldloc.s 5
+		IL_00a5: ldstr "Async_RealSuspension_SetTimeout:Modules.Async_RealSuspension_SetTimeout:__js_module_init__:17"
+		IL_00aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00b3: pop
-		IL_00b4: ret
+		IL_00b4: pop
+		IL_00b5: ret
 	} // end of method Async_RealSuspension_SetTimeout::__js_module_init__
 
 } // end of class Modules.Async_RealSuspension_SetTimeout

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddObjectObject.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddObjectObject.verified.txt
@@ -263,7 +263,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 138 (0x8a)
+		// Code size: 124 (0x7c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_AddObjectObject/Scope,
@@ -294,35 +294,29 @@
 		IL_0026: nop
 		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002c: stloc.3
-		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0032: stloc.2
-		IL_0033: ldloc.1
-		IL_0034: ldloc.2
-		IL_0035: ldc.r8 1
-		IL_003e: box [System.Runtime]System.Double
-		IL_0043: ldc.r8 2
-		IL_004c: box [System.Runtime]System.Double
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0056: stloc.s 4
-		IL_0058: ldloc.3
-		IL_0059: ldloc.s 4
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0060: pop
-		IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0066: stloc.3
-		IL_0067: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006c: stloc.2
-		IL_006d: ldloc.1
-		IL_006e: ldloc.2
-		IL_006f: ldstr "a:"
-		IL_0074: ldstr "b"
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_007e: stloc.s 4
-		IL_0080: ldloc.3
-		IL_0081: ldloc.s 4
-		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0088: pop
-		IL_0089: ret
+		IL_002d: ldnull
+		IL_002e: ldc.r8 1
+		IL_0037: box [System.Runtime]System.Double
+		IL_003c: ldc.r8 2
+		IL_0045: box [System.Runtime]System.Double
+		IL_004a: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
+		IL_004f: stloc.s 4
+		IL_0051: ldloc.3
+		IL_0052: ldloc.s 4
+		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0059: pop
+		IL_005a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_005f: stloc.3
+		IL_0060: ldnull
+		IL_0061: ldstr "a:"
+		IL_0066: ldstr "b"
+		IL_006b: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.3
+		IL_0073: ldloc.s 4
+		IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007a: pop
+		IL_007b: ret
 	} // end of method BinaryOperator_AddObjectObject::__js_module_init__
 
 } // end of class Modules.BinaryOperator_AddObjectObject

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualParameter.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualParameter.verified.txt
@@ -308,7 +308,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 124 (0x7c)
+		// Code size: 88 (0x58)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_EqualParameter/Scope,
@@ -335,31 +335,19 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldc.r8 3
-		IL_0038: box [System.Runtime]System.Double
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0042: pop
-		IL_0043: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0048: stloc.2
-		IL_0049: ldloc.1
-		IL_004a: ldloc.2
-		IL_004b: ldc.r8 5
-		IL_0054: box [System.Runtime]System.Double
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005e: pop
-		IL_005f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0064: stloc.2
-		IL_0065: ldloc.1
-		IL_0066: ldloc.2
-		IL_0067: ldc.r8 7
-		IL_0070: box [System.Runtime]System.Double
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_007a: pop
-		IL_007b: ret
+		IL_0027: ldnull
+		IL_0028: ldc.r8 3
+		IL_0031: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
+		IL_0036: pop
+		IL_0037: ldnull
+		IL_0038: ldc.r8 5
+		IL_0041: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
+		IL_0046: pop
+		IL_0047: ldnull
+		IL_0048: ldc.r8 7
+		IL_0051: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
+		IL_0056: pop
+		IL_0057: ret
 	} // end of method BinaryOperator_EqualParameter::__js_module_init__
 
 } // end of class Modules.BinaryOperator_EqualParameter

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
@@ -273,7 +273,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 146 (0x92)
+		// Code size: 147 (0x93)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope,
@@ -319,32 +319,33 @@
 		IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 		IL_004e: stloc.s 4
 		IL_0050: ldloc.s 4
-		IL_0052: brfalse IL_006d
+		IL_0052: brfalse IL_006e
 
-		IL_0057: ldloc.1
-		IL_0058: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0062: stloc.s 5
-		IL_0064: ldloc.s 5
-		IL_0066: stloc.s 7
-		IL_0068: br IL_0075
+		IL_0057: ldloc.0
+		IL_0058: castclass Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope
+		IL_005d: ldnull
+		IL_005e: call object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
+		IL_0063: stloc.s 5
+		IL_0065: ldloc.s 5
+		IL_0067: stloc.s 7
+		IL_0069: br IL_0076
 
-		IL_006d: ldc.i4.0
-		IL_006e: box [System.Runtime]System.Boolean
-		IL_0073: stloc.s 7
+		IL_006e: ldc.i4.0
+		IL_006f: box [System.Runtime]System.Boolean
+		IL_0074: stloc.s 7
 
-		IL_0075: ldloc.s 7
-		IL_0077: stloc.2
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: stloc.s 8
-		IL_007f: ldloc.0
-		IL_0080: ldfld object Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope::x
-		IL_0085: stloc.s 5
-		IL_0087: ldloc.s 8
-		IL_0089: ldloc.s 5
-		IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0090: pop
-		IL_0091: ret
+		IL_0076: ldloc.s 7
+		IL_0078: stloc.2
+		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007e: stloc.s 8
+		IL_0080: ldloc.0
+		IL_0081: ldfld object Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope::x
+		IL_0086: stloc.s 5
+		IL_0088: ldloc.s 8
+		IL_008a: ldloc.s 5
+		IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0091: pop
+		IL_0092: ret
 	} // end of method BinaryOperator_LogicalAnd_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalAnd_ShortCircuit

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
@@ -335,7 +335,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 196 (0xc4)
+		// Code size: 175 (0xaf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalOr_ArrayHasData/Scope,
@@ -367,59 +367,50 @@
 		IL_0026: nop
 		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002c: stloc.3
-		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0032: stloc.2
-		IL_0033: ldloc.1
-		IL_0034: ldloc.2
-		IL_0035: ldnull
-		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_003b: stloc.s 4
-		IL_003d: ldloc.3
-		IL_003e: ldloc.s 4
-		IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0045: pop
-		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004b: stloc.3
-		IL_004c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0051: stloc.2
-		IL_0052: ldc.i4.0
-		IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0058: stloc.s 5
-		IL_005a: ldloc.1
-		IL_005b: ldloc.2
-		IL_005c: ldloc.s 5
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0063: stloc.s 4
-		IL_0065: ldloc.3
-		IL_0066: ldloc.s 4
-		IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006d: pop
-		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0073: stloc.3
-		IL_0074: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0079: stloc.2
-		IL_007a: ldc.i4.3
-		IL_007b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0080: dup
-		IL_0081: ldc.r8 1
-		IL_008a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_008f: dup
-		IL_0090: ldc.r8 2
-		IL_0099: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_009e: dup
-		IL_009f: ldc.r8 3
-		IL_00a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00ad: stloc.s 5
-		IL_00af: ldloc.1
-		IL_00b0: ldloc.2
-		IL_00b1: ldloc.s 5
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00b8: stloc.s 4
-		IL_00ba: ldloc.3
-		IL_00bb: ldloc.s 4
-		IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c2: pop
-		IL_00c3: ret
+		IL_002d: ldnull
+		IL_002e: ldnull
+		IL_002f: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
+		IL_0034: stloc.s 4
+		IL_0036: ldloc.3
+		IL_0037: ldloc.s 4
+		IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_003e: pop
+		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0044: stloc.3
+		IL_0045: ldc.i4.0
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_004b: stloc.s 5
+		IL_004d: ldnull
+		IL_004e: ldloc.s 5
+		IL_0050: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
+		IL_0055: stloc.s 4
+		IL_0057: ldloc.3
+		IL_0058: ldloc.s 4
+		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005f: pop
+		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0065: stloc.3
+		IL_0066: ldc.i4.3
+		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_006c: dup
+		IL_006d: ldc.r8 1
+		IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_007b: dup
+		IL_007c: ldc.r8 2
+		IL_0085: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_008a: dup
+		IL_008b: ldc.r8 3
+		IL_0094: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0099: stloc.s 5
+		IL_009b: ldnull
+		IL_009c: ldloc.s 5
+		IL_009e: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
+		IL_00a3: stloc.s 4
+		IL_00a5: ldloc.3
+		IL_00a6: ldloc.s 4
+		IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ad: pop
+		IL_00ae: ret
 	} // end of method BinaryOperator_LogicalOr_ArrayHasData::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalOr_ArrayHasData

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
@@ -273,7 +273,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 146 (0x92)
+		// Code size: 147 (0x93)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope,
@@ -319,32 +319,33 @@
 		IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 		IL_004e: stloc.s 4
 		IL_0050: ldloc.s 4
-		IL_0052: brtrue IL_006d
+		IL_0052: brtrue IL_006e
 
-		IL_0057: ldloc.1
-		IL_0058: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0062: stloc.s 5
-		IL_0064: ldloc.s 5
-		IL_0066: stloc.s 7
-		IL_0068: br IL_0075
+		IL_0057: ldloc.0
+		IL_0058: castclass Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope
+		IL_005d: ldnull
+		IL_005e: call object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
+		IL_0063: stloc.s 5
+		IL_0065: ldloc.s 5
+		IL_0067: stloc.s 7
+		IL_0069: br IL_0076
 
-		IL_006d: ldc.i4.1
-		IL_006e: box [System.Runtime]System.Boolean
-		IL_0073: stloc.s 7
+		IL_006e: ldc.i4.1
+		IL_006f: box [System.Runtime]System.Boolean
+		IL_0074: stloc.s 7
 
-		IL_0075: ldloc.s 7
-		IL_0077: stloc.2
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: stloc.s 8
-		IL_007f: ldloc.0
-		IL_0080: ldfld object Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope::x
-		IL_0085: stloc.s 5
-		IL_0087: ldloc.s 8
-		IL_0089: ldloc.s 5
-		IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0090: pop
-		IL_0091: ret
+		IL_0076: ldloc.s 7
+		IL_0078: stloc.2
+		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007e: stloc.s 8
+		IL_0080: ldloc.0
+		IL_0081: ldfld object Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope::x
+		IL_0086: stloc.s 5
+		IL_0088: ldloc.s 8
+		IL_008a: ldloc.s 5
+		IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0091: pop
+		IL_0092: ret
 	} // end of method BinaryOperator_LogicalOr_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalOr_ShortCircuit

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_MulObjectObject.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_MulObjectObject.verified.txt
@@ -263,7 +263,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 156 (0x9c)
+		// Code size: 122 (0x7a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_MulObjectObject/Scope,
@@ -294,37 +294,27 @@
 		IL_0026: nop
 		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002c: stloc.3
-		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0032: stloc.2
-		IL_0033: ldloc.1
-		IL_0034: ldloc.2
-		IL_0035: ldc.r8 3
-		IL_003e: box [System.Runtime]System.Double
-		IL_0043: ldc.r8 4
-		IL_004c: box [System.Runtime]System.Double
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0056: stloc.s 4
-		IL_0058: ldloc.3
-		IL_0059: ldloc.s 4
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0060: pop
-		IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0066: stloc.3
-		IL_0067: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006c: stloc.2
-		IL_006d: ldloc.1
-		IL_006e: ldloc.2
-		IL_006f: ldc.r8 2.5
-		IL_0078: box [System.Runtime]System.Double
-		IL_007d: ldc.r8 4
-		IL_0086: box [System.Runtime]System.Double
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0090: stloc.s 4
-		IL_0092: ldloc.3
-		IL_0093: ldloc.s 4
-		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009a: pop
-		IL_009b: ret
+		IL_002d: ldnull
+		IL_002e: ldc.r8 3
+		IL_0037: ldc.r8 4
+		IL_0040: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
+		IL_0045: stloc.s 4
+		IL_0047: ldloc.3
+		IL_0048: ldloc.s 4
+		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004f: pop
+		IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0055: stloc.3
+		IL_0056: ldnull
+		IL_0057: ldc.r8 2.5
+		IL_0060: ldc.r8 4
+		IL_0069: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
+		IL_006e: stloc.s 4
+		IL_0070: ldloc.3
+		IL_0071: ldloc.s 4
+		IL_0073: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0078: pop
+		IL_0079: ret
 	} // end of method BinaryOperator_MulObjectObject::__js_module_init__
 
 } // end of class Modules.BinaryOperator_MulObjectObject

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ExplicitNumberAssignment.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ExplicitNumberAssignment.verified.txt
@@ -283,7 +283,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 163 (0xa3)
+		// Code size: 142 (0x8e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/Scope,
@@ -314,46 +314,37 @@
 		IL_0026: nop
 		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002c: stloc.3
-		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0032: stloc.2
-		IL_0033: ldloc.1
-		IL_0034: ldloc.2
-		IL_0035: ldc.r8 100
-		IL_003e: box [System.Runtime]System.Double
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0048: stloc.s 4
-		IL_004a: ldloc.3
-		IL_004b: ldloc.s 4
-		IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0052: pop
-		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0058: stloc.3
-		IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005e: stloc.2
-		IL_005f: ldloc.1
-		IL_0060: ldloc.2
-		IL_0061: ldstr "100"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_006b: stloc.s 4
-		IL_006d: ldloc.3
-		IL_006e: ldloc.s 4
-		IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0075: pop
-		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007b: stloc.3
-		IL_007c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0081: stloc.2
-		IL_0082: ldloc.1
-		IL_0083: ldloc.2
-		IL_0084: ldc.r8 0.0
-		IL_008d: box [System.Runtime]System.Double
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0097: stloc.s 4
-		IL_0099: ldloc.3
-		IL_009a: ldloc.s 4
-		IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a1: pop
-		IL_00a2: ret
+		IL_002d: ldnull
+		IL_002e: ldc.r8 100
+		IL_0037: box [System.Runtime]System.Double
+		IL_003c: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
+		IL_0041: stloc.s 4
+		IL_0043: ldloc.3
+		IL_0044: ldloc.s 4
+		IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004b: pop
+		IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0051: stloc.3
+		IL_0052: ldnull
+		IL_0053: ldstr "100"
+		IL_0058: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
+		IL_005d: stloc.s 4
+		IL_005f: ldloc.3
+		IL_0060: ldloc.s 4
+		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0067: pop
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: stloc.3
+		IL_006e: ldnull
+		IL_006f: ldc.r8 0.0
+		IL_0078: box [System.Runtime]System.Double
+		IL_007d: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
+		IL_0082: stloc.s 4
+		IL_0084: ldloc.3
+		IL_0085: ldloc.s 4
+		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008c: pop
+		IL_008d: ret
 	} // end of method BinaryOperator_NumericRefinement_ExplicitNumberAssignment::__js_module_init__
 
 } // end of class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ParameterReuseCSE.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ParameterReuseCSE.verified.txt
@@ -273,7 +273,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 172 (0xac)
+		// Code size: 136 (0x88)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/Scope,
@@ -304,47 +304,35 @@
 		IL_0026: nop
 		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002c: stloc.3
-		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0032: stloc.2
-		IL_0033: ldloc.1
-		IL_0034: ldloc.2
-		IL_0035: ldc.r8 100
-		IL_003e: box [System.Runtime]System.Double
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0048: stloc.s 4
-		IL_004a: ldloc.3
-		IL_004b: ldloc.s 4
-		IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0052: pop
-		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0058: stloc.3
-		IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005e: stloc.2
-		IL_005f: ldloc.1
-		IL_0060: ldloc.2
-		IL_0061: ldc.r8 0.0
-		IL_006a: box [System.Runtime]System.Double
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0074: stloc.s 4
-		IL_0076: ldloc.3
-		IL_0077: ldloc.s 4
-		IL_0079: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007e: pop
-		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0084: stloc.3
-		IL_0085: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008a: stloc.2
-		IL_008b: ldloc.1
-		IL_008c: ldloc.2
-		IL_008d: ldc.r8 255
-		IL_0096: box [System.Runtime]System.Double
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00a0: stloc.s 4
-		IL_00a2: ldloc.3
-		IL_00a3: ldloc.s 4
-		IL_00a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00aa: pop
-		IL_00ab: ret
+		IL_002d: ldnull
+		IL_002e: ldc.r8 100
+		IL_0037: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
+		IL_003c: stloc.s 4
+		IL_003e: ldloc.3
+		IL_003f: ldloc.s 4
+		IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0046: pop
+		IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004c: stloc.3
+		IL_004d: ldnull
+		IL_004e: ldc.r8 0.0
+		IL_0057: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
+		IL_005c: stloc.s 4
+		IL_005e: ldloc.3
+		IL_005f: ldloc.s 4
+		IL_0061: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0066: pop
+		IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006c: stloc.3
+		IL_006d: ldnull
+		IL_006e: ldc.r8 255
+		IL_0077: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
+		IL_007c: stloc.s 4
+		IL_007e: ldloc.3
+		IL_007f: ldloc.s 4
+		IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0086: pop
+		IL_0087: ret
 	} // end of method BinaryOperator_NumericRefinement_ParameterReuseCSE::__js_module_init__
 
 } // end of class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
@@ -276,7 +276,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 167 (0xa7)
+		// Code size: 168 (0xa8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope,
@@ -325,37 +325,38 @@
 		IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::IsNullish(object)
 		IL_0057: stloc.s 5
 		IL_0059: ldloc.s 5
-		IL_005b: brtrue IL_0080
+		IL_005b: brtrue IL_0081
 
-		IL_0060: ldloc.1
-		IL_0061: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_006b: stloc.s 6
-		IL_006d: ldloc.2
-		IL_006e: ldloc.s 6
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0075: stloc.s 6
-		IL_0077: ldloc.s 6
-		IL_0079: stloc.s 7
-		IL_007b: br IL_0083
+		IL_0060: ldloc.0
+		IL_0061: castclass Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope
+		IL_0066: ldnull
+		IL_0067: call object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
+		IL_006c: stloc.s 6
+		IL_006e: ldloc.2
+		IL_006f: ldloc.s 6
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0076: stloc.s 6
+		IL_0078: ldloc.s 6
+		IL_007a: stloc.s 7
+		IL_007c: br IL_0084
 
-		IL_0080: ldnull
-		IL_0081: stloc.s 7
+		IL_0081: ldnull
+		IL_0082: stloc.s 7
 
-		IL_0083: ldloc.s 4
-		IL_0085: ldloc.s 7
-		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008c: pop
-		IL_008d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0092: stloc.s 4
-		IL_0094: ldloc.0
-		IL_0095: ldfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
-		IL_009a: stloc.s 7
-		IL_009c: ldloc.s 4
-		IL_009e: ldloc.s 7
-		IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a5: pop
-		IL_00a6: ret
+		IL_0084: ldloc.s 4
+		IL_0086: ldloc.s 7
+		IL_0088: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008d: pop
+		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0093: stloc.s 4
+		IL_0095: ldloc.0
+		IL_0096: ldfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
+		IL_009b: stloc.s 7
+		IL_009d: ldloc.s 4
+		IL_009f: ldloc.s 7
+		IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a6: pop
+		IL_00a7: ret
 	} // end of method BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
@@ -523,15 +523,14 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 121 (0x79)
+		// Code size: 118 (0x76)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope,
 			[1] class Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject,
 			[2] object[],
-			[3] object[],
-			[4] class Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console
+			[3] class Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_StrictEqualCapturedVariable/Scope::.ctor()
@@ -557,36 +556,35 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.2
-		IL_0035: ldc.i4.1
-		IL_0036: newarr [System.Runtime]System.Object
-		IL_003b: dup
-		IL_003c: ldc.i4.0
-		IL_003d: ldloc.0
-		IL_003e: stelem.ref
-		IL_003f: stloc.3
-		IL_0040: newobj instance void Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject::.ctor()
-		IL_0045: ldc.i4.1
-		IL_0046: conv.r8
-		IL_0047: ldstr ""
-		IL_004c: ldc.i4.0
-		IL_004d: ldc.i4.0
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject>(!!0)
-		IL_0058: stloc.s 4
-		IL_005a: ldloc.1
-		IL_005b: ldloc.2
-		IL_005c: ldloc.s 4
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0063: pop
-		IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0069: stloc.s 5
-		IL_006b: ldloc.s 5
-		IL_006d: ldstr "done"
-		IL_0072: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0077: pop
-		IL_0078: ret
+		IL_002f: ldc.i4.1
+		IL_0030: newarr [System.Runtime]System.Object
+		IL_0035: dup
+		IL_0036: ldc.i4.0
+		IL_0037: ldloc.0
+		IL_0038: stelem.ref
+		IL_0039: stloc.2
+		IL_003a: newobj instance void Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject::.ctor()
+		IL_003f: ldc.i4.1
+		IL_0040: conv.r8
+		IL_0041: ldstr ""
+		IL_0046: ldc.i4.0
+		IL_0047: ldc.i4.0
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject>(!!0)
+		IL_0052: stloc.3
+		IL_0053: ldloc.0
+		IL_0054: castclass Modules.BinaryOperator_StrictEqualCapturedVariable/Scope
+		IL_0059: ldnull
+		IL_005a: ldloc.3
+		IL_005b: call object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
+		IL_0060: pop
+		IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0066: stloc.s 4
+		IL_0068: ldloc.s 4
+		IL_006a: ldstr "done"
+		IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0074: pop
+		IL_0075: ret
 	} // end of method BinaryOperator_StrictEqualCapturedVariable::__js_module_init__
 
 } // end of class Modules.BinaryOperator_StrictEqualCapturedVariable

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedComparisonScheduler.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedComparisonScheduler.verified.txt
@@ -1464,7 +1464,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1210 (0x4ba)
+		// Code size: 1046 (0x416)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypedComparisonScheduler/Scope,
@@ -1637,275 +1637,232 @@
 		IL_0130: nop
 		IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0136: stloc.s 15
-		IL_0138: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_013d: stloc.s 14
-		IL_013f: ldloc.1
-		IL_0140: ldloc.s 14
-		IL_0142: ldc.r8 3
-		IL_014b: box [System.Runtime]System.Double
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0155: stloc.s 16
-		IL_0157: ldloc.s 15
-		IL_0159: ldloc.s 16
-		IL_015b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0160: pop
-		IL_0161: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0166: stloc.s 15
-		IL_0168: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_016d: stloc.s 14
-		IL_016f: ldloc.1
-		IL_0170: ldloc.s 14
-		IL_0172: ldc.r8 0.0
-		IL_017b: box [System.Runtime]System.Double
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0185: stloc.s 16
-		IL_0187: ldc.r8 0.0
-		IL_0190: neg
-		IL_0191: stloc.s 17
-		IL_0193: ldloc.s 17
-		IL_0195: box [System.Runtime]System.Double
-		IL_019a: stloc.s 18
-		IL_019c: ldloc.s 16
-		IL_019e: ldloc.s 18
-		IL_01a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::is(object, object)
-		IL_01a5: box [System.Runtime]System.Boolean
-		IL_01aa: stloc.s 19
-		IL_01ac: ldloc.s 15
-		IL_01ae: ldloc.s 19
-		IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b5: pop
-		IL_01b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01bb: stloc.s 15
-		IL_01bd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01c2: stloc.s 14
-		IL_01c4: ldloc.2
-		IL_01c5: ldloc.s 14
-		IL_01c7: ldc.r8 5
-		IL_01d0: box [System.Runtime]System.Double
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01da: stloc.s 16
-		IL_01dc: ldloc.s 15
-		IL_01de: ldloc.s 16
-		IL_01e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e5: pop
-		IL_01e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01eb: stloc.s 15
-		IL_01ed: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01f2: stloc.s 14
-		IL_01f4: ldloc.3
-		IL_01f5: ldloc.s 14
-		IL_01f7: ldc.r8 1
-		IL_0200: box [System.Runtime]System.Double
-		IL_0205: ldc.r8 2
-		IL_020e: box [System.Runtime]System.Double
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0218: stloc.s 16
-		IL_021a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_021f: stloc.s 14
-		IL_0221: ldloc.3
-		IL_0222: ldloc.s 14
-		IL_0224: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_022d: box [System.Runtime]System.Double
-		IL_0232: ldc.r8 2
-		IL_023b: box [System.Runtime]System.Double
-		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0245: stloc.s 20
-		IL_0247: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_024c: stloc.s 14
-		IL_024e: ldloc.3
-		IL_024f: ldloc.s 14
-		IL_0251: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_025a: box [System.Runtime]System.Double
-		IL_025f: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_0268: box [System.Runtime]System.Double
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0272: stloc.s 21
-		IL_0274: ldloc.s 15
-		IL_0276: ldloc.s 16
-		IL_0278: ldloc.s 20
-		IL_027a: ldloc.s 21
-		IL_027c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0281: pop
-		IL_0282: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0287: stloc.s 15
-		IL_0289: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_028e: stloc.s 14
-		IL_0290: ldloc.s 4
-		IL_0292: ldloc.s 14
-		IL_0294: ldc.r8 2
-		IL_029d: box [System.Runtime]System.Double
-		IL_02a2: ldc.r8 10
-		IL_02ab: box [System.Runtime]System.Double
-		IL_02b0: ldc.r8 3
-		IL_02b9: box [System.Runtime]System.Double
-		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_02c3: stloc.s 21
-		IL_02c5: ldloc.s 15
-		IL_02c7: ldloc.s 21
-		IL_02c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ce: pop
-		IL_02cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02d4: stloc.s 15
-		IL_02d6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02db: stloc.s 14
-		IL_02dd: ldloc.s 5
-		IL_02df: ldloc.s 14
-		IL_02e1: ldc.r8 2
-		IL_02ea: box [System.Runtime]System.Double
-		IL_02ef: ldc.r8 10
-		IL_02f8: box [System.Runtime]System.Double
-		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0302: stloc.s 21
-		IL_0304: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0309: stloc.s 14
-		IL_030b: ldloc.s 5
-		IL_030d: ldloc.s 14
-		IL_030f: ldc.r8 10
-		IL_0318: box [System.Runtime]System.Double
-		IL_031d: ldc.r8 2
-		IL_0326: box [System.Runtime]System.Double
-		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0330: stloc.s 20
-		IL_0332: ldloc.s 15
-		IL_0334: ldloc.s 21
-		IL_0336: ldloc.s 20
-		IL_0338: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_033d: pop
-		IL_033e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0343: stloc.s 15
-		IL_0345: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_034a: stloc.s 14
-		IL_034c: ldloc.s 6
-		IL_034e: ldloc.s 14
-		IL_0350: ldc.r8 1
-		IL_0359: box [System.Runtime]System.Double
-		IL_035e: ldstr "x"
-		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0368: stloc.s 20
-		IL_036a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_036f: stloc.s 14
-		IL_0371: ldloc.s 6
-		IL_0373: ldloc.s 14
-		IL_0375: ldc.r8 0.0
-		IL_037e: box [System.Runtime]System.Double
-		IL_0383: ldstr "x"
-		IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_038d: stloc.s 21
-		IL_038f: ldloc.s 15
-		IL_0391: ldloc.s 20
-		IL_0393: ldloc.s 21
-		IL_0395: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_039a: pop
-		IL_039b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03a0: stloc.s 15
-		IL_03a2: ldloc.s 7
-		IL_03a4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_03ae: stloc.s 21
-		IL_03b0: ldloc.s 8
-		IL_03b2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_03bc: stloc.s 20
-		IL_03be: ldloc.s 21
-		IL_03c0: ldloc.s 20
-		IL_03c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-		IL_03c7: stloc.s 22
-		IL_03c9: ldloc.s 22
-		IL_03cb: box [System.Runtime]System.Boolean
-		IL_03d0: stloc.s 19
-		IL_03d2: ldloc.0
-		IL_03d3: ldfld object Modules.BinaryOperator_TypedComparisonScheduler/Scope::order
-		IL_03d8: stloc.s 20
-		IL_03da: ldloc.s 15
-		IL_03dc: ldloc.s 19
-		IL_03de: ldloc.s 20
-		IL_03e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03e5: pop
+		IL_0138: ldnull
+		IL_0139: ldc.r8 3
+		IL_0142: call object Modules.BinaryOperator_TypedComparisonScheduler/'neg'::__js_call__(object, float64)
+		IL_0147: stloc.s 16
+		IL_0149: ldloc.s 15
+		IL_014b: ldloc.s 16
+		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0152: pop
+		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0158: stloc.s 15
+		IL_015a: ldnull
+		IL_015b: ldc.r8 0.0
+		IL_0164: call object Modules.BinaryOperator_TypedComparisonScheduler/'neg'::__js_call__(object, float64)
+		IL_0169: stloc.s 16
+		IL_016b: ldc.r8 0.0
+		IL_0174: neg
+		IL_0175: stloc.s 17
+		IL_0177: ldloc.s 17
+		IL_0179: box [System.Runtime]System.Double
+		IL_017e: stloc.s 18
+		IL_0180: ldloc.s 16
+		IL_0182: ldloc.s 18
+		IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::is(object, object)
+		IL_0189: box [System.Runtime]System.Boolean
+		IL_018e: stloc.s 19
+		IL_0190: ldloc.s 15
+		IL_0192: ldloc.s 19
+		IL_0194: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0199: pop
+		IL_019a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019f: stloc.s 15
+		IL_01a1: ldnull
+		IL_01a2: ldc.r8 5
+		IL_01ab: call object Modules.BinaryOperator_TypedComparisonScheduler/bitNot::__js_call__(object, float64)
+		IL_01b0: stloc.s 16
+		IL_01b2: ldloc.s 15
+		IL_01b4: ldloc.s 16
+		IL_01b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01bb: pop
+		IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c1: stloc.s 15
+		IL_01c3: ldnull
+		IL_01c4: ldc.r8 1
+		IL_01cd: box [System.Runtime]System.Double
+		IL_01d2: ldc.r8 2
+		IL_01db: box [System.Runtime]System.Double
+		IL_01e0: call object Modules.BinaryOperator_TypedComparisonScheduler/less::__js_call__(object, object, object)
+		IL_01e5: stloc.s 16
+		IL_01e7: ldnull
+		IL_01e8: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_01f1: box [System.Runtime]System.Double
+		IL_01f6: ldc.r8 2
+		IL_01ff: box [System.Runtime]System.Double
+		IL_0204: call object Modules.BinaryOperator_TypedComparisonScheduler/less::__js_call__(object, object, object)
+		IL_0209: stloc.s 20
+		IL_020b: ldnull
+		IL_020c: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_0215: box [System.Runtime]System.Double
+		IL_021a: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_0223: box [System.Runtime]System.Double
+		IL_0228: call object Modules.BinaryOperator_TypedComparisonScheduler/less::__js_call__(object, object, object)
+		IL_022d: stloc.s 21
+		IL_022f: ldloc.s 15
+		IL_0231: ldloc.s 16
+		IL_0233: ldloc.s 20
+		IL_0235: ldloc.s 21
+		IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_023c: pop
+		IL_023d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0242: stloc.s 15
+		IL_0244: ldnull
+		IL_0245: ldc.r8 2
+		IL_024e: ldc.r8 10
+		IL_0257: ldc.r8 3
+		IL_0260: call object Modules.BinaryOperator_TypedComparisonScheduler/compareExpr::__js_call__(object, float64, float64, float64)
+		IL_0265: stloc.s 21
+		IL_0267: ldloc.s 15
+		IL_0269: ldloc.s 21
+		IL_026b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0270: pop
+		IL_0271: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0276: stloc.s 15
+		IL_0278: ldnull
+		IL_0279: ldc.r8 2
+		IL_0282: ldc.r8 10
+		IL_028b: call object Modules.BinaryOperator_TypedComparisonScheduler/branch::__js_call__(object, float64, float64)
+		IL_0290: stloc.s 21
+		IL_0292: ldnull
+		IL_0293: ldc.r8 10
+		IL_029c: ldc.r8 2
+		IL_02a5: call object Modules.BinaryOperator_TypedComparisonScheduler/branch::__js_call__(object, float64, float64)
+		IL_02aa: stloc.s 20
+		IL_02ac: ldloc.s 15
+		IL_02ae: ldloc.s 21
+		IL_02b0: ldloc.s 20
+		IL_02b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02b7: pop
+		IL_02b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02bd: stloc.s 15
+		IL_02bf: ldnull
+		IL_02c0: ldc.r8 1
+		IL_02c9: ldstr "x"
+		IL_02ce: call object Modules.BinaryOperator_TypedComparisonScheduler/boolEq::__js_call__(object, float64, string)
+		IL_02d3: stloc.s 20
+		IL_02d5: ldnull
+		IL_02d6: ldc.r8 0.0
+		IL_02df: ldstr "x"
+		IL_02e4: call object Modules.BinaryOperator_TypedComparisonScheduler/boolEq::__js_call__(object, float64, string)
+		IL_02e9: stloc.s 21
+		IL_02eb: ldloc.s 15
+		IL_02ed: ldloc.s 20
+		IL_02ef: ldloc.s 21
+		IL_02f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02f6: pop
+		IL_02f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02fc: stloc.s 15
+		IL_02fe: ldloc.0
+		IL_02ff: castclass Modules.BinaryOperator_TypedComparisonScheduler/Scope
+		IL_0304: ldnull
+		IL_0305: call object Modules.BinaryOperator_TypedComparisonScheduler/left::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
+		IL_030a: stloc.s 21
+		IL_030c: ldloc.0
+		IL_030d: castclass Modules.BinaryOperator_TypedComparisonScheduler/Scope
+		IL_0312: ldnull
+		IL_0313: call object Modules.BinaryOperator_TypedComparisonScheduler/right::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
+		IL_0318: stloc.s 20
+		IL_031a: ldloc.s 21
+		IL_031c: ldloc.s 20
+		IL_031e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+		IL_0323: stloc.s 22
+		IL_0325: ldloc.s 22
+		IL_0327: box [System.Runtime]System.Boolean
+		IL_032c: stloc.s 19
+		IL_032e: ldloc.0
+		IL_032f: ldfld object Modules.BinaryOperator_TypedComparisonScheduler/Scope::order
+		IL_0334: stloc.s 20
+		IL_0336: ldloc.s 15
+		IL_0338: ldloc.s 19
+		IL_033a: ldloc.s 20
+		IL_033c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0341: pop
 		.try
 		{
-			IL_03e6: nop
-			IL_03e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03ec: stloc.s 15
-			IL_03ee: ldstr "Cannot access 'tdzValue' before initialization"
-			IL_03f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_03f8: stloc.s 23
-			IL_03fa: ldloc.s 23
-			IL_03fc: isinst [System.Runtime]System.Exception
-			IL_0401: dup
-			IL_0402: brtrue IL_0410
+			IL_0342: nop
+			IL_0343: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0348: stloc.s 15
+			IL_034a: ldstr "Cannot access 'tdzValue' before initialization"
+			IL_034f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_0354: stloc.s 23
+			IL_0356: ldloc.s 23
+			IL_0358: isinst [System.Runtime]System.Exception
+			IL_035d: dup
+			IL_035e: brtrue IL_036c
 
-			IL_0407: pop
-			IL_0408: ldloc.s 23
-			IL_040a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_040f: throw
+			IL_0363: pop
+			IL_0364: ldloc.s 23
+			IL_0366: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_036b: throw
 
-			IL_0410: throw
+			IL_036c: throw
 
-			IL_0411: ldnull
-			IL_0412: ldc.r8 1
-			IL_041b: box [System.Runtime]System.Double
-			IL_0420: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_0425: stloc.s 22
-			IL_0427: ldloc.s 22
-			IL_0429: box [System.Runtime]System.Boolean
-			IL_042e: stloc.s 19
-			IL_0430: ldloc.s 15
-			IL_0432: ldloc.s 19
-			IL_0434: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0439: pop
-			IL_043a: leave IL_04ab
+			IL_036d: ldnull
+			IL_036e: ldc.r8 1
+			IL_0377: box [System.Runtime]System.Double
+			IL_037c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_0381: stloc.s 22
+			IL_0383: ldloc.s 22
+			IL_0385: box [System.Runtime]System.Boolean
+			IL_038a: stloc.s 19
+			IL_038c: ldloc.s 15
+			IL_038e: ldloc.s 19
+			IL_0390: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0395: pop
+			IL_0396: leave IL_0407
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_043f: stloc.s 9
-			IL_0441: ldloc.s 9
-			IL_0443: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0448: dup
-			IL_0449: brtrue IL_045f
+			IL_039b: stloc.s 9
+			IL_039d: ldloc.s 9
+			IL_039f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03a4: dup
+			IL_03a5: brtrue IL_03bb
 
-			IL_044e: pop
-			IL_044f: ldloc.s 9
-			IL_0451: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0456: dup
-			IL_0457: brtrue IL_046b
+			IL_03aa: pop
+			IL_03ab: ldloc.s 9
+			IL_03ad: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03b2: dup
+			IL_03b3: brtrue IL_03c7
 
-			IL_045c: pop
-			IL_045d: rethrow
+			IL_03b8: pop
+			IL_03b9: rethrow
 
-			IL_045f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0464: stloc.s 10
-			IL_0466: br IL_046d
+			IL_03bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03c0: stloc.s 10
+			IL_03c2: br IL_03c9
 
-			IL_046b: stloc.s 10
+			IL_03c7: stloc.s 10
 
-			IL_046d: ldloc.s 10
-			IL_046f: stloc.s 11
-			IL_0471: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0476: stloc.s 15
-			IL_0478: ldloc.s 11
-			IL_047a: stloc.s 20
-			IL_047c: ldstr "ReferenceError"
-			IL_0481: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0486: stloc.s 21
-			IL_0488: ldloc.s 20
-			IL_048a: ldloc.s 21
-			IL_048c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0491: stloc.s 22
-			IL_0493: ldloc.s 22
-			IL_0495: box [System.Runtime]System.Boolean
-			IL_049a: stloc.s 19
-			IL_049c: ldloc.s 15
-			IL_049e: ldloc.s 19
-			IL_04a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04a5: pop
-			IL_04a6: leave IL_04ab
+			IL_03c9: ldloc.s 10
+			IL_03cb: stloc.s 11
+			IL_03cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03d2: stloc.s 15
+			IL_03d4: ldloc.s 11
+			IL_03d6: stloc.s 20
+			IL_03d8: ldstr "ReferenceError"
+			IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03e2: stloc.s 21
+			IL_03e4: ldloc.s 20
+			IL_03e6: ldloc.s 21
+			IL_03e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_03ed: stloc.s 22
+			IL_03ef: ldloc.s 22
+			IL_03f1: box [System.Runtime]System.Boolean
+			IL_03f6: stloc.s 19
+			IL_03f8: ldloc.s 15
+			IL_03fa: ldloc.s 19
+			IL_03fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0401: pop
+			IL_0402: leave IL_0407
 		} // end handler
 
-		IL_04ab: ldc.r8 0.0
-		IL_04b4: stloc.s 12
-		IL_04b6: ldnull
-		IL_04b7: stloc.s 13
-		IL_04b9: ret
+		IL_0407: ldc.r8 0.0
+		IL_0410: stloc.s 12
+		IL_0412: ldnull
+		IL_0413: stloc.s 13
+		IL_0415: ret
 	} // end of method BinaryOperator_TypedComparisonScheduler::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypedComparisonScheduler

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
@@ -1523,7 +1523,7 @@
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1532,31 +1532,21 @@
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.BinaryOperator_TypedNumericScheduler/Scope::left
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldfld object Modules.BinaryOperator_TypedNumericScheduler/Scope::right
-			IL_001c: ldc.i4.1
-			IL_001d: newarr [System.Runtime]System.Object
-			IL_0022: dup
-			IL_0023: ldc.i4.0
-			IL_0024: ldarg.0
-			IL_0025: stelem.ref
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_002b: stloc.1
-			IL_002c: ldloc.0
-			IL_002d: ldloc.1
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0033: stloc.2
-			IL_0034: ldloc.2
-			IL_0035: ret
+			IL_0001: castclass Modules.BinaryOperator_TypedNumericScheduler/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/left::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
+			IL_000c: stloc.0
+			IL_000d: ldarg.0
+			IL_000e: castclass Modules.BinaryOperator_TypedNumericScheduler/Scope
+			IL_0013: ldnull
+			IL_0014: call object Modules.BinaryOperator_TypedNumericScheduler/right::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
+			IL_0019: stloc.1
+			IL_001a: ldloc.0
+			IL_001b: ldloc.1
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0021: stloc.2
+			IL_0022: ldloc.2
+			IL_0023: ret
 		} // end of method calls::__js_call__
 
 	} // end of class calls
@@ -1781,7 +1771,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1199 (0x4af)
+		// Code size: 970 (0x3ca)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypedNumericScheduler/Scope,
@@ -1801,7 +1791,9 @@
 			[14] object,
 			[15] float64,
 			[16] object,
-			[17] object
+			[17] object,
+			[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[19] string
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/Scope::.ctor()
@@ -1990,211 +1982,156 @@
 		IL_018d: nop
 		IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0193: stloc.s 12
-		IL_0195: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_019a: stloc.s 9
-		IL_019c: ldloc.1
-		IL_019d: ldloc.s 9
-		IL_019f: ldc.r8 4
-		IL_01a8: box [System.Runtime]System.Double
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01b2: stloc.s 13
-		IL_01b4: ldloc.s 12
-		IL_01b6: ldloc.s 13
-		IL_01b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01bd: pop
-		IL_01be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c3: stloc.s 12
-		IL_01c5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01ca: stloc.s 9
-		IL_01cc: ldloc.2
-		IL_01cd: ldloc.s 9
-		IL_01cf: ldc.r8 1
-		IL_01d8: box [System.Runtime]System.Double
-		IL_01dd: ldc.r8 2
-		IL_01e6: box [System.Runtime]System.Double
-		IL_01eb: ldc.r8 3
-		IL_01f4: box [System.Runtime]System.Double
-		IL_01f9: ldc.r8 4
-		IL_0202: box [System.Runtime]System.Double
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_020c: stloc.s 13
-		IL_020e: ldloc.s 12
-		IL_0210: ldloc.s 13
-		IL_0212: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0217: pop
-		IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021d: stloc.s 12
-		IL_021f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0224: stloc.s 9
-		IL_0226: ldloc.3
-		IL_0227: ldloc.s 9
-		IL_0229: ldc.r8 2
-		IL_0232: box [System.Runtime]System.Double
-		IL_0237: ldc.r8 3
-		IL_0240: box [System.Runtime]System.Double
-		IL_0245: ldc.r8 4
-		IL_024e: box [System.Runtime]System.Double
-		IL_0253: ldc.r8 5
-		IL_025c: box [System.Runtime]System.Double
-		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_0266: stloc.s 13
-		IL_0268: ldloc.s 12
-		IL_026a: ldloc.s 13
-		IL_026c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0271: pop
-		IL_0272: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0277: stloc.s 12
-		IL_0279: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_027e: stloc.s 9
-		IL_0280: ldloc.s 4
-		IL_0282: ldloc.s 9
-		IL_0284: ldc.r8 10
-		IL_028d: box [System.Runtime]System.Double
-		IL_0292: ldc.r8 3
-		IL_029b: box [System.Runtime]System.Double
-		IL_02a0: ldc.r8 2
-		IL_02a9: box [System.Runtime]System.Double
-		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_02b3: stloc.s 13
-		IL_02b5: ldloc.s 12
-		IL_02b7: ldloc.s 13
-		IL_02b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02be: pop
-		IL_02bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c4: stloc.s 12
-		IL_02c6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02cb: stloc.s 9
-		IL_02cd: ldloc.s 5
-		IL_02cf: ldloc.s 9
-		IL_02d1: ldc.r8 20
-		IL_02da: box [System.Runtime]System.Double
-		IL_02df: ldc.r8 3
-		IL_02e8: box [System.Runtime]System.Double
-		IL_02ed: ldc.r8 2
-		IL_02f6: box [System.Runtime]System.Double
-		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0300: stloc.s 13
-		IL_0302: ldloc.s 12
-		IL_0304: ldloc.s 13
-		IL_0306: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_030b: pop
-		IL_030c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0311: stloc.s 12
-		IL_0313: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0318: stloc.s 9
-		IL_031a: ldloc.s 6
-		IL_031c: ldloc.s 9
-		IL_031e: ldc.r8 2
-		IL_0327: box [System.Runtime]System.Double
-		IL_032c: ldc.r8 3
-		IL_0335: box [System.Runtime]System.Double
-		IL_033a: ldc.r8 1
-		IL_0343: box [System.Runtime]System.Double
-		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_034d: stloc.s 13
-		IL_034f: ldloc.s 12
-		IL_0351: ldloc.s 13
-		IL_0353: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0358: pop
-		IL_0359: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_035e: stloc.s 12
-		IL_0360: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0365: stloc.s 9
-		IL_0367: ldloc.1
-		IL_0368: ldloc.s 9
-		IL_036a: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_0373: box [System.Runtime]System.Double
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_037d: stloc.s 13
-		IL_037f: ldloc.s 13
-		IL_0381: call bool [JavaScriptRuntime]JavaScriptRuntime.Number::isNaN(object)
-		IL_0386: box [System.Runtime]System.Boolean
-		IL_038b: stloc.s 14
-		IL_038d: ldloc.s 12
-		IL_038f: ldloc.s 14
-		IL_0391: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0396: pop
-		IL_0397: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_039c: stloc.s 12
-		IL_039e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03a3: stloc.s 9
-		IL_03a5: ldc.r8 0.0
-		IL_03ae: neg
-		IL_03af: stloc.s 15
-		IL_03b1: ldloc.s 15
-		IL_03b3: box [System.Runtime]System.Double
-		IL_03b8: stloc.s 16
-		IL_03ba: ldloc.s 5
-		IL_03bc: ldloc.s 9
-		IL_03be: ldloc.s 16
-		IL_03c0: ldc.r8 1
-		IL_03c9: box [System.Runtime]System.Double
-		IL_03ce: ldc.r8 2
-		IL_03d7: box [System.Runtime]System.Double
-		IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_03e1: stloc.s 13
-		IL_03e3: ldc.r8 0.0
-		IL_03ec: neg
-		IL_03ed: stloc.s 15
-		IL_03ef: ldloc.s 15
-		IL_03f1: box [System.Runtime]System.Double
-		IL_03f6: stloc.s 16
-		IL_03f8: ldloc.s 13
-		IL_03fa: ldloc.s 16
-		IL_03fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::is(object, object)
-		IL_0401: box [System.Runtime]System.Boolean
-		IL_0406: stloc.s 14
-		IL_0408: ldloc.s 12
-		IL_040a: ldloc.s 14
-		IL_040c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0411: pop
-		IL_0412: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0417: stloc.s 12
-		IL_0419: ldloc.s 7
-		IL_041b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0425: stloc.s 13
-		IL_0427: ldloc.0
-		IL_0428: ldfld object Modules.BinaryOperator_TypedNumericScheduler/Scope::order
-		IL_042d: stloc.s 17
-		IL_042f: ldloc.s 12
-		IL_0431: ldloc.s 13
-		IL_0433: ldloc.s 17
-		IL_0435: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_043a: pop
-		IL_043b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0440: stloc.s 12
-		IL_0442: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0447: stloc.s 9
-		IL_0449: ldloc.s 8
-		IL_044b: ldloc.s 9
-		IL_044d: ldc.r8 3
-		IL_0456: box [System.Runtime]System.Double
-		IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0460: stloc.s 17
-		IL_0462: ldloc.s 17
-		IL_0464: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0469: volatile.
-		IL_046b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0470: brfalse IL_0489
-
-		IL_0475: ldstr "join"
-		IL_047a: ldstr ","
-		IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0484: br IL_04a2
-
-		IL_0489: ldstr "join"
-		IL_048e: ldstr ","
-		IL_0493: ldstr "BinaryOperator_TypedNumericScheduler:Modules.BinaryOperator_TypedNumericScheduler:__js_module_init__:152"
-		IL_0498: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
-
-		IL_04a2: stloc.s 17
-		IL_04a4: ldloc.s 12
-		IL_04a6: ldloc.s 17
-		IL_04a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ad: pop
-		IL_04ae: ret
+		IL_0195: ldnull
+		IL_0196: ldc.r8 4
+		IL_019f: box [System.Runtime]System.Double
+		IL_01a4: call object Modules.BinaryOperator_TypedNumericScheduler/mulAdd::__js_call__(object, object)
+		IL_01a9: stloc.s 13
+		IL_01ab: ldloc.s 12
+		IL_01ad: ldloc.s 13
+		IL_01af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b4: pop
+		IL_01b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ba: stloc.s 12
+		IL_01bc: ldnull
+		IL_01bd: ldc.r8 1
+		IL_01c6: ldc.r8 2
+		IL_01cf: ldc.r8 3
+		IL_01d8: ldc.r8 4
+		IL_01e1: call object Modules.BinaryOperator_TypedNumericScheduler/addChain::__js_call__(object, float64, float64, float64, float64)
+		IL_01e6: stloc.s 13
+		IL_01e8: ldloc.s 12
+		IL_01ea: ldloc.s 13
+		IL_01ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f1: pop
+		IL_01f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f7: stloc.s 12
+		IL_01f9: ldnull
+		IL_01fa: ldc.r8 2
+		IL_0203: ldc.r8 3
+		IL_020c: ldc.r8 4
+		IL_0215: ldc.r8 5
+		IL_021e: call object Modules.BinaryOperator_TypedNumericScheduler/tree::__js_call__(object, float64, float64, float64, float64)
+		IL_0223: stloc.s 13
+		IL_0225: ldloc.s 12
+		IL_0227: ldloc.s 13
+		IL_0229: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_022e: pop
+		IL_022f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0234: stloc.s 12
+		IL_0236: ldnull
+		IL_0237: ldc.r8 10
+		IL_0240: ldc.r8 3
+		IL_0249: ldc.r8 2
+		IL_0252: call object Modules.BinaryOperator_TypedNumericScheduler/subChain::__js_call__(object, float64, float64, float64)
+		IL_0257: stloc.s 13
+		IL_0259: ldloc.s 12
+		IL_025b: ldloc.s 13
+		IL_025d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0262: pop
+		IL_0263: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0268: stloc.s 12
+		IL_026a: ldnull
+		IL_026b: ldc.r8 20
+		IL_0274: ldc.r8 3
+		IL_027d: ldc.r8 2
+		IL_0286: call object Modules.BinaryOperator_TypedNumericScheduler/divMod::__js_call__(object, float64, float64, float64)
+		IL_028b: stloc.s 13
+		IL_028d: ldloc.s 12
+		IL_028f: ldloc.s 13
+		IL_0291: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0296: pop
+		IL_0297: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_029c: stloc.s 12
+		IL_029e: ldnull
+		IL_029f: ldc.r8 2
+		IL_02a8: ldc.r8 3
+		IL_02b1: ldc.r8 1
+		IL_02ba: call object Modules.BinaryOperator_TypedNumericScheduler/expAdd::__js_call__(object, float64, float64, float64)
+		IL_02bf: stloc.s 13
+		IL_02c1: ldloc.s 12
+		IL_02c3: ldloc.s 13
+		IL_02c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ca: pop
+		IL_02cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d0: stloc.s 12
+		IL_02d2: ldnull
+		IL_02d3: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_02dc: box [System.Runtime]System.Double
+		IL_02e1: call object Modules.BinaryOperator_TypedNumericScheduler/mulAdd::__js_call__(object, object)
+		IL_02e6: stloc.s 13
+		IL_02e8: ldloc.s 13
+		IL_02ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Number::isNaN(object)
+		IL_02ef: box [System.Runtime]System.Boolean
+		IL_02f4: stloc.s 14
+		IL_02f6: ldloc.s 12
+		IL_02f8: ldloc.s 14
+		IL_02fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ff: pop
+		IL_0300: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0305: stloc.s 12
+		IL_0307: ldc.r8 0.0
+		IL_0310: neg
+		IL_0311: stloc.s 15
+		IL_0313: ldloc.s 15
+		IL_0315: box [System.Runtime]System.Double
+		IL_031a: stloc.s 16
+		IL_031c: ldnull
+		IL_031d: ldloc.s 15
+		IL_031f: ldc.r8 1
+		IL_0328: ldc.r8 2
+		IL_0331: call object Modules.BinaryOperator_TypedNumericScheduler/divMod::__js_call__(object, float64, float64, float64)
+		IL_0336: stloc.s 13
+		IL_0338: ldc.r8 0.0
+		IL_0341: neg
+		IL_0342: stloc.s 15
+		IL_0344: ldloc.s 15
+		IL_0346: box [System.Runtime]System.Double
+		IL_034b: stloc.s 16
+		IL_034d: ldloc.s 13
+		IL_034f: ldloc.s 16
+		IL_0351: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::is(object, object)
+		IL_0356: box [System.Runtime]System.Boolean
+		IL_035b: stloc.s 14
+		IL_035d: ldloc.s 12
+		IL_035f: ldloc.s 14
+		IL_0361: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0366: pop
+		IL_0367: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_036c: stloc.s 12
+		IL_036e: ldloc.0
+		IL_036f: castclass Modules.BinaryOperator_TypedNumericScheduler/Scope
+		IL_0374: ldnull
+		IL_0375: call object Modules.BinaryOperator_TypedNumericScheduler/calls::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
+		IL_037a: stloc.s 13
+		IL_037c: ldloc.0
+		IL_037d: ldfld object Modules.BinaryOperator_TypedNumericScheduler/Scope::order
+		IL_0382: stloc.s 17
+		IL_0384: ldloc.s 12
+		IL_0386: ldloc.s 13
+		IL_0388: ldloc.s 17
+		IL_038a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_038f: pop
+		IL_0390: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0395: stloc.s 12
+		IL_0397: ldnull
+		IL_0398: ldc.r8 3
+		IL_03a1: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.BinaryOperator_TypedNumericScheduler/postfix::__js_call__(object, float64)
+		IL_03a6: stloc.s 18
+		IL_03a8: ldloc.s 18
+		IL_03aa: ldc.i4.1
+		IL_03ab: newarr [System.Runtime]System.Object
+		IL_03b0: dup
+		IL_03b1: ldc.i4.0
+		IL_03b2: ldstr ","
+		IL_03b7: stelem.ref
+		IL_03b8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_03bd: stloc.s 19
+		IL_03bf: ldloc.s 12
+		IL_03c1: ldloc.s 19
+		IL_03c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03c8: pop
+		IL_03c9: ret
 	} // end of method BinaryOperator_TypedNumericScheduler::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypedNumericScheduler
@@ -2219,12 +2156,4 @@
 	} // end of method Program::Main
 
 } // end of class Program
-
-.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
-	extends [System.Runtime]System.Object
-{
-	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_15
-
-} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -471,7 +471,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 71 (0x47)
+		// Code size: 72 (0x48)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope,
@@ -505,11 +505,12 @@
 		IL_002f: ldstr "Hello from global"
 		IL_0034: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
 		IL_0039: nop
-		IL_003a: ldloc.1
-		IL_003b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0045: pop
-		IL_0046: ret
+		IL_003a: ldloc.0
+		IL_003b: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
+		IL_0040: ldnull
+		IL_0041: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
+		IL_0046: pop
+		IL_0047: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -459,7 +459,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 71 (0x47)
+		// Code size: 72 (0x48)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope,
@@ -493,11 +493,12 @@
 		IL_002f: ldstr "Hello from global"
 		IL_0034: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
 		IL_0039: nop
-		IL_003a: ldloc.1
-		IL_003b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0045: pop
-		IL_0046: ret
+		IL_003a: ldloc.0
+		IL_003b: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
+		IL_0040: ldnull
+		IL_0041: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
+		IL_0046: pop
+		IL_0047: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -450,7 +450,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 60 (0x3c)
+		// Code size: 61 (0x3d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope,
@@ -481,11 +481,12 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldloc.1
-		IL_0030: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003a: pop
-		IL_003b: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope
+		IL_0035: ldnull
+		IL_0036: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
+		IL_003b: pop
+		IL_003c: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -438,7 +438,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 60 (0x3c)
+		// Code size: 61 (0x3d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope,
@@ -469,11 +469,12 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldloc.1
-		IL_0030: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003a: pop
-		IL_003b: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope
+		IL_0035: ldnull
+		IL_0036: call object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
+		IL_003b: pop
+		IL_003c: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -549,7 +549,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 71 (0x47)
+		// Code size: 72 (0x48)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope,
@@ -583,11 +583,12 @@
 		IL_002f: ldstr "Hello from global"
 		IL_0034: stfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
 		IL_0039: nop
-		IL_003a: ldloc.1
-		IL_003b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0045: pop
-		IL_0046: ret
+		IL_003a: ldloc.0
+		IL_003b: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
+		IL_0040: ldnull
+		IL_0041: call object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
+		IL_0046: pop
+		IL_0047: ret
 	} // end of method Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -532,7 +532,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 60 (0x3c)
+		// Code size: 61 (0x3d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope,
@@ -563,11 +563,12 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldloc.1
-		IL_0030: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003a: pop
-		IL_003b: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope
+		IL_0035: ldnull
+		IL_0036: call object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
+		IL_003b: pop
+		IL_003c: ret
 	} // end of method Classes_ClassMethod_AccessFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessFunctionVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
@@ -2460,7 +2460,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 5294 (0x14ae)
+		// Code size: 5274 (0x149a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_GeneratedMethodFunctionObjects/Scope,
@@ -3705,565 +3705,561 @@
 		IL_0e32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
 		IL_0e37: pop
 		IL_0e38: nop
-		IL_0e39: ldloc.1
-		IL_0e3a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0e3f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0e44: stloc.s 19
-		IL_0e46: ldloc.1
-		IL_0e47: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0e4c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0e51: stloc.s 20
-		IL_0e53: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0e58: stloc.s 39
-		IL_0e5a: volatile.
-		IL_0e5c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-		IL_0e61: brfalse IL_0e77
+		IL_0e39: ldnull
+		IL_0e3a: call object Modules.Classes_GeneratedMethodFunctionObjects/makeClass::__js_call__(object)
+		IL_0e3f: stloc.s 19
+		IL_0e41: ldnull
+		IL_0e42: call object Modules.Classes_GeneratedMethodFunctionObjects/makeClass::__js_call__(object)
+		IL_0e47: stloc.s 20
+		IL_0e49: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0e4e: stloc.s 39
+		IL_0e50: volatile.
+		IL_0e52: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+		IL_0e57: brfalse IL_0e6d
 
-		IL_0e66: ldloc.s 19
-		IL_0e68: ldstr "prototype"
-		IL_0e6d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0e72: br IL_0e8d
+		IL_0e5c: ldloc.s 19
+		IL_0e5e: ldstr "prototype"
+		IL_0e63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0e68: br IL_0e83
 
-		IL_0e77: ldloc.s 19
-		IL_0e79: ldstr "prototype"
-		IL_0e7e: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:294"
-		IL_0e83: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-		IL_0e88: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0e6d: ldloc.s 19
+		IL_0e6f: ldstr "prototype"
+		IL_0e74: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:294"
+		IL_0e79: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+		IL_0e7e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0e8d: stloc.s 42
-		IL_0e8f: volatile.
-		IL_0e91: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-		IL_0e96: brfalse IL_0eac
+		IL_0e83: stloc.s 42
+		IL_0e85: volatile.
+		IL_0e87: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_0e8c: brfalse IL_0ea2
 
-		IL_0e9b: ldloc.s 42
-		IL_0e9d: ldstr "method"
-		IL_0ea2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ea7: br IL_0ec2
+		IL_0e91: ldloc.s 42
+		IL_0e93: ldstr "method"
+		IL_0e98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0e9d: br IL_0eb8
 
-		IL_0eac: ldloc.s 42
-		IL_0eae: ldstr "method"
-		IL_0eb3: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:296"
-		IL_0eb8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-		IL_0ebd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ea2: ldloc.s 42
+		IL_0ea4: ldstr "method"
+		IL_0ea9: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:296"
+		IL_0eae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_0eb3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0ec2: stloc.s 42
-		IL_0ec4: volatile.
-		IL_0ec6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_0ecb: brfalse IL_0ee1
+		IL_0eb8: stloc.s 42
+		IL_0eba: volatile.
+		IL_0ebc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_0ec1: brfalse IL_0ed7
 
-		IL_0ed0: ldloc.s 20
-		IL_0ed2: ldstr "prototype"
-		IL_0ed7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0edc: br IL_0ef7
+		IL_0ec6: ldloc.s 20
+		IL_0ec8: ldstr "prototype"
+		IL_0ecd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ed2: br IL_0eed
 
-		IL_0ee1: ldloc.s 20
-		IL_0ee3: ldstr "prototype"
-		IL_0ee8: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:298"
-		IL_0eed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_0ef2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ed7: ldloc.s 20
+		IL_0ed9: ldstr "prototype"
+		IL_0ede: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:298"
+		IL_0ee3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_0ee8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0ef7: stloc.s 43
-		IL_0ef9: volatile.
-		IL_0efb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-		IL_0f00: brfalse IL_0f16
+		IL_0eed: stloc.s 43
+		IL_0eef: volatile.
+		IL_0ef1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_0ef6: brfalse IL_0f0c
 
-		IL_0f05: ldloc.s 43
-		IL_0f07: ldstr "method"
-		IL_0f0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0f11: br IL_0f2c
+		IL_0efb: ldloc.s 43
+		IL_0efd: ldstr "method"
+		IL_0f02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0f07: br IL_0f22
 
-		IL_0f16: ldloc.s 43
-		IL_0f18: ldstr "method"
-		IL_0f1d: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:300"
-		IL_0f22: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-		IL_0f27: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0f0c: ldloc.s 43
+		IL_0f0e: ldstr "method"
+		IL_0f13: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:300"
+		IL_0f18: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_0f1d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0f2c: stloc.s 43
-		IL_0f2e: ldloc.s 42
-		IL_0f30: ldloc.s 43
-		IL_0f32: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0f37: stloc.s 44
-		IL_0f39: ldloc.s 44
-		IL_0f3b: box [System.Runtime]System.Boolean
-		IL_0f40: stloc.s 47
-		IL_0f42: ldloc.s 39
-		IL_0f44: ldstr "identity"
-		IL_0f49: ldloc.s 47
-		IL_0f4b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0f50: pop
-		IL_0f51: nop
-		IL_0f52: ldloc.2
-		IL_0f53: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0f58: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0f5d: stloc.s 21
-		IL_0f5f: ldloc.2
-		IL_0f60: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0f65: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0f6a: stloc.s 22
-		IL_0f6c: ldloc.s 21
-		IL_0f6e: dup
-		IL_0f6f: ldc.r8 1
-		IL_0f78: box [System.Runtime]System.Double
-		IL_0f7d: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0f82: stloc.s 23
-		IL_0f84: ldloc.s 22
-		IL_0f86: dup
-		IL_0f87: ldc.r8 2
-		IL_0f90: box [System.Runtime]System.Double
-		IL_0f95: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0f9a: stloc.s 24
-		IL_0f9c: ldc.i4.0
-		IL_0f9d: box [System.Runtime]System.Boolean
-		IL_0fa2: stloc.s 25
+		IL_0f22: stloc.s 43
+		IL_0f24: ldloc.s 42
+		IL_0f26: ldloc.s 43
+		IL_0f28: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0f2d: stloc.s 44
+		IL_0f2f: ldloc.s 44
+		IL_0f31: box [System.Runtime]System.Boolean
+		IL_0f36: stloc.s 47
+		IL_0f38: ldloc.s 39
+		IL_0f3a: ldstr "identity"
+		IL_0f3f: ldloc.s 47
+		IL_0f41: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0f46: pop
+		IL_0f47: nop
+		IL_0f48: ldnull
+		IL_0f49: call object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass::__js_call__(object)
+		IL_0f4e: stloc.s 21
+		IL_0f50: ldnull
+		IL_0f51: call object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass::__js_call__(object)
+		IL_0f56: stloc.s 22
+		IL_0f58: ldloc.s 21
+		IL_0f5a: dup
+		IL_0f5b: ldc.r8 1
+		IL_0f64: box [System.Runtime]System.Double
+		IL_0f69: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0f6e: stloc.s 23
+		IL_0f70: ldloc.s 22
+		IL_0f72: dup
+		IL_0f73: ldc.r8 2
+		IL_0f7c: box [System.Runtime]System.Double
+		IL_0f81: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0f86: stloc.s 24
+		IL_0f88: ldc.i4.0
+		IL_0f89: box [System.Runtime]System.Boolean
+		IL_0f8e: stloc.s 25
 		.try
 		{
-			IL_0fa4: nop
-			IL_0fa5: volatile.
-			IL_0fa7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_0fac: brfalse IL_0fc2
+			IL_0f90: nop
+			IL_0f91: volatile.
+			IL_0f93: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0f98: brfalse IL_0fae
 
-			IL_0fb1: ldloc.s 21
-			IL_0fb3: ldstr "prototype"
-			IL_0fb8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0fbd: br IL_0fd8
+			IL_0f9d: ldloc.s 21
+			IL_0f9f: ldstr "prototype"
+			IL_0fa4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fa9: br IL_0fc4
 
-			IL_0fc2: ldloc.s 21
-			IL_0fc4: ldstr "prototype"
-			IL_0fc9: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:332"
-			IL_0fce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_0fd3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0fae: ldloc.s 21
+			IL_0fb0: ldstr "prototype"
+			IL_0fb5: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:332"
+			IL_0fba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0fbf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0fd8: stloc.s 43
-			IL_0fda: volatile.
-			IL_0fdc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_0fe1: brfalse IL_0ff7
+			IL_0fc4: stloc.s 43
+			IL_0fc6: volatile.
+			IL_0fc8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0fcd: brfalse IL_0fe3
 
-			IL_0fe6: ldloc.s 43
-			IL_0fe8: ldstr "read"
-			IL_0fed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ff2: br IL_100d
+			IL_0fd2: ldloc.s 43
+			IL_0fd4: ldstr "read"
+			IL_0fd9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fde: br IL_0ff9
 
-			IL_0ff7: ldloc.s 43
-			IL_0ff9: ldstr "read"
-			IL_0ffe: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:334"
-			IL_1003: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_1008: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0fe3: ldloc.s 43
+			IL_0fe5: ldstr "read"
+			IL_0fea: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:334"
+			IL_0fef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0ff4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_100d: stloc.s 43
-			IL_100f: ldloc.s 43
-			IL_1011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1016: volatile.
-			IL_1018: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_101d: brfalse IL_1033
+			IL_0ff9: stloc.s 43
+			IL_0ffb: ldloc.s 43
+			IL_0ffd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_1002: volatile.
+			IL_1004: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_1009: brfalse IL_101f
 
-			IL_1022: ldstr "call"
-			IL_1027: ldloc.s 24
-			IL_1029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_102e: br IL_1049
+			IL_100e: ldstr "call"
+			IL_1013: ldloc.s 24
+			IL_1015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_101a: br IL_1035
 
-			IL_1033: ldstr "call"
-			IL_1038: ldloc.s 24
-			IL_103a: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:336"
-			IL_103f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_1044: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_101f: ldstr "call"
+			IL_1024: ldloc.s 24
+			IL_1026: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:336"
+			IL_102b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_1030: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_1049: pop
-			IL_104a: leave IL_10ae
+			IL_1035: pop
+			IL_1036: leave IL_109a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_104f: stloc.s 26
-			IL_1051: ldloc.s 26
-			IL_1053: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_1058: dup
-			IL_1059: brtrue IL_106f
+			IL_103b: stloc.s 26
+			IL_103d: ldloc.s 26
+			IL_103f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_1044: dup
+			IL_1045: brtrue IL_105b
 
-			IL_105e: pop
-			IL_105f: ldloc.s 26
-			IL_1061: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_1066: dup
-			IL_1067: brtrue IL_107b
+			IL_104a: pop
+			IL_104b: ldloc.s 26
+			IL_104d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_1052: dup
+			IL_1053: brtrue IL_1067
 
-			IL_106c: pop
-			IL_106d: rethrow
+			IL_1058: pop
+			IL_1059: rethrow
 
-			IL_106f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_1074: stloc.s 27
-			IL_1076: br IL_107d
+			IL_105b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_1060: stloc.s 27
+			IL_1062: br IL_1069
 
-			IL_107b: stloc.s 27
+			IL_1067: stloc.s 27
 
-			IL_107d: ldloc.s 27
-			IL_107f: stloc.s 28
-			IL_1081: ldloc.s 28
-			IL_1083: stloc.s 43
-			IL_1085: ldstr "TypeError"
-			IL_108a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_108f: stloc.s 42
-			IL_1091: ldloc.s 43
-			IL_1093: ldloc.s 42
-			IL_1095: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_109a: stloc.s 44
-			IL_109c: ldloc.s 44
-			IL_109e: box [System.Runtime]System.Boolean
-			IL_10a3: stloc.s 47
-			IL_10a5: ldloc.s 47
-			IL_10a7: stloc.s 25
-			IL_10a9: leave IL_10ae
+			IL_1069: ldloc.s 27
+			IL_106b: stloc.s 28
+			IL_106d: ldloc.s 28
+			IL_106f: stloc.s 43
+			IL_1071: ldstr "TypeError"
+			IL_1076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_107b: stloc.s 42
+			IL_107d: ldloc.s 43
+			IL_107f: ldloc.s 42
+			IL_1081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_1086: stloc.s 44
+			IL_1088: ldloc.s 44
+			IL_108a: box [System.Runtime]System.Boolean
+			IL_108f: stloc.s 47
+			IL_1091: ldloc.s 47
+			IL_1093: stloc.s 25
+			IL_1095: leave IL_109a
 		} // end handler
 
-		IL_10ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_10b3: stloc.s 39
-		IL_10b5: volatile.
-		IL_10b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_10bc: brfalse IL_10d2
+		IL_109a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_109f: stloc.s 39
+		IL_10a1: volatile.
+		IL_10a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_10a8: brfalse IL_10be
 
-		IL_10c1: ldloc.s 21
-		IL_10c3: ldstr "prototype"
-		IL_10c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_10cd: br IL_10e8
+		IL_10ad: ldloc.s 21
+		IL_10af: ldstr "prototype"
+		IL_10b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_10b9: br IL_10d4
 
-		IL_10d2: ldloc.s 21
-		IL_10d4: ldstr "prototype"
-		IL_10d9: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:360"
-		IL_10de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_10e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_10be: ldloc.s 21
+		IL_10c0: ldstr "prototype"
+		IL_10c5: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:360"
+		IL_10ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_10cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_10e8: stloc.s 42
-		IL_10ea: volatile.
-		IL_10ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-		IL_10f1: brfalse IL_1107
+		IL_10d4: stloc.s 42
+		IL_10d6: volatile.
+		IL_10d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_10dd: brfalse IL_10f3
 
-		IL_10f6: ldloc.s 22
-		IL_10f8: ldstr "prototype"
-		IL_10fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1102: br IL_111d
+		IL_10e2: ldloc.s 22
+		IL_10e4: ldstr "prototype"
+		IL_10e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_10ee: br IL_1109
 
-		IL_1107: ldloc.s 22
-		IL_1109: ldstr "prototype"
-		IL_110e: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:362"
-		IL_1113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-		IL_1118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_10f3: ldloc.s 22
+		IL_10f5: ldstr "prototype"
+		IL_10fa: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:362"
+		IL_10ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_1104: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_111d: stloc.s 43
-		IL_111f: ldloc.s 42
-		IL_1121: ldloc.s 43
-		IL_1123: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_1128: stloc.s 44
-		IL_112a: ldloc.s 44
-		IL_112c: box [System.Runtime]System.Boolean
-		IL_1131: stloc.s 47
-		IL_1133: volatile.
-		IL_1135: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-		IL_113a: brfalse IL_1150
+		IL_1109: stloc.s 43
+		IL_110b: ldloc.s 42
+		IL_110d: ldloc.s 43
+		IL_110f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_1114: stloc.s 44
+		IL_1116: ldloc.s 44
+		IL_1118: box [System.Runtime]System.Boolean
+		IL_111d: stloc.s 47
+		IL_111f: volatile.
+		IL_1121: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+		IL_1126: brfalse IL_113c
 
-		IL_113f: ldloc.s 21
-		IL_1141: ldstr "prototype"
-		IL_1146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_114b: br IL_1166
+		IL_112b: ldloc.s 21
+		IL_112d: ldstr "prototype"
+		IL_1132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1137: br IL_1152
 
-		IL_1150: ldloc.s 21
-		IL_1152: ldstr "prototype"
-		IL_1157: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:366"
-		IL_115c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-		IL_1161: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_113c: ldloc.s 21
+		IL_113e: ldstr "prototype"
+		IL_1143: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:366"
+		IL_1148: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+		IL_114d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1166: stloc.s 43
-		IL_1168: volatile.
-		IL_116a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-		IL_116f: brfalse IL_1185
+		IL_1152: stloc.s 43
+		IL_1154: volatile.
+		IL_1156: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+		IL_115b: brfalse IL_1171
 
-		IL_1174: ldloc.s 43
-		IL_1176: ldstr "read"
-		IL_117b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1180: br IL_119b
+		IL_1160: ldloc.s 43
+		IL_1162: ldstr "read"
+		IL_1167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_116c: br IL_1187
 
-		IL_1185: ldloc.s 43
-		IL_1187: ldstr "read"
-		IL_118c: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:368"
-		IL_1191: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-		IL_1196: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1171: ldloc.s 43
+		IL_1173: ldstr "read"
+		IL_1178: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:368"
+		IL_117d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+		IL_1182: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_119b: stloc.s 43
-		IL_119d: volatile.
-		IL_119f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_11a4: brfalse IL_11ba
+		IL_1187: stloc.s 43
+		IL_1189: volatile.
+		IL_118b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_1190: brfalse IL_11a6
 
-		IL_11a9: ldloc.s 22
-		IL_11ab: ldstr "prototype"
-		IL_11b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_11b5: br IL_11d0
+		IL_1195: ldloc.s 22
+		IL_1197: ldstr "prototype"
+		IL_119c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_11a1: br IL_11bc
 
-		IL_11ba: ldloc.s 22
-		IL_11bc: ldstr "prototype"
-		IL_11c1: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:370"
-		IL_11c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_11cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_11a6: ldloc.s 22
+		IL_11a8: ldstr "prototype"
+		IL_11ad: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:370"
+		IL_11b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_11b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_11d0: stloc.s 42
-		IL_11d2: volatile.
-		IL_11d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_11d9: brfalse IL_11ef
+		IL_11bc: stloc.s 42
+		IL_11be: volatile.
+		IL_11c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_11c5: brfalse IL_11db
 
-		IL_11de: ldloc.s 42
-		IL_11e0: ldstr "read"
-		IL_11e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_11ea: br IL_1205
+		IL_11ca: ldloc.s 42
+		IL_11cc: ldstr "read"
+		IL_11d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_11d6: br IL_11f1
 
-		IL_11ef: ldloc.s 42
-		IL_11f1: ldstr "read"
-		IL_11f6: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:372"
-		IL_11fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_1200: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_11db: ldloc.s 42
+		IL_11dd: ldstr "read"
+		IL_11e2: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:372"
+		IL_11e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_11ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1205: stloc.s 42
-		IL_1207: ldloc.s 43
-		IL_1209: ldloc.s 42
-		IL_120b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_1210: stloc.s 44
-		IL_1212: ldloc.s 44
-		IL_1214: box [System.Runtime]System.Boolean
-		IL_1219: stloc.s 46
-		IL_121b: volatile.
-		IL_121d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-		IL_1222: brfalse IL_1238
+		IL_11f1: stloc.s 42
+		IL_11f3: ldloc.s 43
+		IL_11f5: ldloc.s 42
+		IL_11f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_11fc: stloc.s 44
+		IL_11fe: ldloc.s 44
+		IL_1200: box [System.Runtime]System.Boolean
+		IL_1205: stloc.s 46
+		IL_1207: volatile.
+		IL_1209: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_120e: brfalse IL_1224
 
-		IL_1227: ldloc.s 21
-		IL_1229: ldstr "prototype"
-		IL_122e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1233: br IL_124e
+		IL_1213: ldloc.s 21
+		IL_1215: ldstr "prototype"
+		IL_121a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_121f: br IL_123a
 
-		IL_1238: ldloc.s 21
-		IL_123a: ldstr "prototype"
-		IL_123f: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:376"
-		IL_1244: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-		IL_1249: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1224: ldloc.s 21
+		IL_1226: ldstr "prototype"
+		IL_122b: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:376"
+		IL_1230: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_1235: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_124e: stloc.s 42
-		IL_1250: volatile.
-		IL_1252: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-		IL_1257: brfalse IL_126d
+		IL_123a: stloc.s 42
+		IL_123c: volatile.
+		IL_123e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+		IL_1243: brfalse IL_1259
 
-		IL_125c: ldloc.s 42
-		IL_125e: ldstr "read"
-		IL_1263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_1268: br IL_1283
+		IL_1248: ldloc.s 42
+		IL_124a: ldstr "read"
+		IL_124f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1254: br IL_126f
 
-		IL_126d: ldloc.s 42
-		IL_126f: ldstr "read"
-		IL_1274: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:378"
-		IL_1279: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-		IL_127e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_1259: ldloc.s 42
+		IL_125b: ldstr "read"
+		IL_1260: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:378"
+		IL_1265: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+		IL_126a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1283: stloc.s 42
-		IL_1285: ldloc.s 42
-		IL_1287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_128c: volatile.
-		IL_128e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-		IL_1293: brfalse IL_12a9
+		IL_126f: stloc.s 42
+		IL_1271: ldloc.s 42
+		IL_1273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_1278: volatile.
+		IL_127a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+		IL_127f: brfalse IL_1295
 
-		IL_1298: ldstr "call"
-		IL_129d: ldloc.s 23
-		IL_129f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_12a4: br IL_12bf
+		IL_1284: ldstr "call"
+		IL_1289: ldloc.s 23
+		IL_128b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_1290: br IL_12ab
 
-		IL_12a9: ldstr "call"
-		IL_12ae: ldloc.s 23
-		IL_12b0: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:380"
-		IL_12b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-		IL_12ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_1295: ldstr "call"
+		IL_129a: ldloc.s 23
+		IL_129c: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:380"
+		IL_12a1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+		IL_12a6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_12bf: stloc.s 42
-		IL_12c1: ldloc.s 39
-		IL_12c3: ldc.i4.5
-		IL_12c4: newarr [System.Runtime]System.Object
-		IL_12c9: dup
-		IL_12ca: ldc.i4.0
-		IL_12cb: ldstr "privateIdentity"
+		IL_12ab: stloc.s 42
+		IL_12ad: ldloc.s 39
+		IL_12af: ldc.i4.5
+		IL_12b0: newarr [System.Runtime]System.Object
+		IL_12b5: dup
+		IL_12b6: ldc.i4.0
+		IL_12b7: ldstr "privateIdentity"
+		IL_12bc: stelem.ref
+		IL_12bd: dup
+		IL_12be: ldc.i4.1
+		IL_12bf: ldloc.s 47
+		IL_12c1: stelem.ref
+		IL_12c2: dup
+		IL_12c3: ldc.i4.2
+		IL_12c4: ldloc.s 46
+		IL_12c6: stelem.ref
+		IL_12c7: dup
+		IL_12c8: ldc.i4.3
+		IL_12c9: ldloc.s 42
+		IL_12cb: stelem.ref
+		IL_12cc: dup
+		IL_12cd: ldc.i4.4
+		IL_12ce: ldloc.s 25
 		IL_12d0: stelem.ref
-		IL_12d1: dup
-		IL_12d2: ldc.i4.1
-		IL_12d3: ldloc.s 47
-		IL_12d5: stelem.ref
-		IL_12d6: dup
-		IL_12d7: ldc.i4.2
-		IL_12d8: ldloc.s 46
-		IL_12da: stelem.ref
-		IL_12db: dup
-		IL_12dc: ldc.i4.3
-		IL_12dd: ldloc.s 42
-		IL_12df: stelem.ref
-		IL_12e0: dup
-		IL_12e1: ldc.i4.4
-		IL_12e2: ldloc.s 25
-		IL_12e4: stelem.ref
-		IL_12e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_12ea: pop
-		IL_12eb: ldc.i4.0
-		IL_12ec: box [System.Runtime]System.Boolean
-		IL_12f1: stloc.s 29
+		IL_12d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_12d6: pop
+		IL_12d7: ldc.i4.0
+		IL_12d8: box [System.Runtime]System.Boolean
+		IL_12dd: stloc.s 29
 		.try
 		{
-			IL_12f3: nop
-			IL_12f4: volatile.
-			IL_12f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_12fb: brfalse IL_1311
+			IL_12df: nop
+			IL_12e0: volatile.
+			IL_12e2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_12e7: brfalse IL_12fd
 
-			IL_1300: ldloc.s 21
-			IL_1302: ldstr "readStatic"
-			IL_1307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_130c: br IL_1327
+			IL_12ec: ldloc.s 21
+			IL_12ee: ldstr "readStatic"
+			IL_12f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_12f8: br IL_1313
 
-			IL_1311: ldloc.s 21
-			IL_1313: ldstr "readStatic"
-			IL_1318: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:391"
-			IL_131d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_1322: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_12fd: ldloc.s 21
+			IL_12ff: ldstr "readStatic"
+			IL_1304: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:391"
+			IL_1309: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_130e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1327: stloc.s 42
-			IL_1329: ldloc.s 42
-			IL_132b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_1330: volatile.
-			IL_1332: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_1337: brfalse IL_134d
+			IL_1313: stloc.s 42
+			IL_1315: ldloc.s 42
+			IL_1317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_131c: volatile.
+			IL_131e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_1323: brfalse IL_1339
 
-			IL_133c: ldstr "call"
-			IL_1341: ldloc.s 22
-			IL_1343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_1348: br IL_1363
+			IL_1328: ldstr "call"
+			IL_132d: ldloc.s 22
+			IL_132f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_1334: br IL_134f
 
-			IL_134d: ldstr "call"
-			IL_1352: ldloc.s 22
-			IL_1354: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:393"
-			IL_1359: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_135e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_1339: ldstr "call"
+			IL_133e: ldloc.s 22
+			IL_1340: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:393"
+			IL_1345: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_134a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_1363: pop
-			IL_1364: leave IL_13c8
+			IL_134f: pop
+			IL_1350: leave IL_13b4
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_1369: stloc.s 30
-			IL_136b: ldloc.s 30
-			IL_136d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_1372: dup
-			IL_1373: brtrue IL_1389
+			IL_1355: stloc.s 30
+			IL_1357: ldloc.s 30
+			IL_1359: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_135e: dup
+			IL_135f: brtrue IL_1375
 
-			IL_1378: pop
-			IL_1379: ldloc.s 30
-			IL_137b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_1380: dup
-			IL_1381: brtrue IL_1395
+			IL_1364: pop
+			IL_1365: ldloc.s 30
+			IL_1367: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_136c: dup
+			IL_136d: brtrue IL_1381
 
-			IL_1386: pop
-			IL_1387: rethrow
+			IL_1372: pop
+			IL_1373: rethrow
 
-			IL_1389: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_138e: stloc.s 31
-			IL_1390: br IL_1397
+			IL_1375: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_137a: stloc.s 31
+			IL_137c: br IL_1383
 
-			IL_1395: stloc.s 31
+			IL_1381: stloc.s 31
 
-			IL_1397: ldloc.s 31
-			IL_1399: stloc.s 32
-			IL_139b: ldloc.s 32
-			IL_139d: stloc.s 42
-			IL_139f: ldstr "TypeError"
-			IL_13a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_13a9: stloc.s 43
-			IL_13ab: ldloc.s 42
-			IL_13ad: ldloc.s 43
-			IL_13af: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_13b4: stloc.s 44
-			IL_13b6: ldloc.s 44
-			IL_13b8: box [System.Runtime]System.Boolean
-			IL_13bd: stloc.s 46
-			IL_13bf: ldloc.s 46
-			IL_13c1: stloc.s 29
-			IL_13c3: leave IL_13c8
+			IL_1383: ldloc.s 31
+			IL_1385: stloc.s 32
+			IL_1387: ldloc.s 32
+			IL_1389: stloc.s 42
+			IL_138b: ldstr "TypeError"
+			IL_1390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_1395: stloc.s 43
+			IL_1397: ldloc.s 42
+			IL_1399: ldloc.s 43
+			IL_139b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_13a0: stloc.s 44
+			IL_13a2: ldloc.s 44
+			IL_13a4: box [System.Runtime]System.Boolean
+			IL_13a9: stloc.s 46
+			IL_13ab: ldloc.s 46
+			IL_13ad: stloc.s 29
+			IL_13af: leave IL_13b4
 		} // end handler
 
-		IL_13c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_13cd: stloc.s 39
-		IL_13cf: volatile.
-		IL_13d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-		IL_13d6: brfalse IL_13ec
+		IL_13b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_13b9: stloc.s 39
+		IL_13bb: volatile.
+		IL_13bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+		IL_13c2: brfalse IL_13d8
 
-		IL_13db: ldloc.s 21
-		IL_13dd: ldstr "readStatic"
-		IL_13e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_13e7: br IL_1402
+		IL_13c7: ldloc.s 21
+		IL_13c9: ldstr "readStatic"
+		IL_13ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_13d3: br IL_13ee
 
-		IL_13ec: ldloc.s 21
-		IL_13ee: ldstr "readStatic"
-		IL_13f3: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:417"
-		IL_13f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-		IL_13fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_13d8: ldloc.s 21
+		IL_13da: ldstr "readStatic"
+		IL_13df: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:417"
+		IL_13e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+		IL_13e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1402: stloc.s 43
-		IL_1404: volatile.
-		IL_1406: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-		IL_140b: brfalse IL_1421
+		IL_13ee: stloc.s 43
+		IL_13f0: volatile.
+		IL_13f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_13f7: brfalse IL_140d
 
-		IL_1410: ldloc.s 22
-		IL_1412: ldstr "readStatic"
-		IL_1417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_141c: br IL_1437
+		IL_13fc: ldloc.s 22
+		IL_13fe: ldstr "readStatic"
+		IL_1403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_1408: br IL_1423
 
-		IL_1421: ldloc.s 22
-		IL_1423: ldstr "readStatic"
-		IL_1428: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:419"
-		IL_142d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-		IL_1432: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_140d: ldloc.s 22
+		IL_140f: ldstr "readStatic"
+		IL_1414: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:419"
+		IL_1419: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_141e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_1437: stloc.s 42
-		IL_1439: ldloc.s 43
-		IL_143b: ldloc.s 42
-		IL_143d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_1442: stloc.s 44
-		IL_1444: ldloc.s 44
-		IL_1446: box [System.Runtime]System.Boolean
-		IL_144b: stloc.s 46
-		IL_144d: ldloc.s 21
-		IL_144f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_1454: volatile.
-		IL_1456: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-		IL_145b: brfalse IL_146f
+		IL_1423: stloc.s 42
+		IL_1425: ldloc.s 43
+		IL_1427: ldloc.s 42
+		IL_1429: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_142e: stloc.s 44
+		IL_1430: ldloc.s 44
+		IL_1432: box [System.Runtime]System.Boolean
+		IL_1437: stloc.s 46
+		IL_1439: ldloc.s 21
+		IL_143b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_1440: volatile.
+		IL_1442: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+		IL_1447: brfalse IL_145b
 
-		IL_1460: ldstr "readStatic"
-		IL_1465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_146a: br IL_1483
+		IL_144c: ldstr "readStatic"
+		IL_1451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_1456: br IL_146f
 
-		IL_146f: ldstr "readStatic"
-		IL_1474: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:423"
-		IL_1479: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-		IL_147e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_145b: ldstr "readStatic"
+		IL_1460: ldstr "Classes_GeneratedMethodFunctionObjects:Modules.Classes_GeneratedMethodFunctionObjects:__js_module_init__:423"
+		IL_1465: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+		IL_146a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_1483: stloc.s 42
-		IL_1485: ldloc.s 39
-		IL_1487: ldc.i4.4
-		IL_1488: newarr [System.Runtime]System.Object
-		IL_148d: dup
-		IL_148e: ldc.i4.0
-		IL_148f: ldstr "staticPrivateIdentity"
-		IL_1494: stelem.ref
-		IL_1495: dup
-		IL_1496: ldc.i4.1
-		IL_1497: ldloc.s 46
-		IL_1499: stelem.ref
-		IL_149a: dup
-		IL_149b: ldc.i4.2
-		IL_149c: ldloc.s 42
-		IL_149e: stelem.ref
-		IL_149f: dup
-		IL_14a0: ldc.i4.3
-		IL_14a1: ldloc.s 29
-		IL_14a3: stelem.ref
-		IL_14a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_14a9: pop
-		IL_14aa: ldnull
-		IL_14ab: stloc.s 33
-		IL_14ad: ret
+		IL_146f: stloc.s 42
+		IL_1471: ldloc.s 39
+		IL_1473: ldc.i4.4
+		IL_1474: newarr [System.Runtime]System.Object
+		IL_1479: dup
+		IL_147a: ldc.i4.0
+		IL_147b: ldstr "staticPrivateIdentity"
+		IL_1480: stelem.ref
+		IL_1481: dup
+		IL_1482: ldc.i4.1
+		IL_1483: ldloc.s 46
+		IL_1485: stelem.ref
+		IL_1486: dup
+		IL_1487: ldc.i4.2
+		IL_1488: ldloc.s 42
+		IL_148a: stelem.ref
+		IL_148b: dup
+		IL_148c: ldc.i4.3
+		IL_148d: ldloc.s 29
+		IL_148f: stelem.ref
+		IL_1490: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_1495: pop
+		IL_1496: ldnull
+		IL_1497: stloc.s 33
+		IL_1499: ret
 	} // end of method Classes_GeneratedMethodFunctionObjects::__js_module_init__
 
 } // end of class Modules.Classes_GeneratedMethodFunctionObjects

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
@@ -835,7 +835,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 217 (0xd9)
+		// Code size: 218 (0xda)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope,
@@ -924,11 +924,12 @@
 		IL_00c4: ldloc.s 5
 		IL_00c6: stfld object Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope::GlobalBase
 		IL_00cb: nop
-		IL_00cc: ldloc.1
-		IL_00cd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00d7: pop
-		IL_00d8: ret
+		IL_00cc: ldloc.0
+		IL_00cd: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope
+		IL_00d2: ldnull
+		IL_00d3: call object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun::__js_call__(class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope, object)
+		IL_00d8: pop
+		IL_00d9: ret
 	} // end of method Classes_Inheritance_NestedClassExtendsGlobal::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_NestedClassExtendsGlobal

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -926,7 +926,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 60 (0x3c)
+		// Code size: 61 (0x3d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope,
@@ -957,11 +957,12 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldloc.1
-		IL_0030: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003a: pop
-		IL_003b: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope
+		IL_0035: ldnull
+		IL_0036: call object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
+		IL_003b: pop
+		IL_003c: ret
 	} // end of method Classes_Inheritance_SuperCapturedScopeVar::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_SuperCapturedScopeVar

--- a/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
+++ b/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
@@ -287,7 +287,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 181 (0xb5)
+		// Code size: 150 (0x96)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/Scope,
@@ -320,52 +320,41 @@
 		IL_0026: nop
 		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002c: stloc.3
-		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0032: stloc.2
-		IL_0033: ldloc.1
-		IL_0034: ldloc.2
-		IL_0035: ldc.r8 5
-		IL_003e: box [System.Runtime]System.Double
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0048: stloc.s 4
-		IL_004a: ldloc.3
-		IL_004b: ldloc.s 4
-		IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0052: pop
-		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0058: stloc.3
-		IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005e: stloc.2
-		IL_005f: ldloc.1
-		IL_0060: ldloc.2
-		IL_0061: ldc.r8 3.14
-		IL_006a: box [System.Runtime]System.Double
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0074: stloc.s 4
-		IL_0076: ldloc.3
-		IL_0077: ldloc.s 4
-		IL_0079: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007e: pop
-		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0084: stloc.3
-		IL_0085: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008a: stloc.2
-		IL_008b: ldc.r8 2
-		IL_0094: neg
-		IL_0095: stloc.s 5
-		IL_0097: ldloc.s 5
-		IL_0099: box [System.Runtime]System.Double
-		IL_009e: stloc.s 6
-		IL_00a0: ldloc.1
-		IL_00a1: ldloc.2
-		IL_00a2: ldloc.s 6
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00a9: stloc.s 4
-		IL_00ab: ldloc.3
-		IL_00ac: ldloc.s 4
-		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b3: pop
-		IL_00b4: ret
+		IL_002d: ldnull
+		IL_002e: ldc.r8 5
+		IL_0037: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
+		IL_003c: stloc.s 4
+		IL_003e: ldloc.3
+		IL_003f: ldloc.s 4
+		IL_0041: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0046: pop
+		IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004c: stloc.3
+		IL_004d: ldnull
+		IL_004e: ldc.r8 3.14
+		IL_0057: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
+		IL_005c: stloc.s 4
+		IL_005e: ldloc.3
+		IL_005f: ldloc.s 4
+		IL_0061: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0066: pop
+		IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006c: stloc.3
+		IL_006d: ldc.r8 2
+		IL_0076: neg
+		IL_0077: stloc.s 5
+		IL_0079: ldloc.s 5
+		IL_007b: box [System.Runtime]System.Double
+		IL_0080: stloc.s 6
+		IL_0082: ldnull
+		IL_0083: ldloc.s 5
+		IL_0085: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
+		IL_008a: stloc.s 4
+		IL_008c: ldloc.3
+		IL_008d: ldloc.s 4
+		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0094: pop
+		IL_0095: ret
 	} // end of method CoercionCSE_BoxedDoubleToNumber_NoCse::__js_module_init__
 
 } // end of class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -654,7 +654,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 331 (0x14b)
+		// Code size: 332 (0x14c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Basic/Scope,
@@ -783,11 +783,12 @@
 		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 		IL_013d: pop
-		IL_013e: ldloc.1
-		IL_013f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0149: pop
-		IL_014a: ret
+		IL_013e: ldloc.0
+		IL_013f: castclass Modules.CommonJS_Require_Basic/Scope
+		IL_0144: ldnull
+		IL_0145: call object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
+		IL_014a: pop
+		IL_014b: ret
 	} // end of method CommonJS_Require_Basic::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Basic
@@ -1350,7 +1351,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 299 (0x12b)
+		// Code size: 300 (0x12c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Dependency/Scope,
@@ -1468,11 +1469,12 @@
 		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 		IL_011d: pop
-		IL_011e: ldloc.1
-		IL_011f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0129: pop
-		IL_012a: ret
+		IL_011e: ldloc.0
+		IL_011f: castclass Modules.CommonJS_Require_Dependency/Scope
+		IL_0124: ldnull
+		IL_0125: call object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
+		IL_012a: pop
+		IL_012b: ret
 	} // end of method CommonJS_Require_Dependency::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Dependency

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_FunctionValueIdentity.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_FunctionValueIdentity.verified.txt
@@ -732,7 +732,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1404 (0x57c)
+		// Code size: 1396 (0x574)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_FunctionValueIdentity/Scope,
@@ -801,422 +801,420 @@
 		IL_005f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
 		IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
 		IL_0069: stloc.3
-		IL_006a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006f: stloc.s 8
-		IL_0071: ldloc.0
-		IL_0072: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_007c: stloc.s 9
-		IL_007e: ldloc.1
-		IL_007f: ldloc.s 8
-		IL_0081: ldloc.s 9
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0088: stloc.s 4
-		IL_008a: ldloc.0
-		IL_008b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_0095: stloc.s 9
-		IL_0097: newobj instance void Modules.CommonJS_Require_FunctionValueIdentity/ObjectLiterals/L13C16_holder::.ctor()
-		IL_009c: stloc.s 5
-		IL_009e: ldloc.s 5
-		IL_00a0: ldloc.s 9
-		IL_00a2: callvirt instance void Modules.CommonJS_Require_FunctionValueIdentity/ObjectLiterals/L13C16_holder::set_value(object)
-		IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ac: stloc.s 10
-		IL_00ae: ldloc.0
-		IL_00af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_00b4: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_00b9: stloc.s 9
-		IL_00bb: ldloc.s 9
-		IL_00bd: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_00c2: stloc.s 11
-		IL_00c4: ldloc.s 10
-		IL_00c6: ldloc.s 11
-		IL_00c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cd: pop
-		IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d3: stloc.s 10
-		IL_00d5: ldloc.0
-		IL_00d6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_00e0: stloc.s 9
-		IL_00e2: ldloc.3
-		IL_00e3: ldloc.s 9
-		IL_00e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00ea: stloc.s 12
-		IL_00ec: ldloc.s 12
-		IL_00ee: box [System.Runtime]System.Boolean
-		IL_00f3: stloc.s 13
-		IL_00f5: ldloc.s 10
-		IL_00f7: ldloc.s 13
-		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fe: pop
-		IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0104: stloc.s 10
-		IL_0106: ldloc.0
-		IL_0107: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_010c: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_0111: stloc.s 9
-		IL_0113: ldloc.s 4
-		IL_0115: ldloc.s 9
-		IL_0117: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_011c: stloc.s 12
-		IL_011e: ldloc.s 12
-		IL_0120: box [System.Runtime]System.Boolean
-		IL_0125: stloc.s 13
-		IL_0127: ldloc.s 10
-		IL_0129: ldloc.s 13
-		IL_012b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0130: pop
-		IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0136: stloc.s 10
-		IL_0138: ldloc.s 5
-		IL_013a: castclass Modules.CommonJS_Require_FunctionValueIdentity/ObjectLiterals/L13C16_holder
-		IL_013f: callvirt instance object Modules.CommonJS_Require_FunctionValueIdentity/ObjectLiterals/L13C16_holder::get_value()
-		IL_0144: stloc.s 14
-		IL_0146: ldloc.0
-		IL_0147: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_0151: stloc.s 9
-		IL_0153: ldloc.s 14
-		IL_0155: ldloc.s 9
-		IL_0157: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_015c: stloc.s 12
-		IL_015e: ldloc.s 12
-		IL_0160: box [System.Runtime]System.Boolean
-		IL_0165: stloc.s 13
-		IL_0167: ldloc.s 10
-		IL_0169: ldloc.s 13
-		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0170: pop
-		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0176: stloc.s 10
-		IL_0178: ldloc.2
-		IL_0179: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0183: stloc.s 14
-		IL_0185: ldloc.0
-		IL_0186: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_018b: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_0190: stloc.s 9
-		IL_0192: ldloc.s 14
-		IL_0194: ldloc.s 9
-		IL_0196: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_019b: stloc.s 12
-		IL_019d: ldloc.s 12
-		IL_019f: box [System.Runtime]System.Boolean
-		IL_01a4: stloc.s 13
-		IL_01a6: ldloc.s 10
-		IL_01a8: ldloc.s 13
-		IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01af: pop
-		IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b5: stloc.s 10
-		IL_01b7: volatile.
-		IL_01b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_01be: brfalse IL_01d3
+		IL_006a: ldloc.0
+		IL_006b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_0075: stloc.s 9
+		IL_0077: ldnull
+		IL_0078: ldloc.s 9
+		IL_007a: call object Modules.CommonJS_Require_FunctionValueIdentity/passthrough::__js_call__(object, object)
+		IL_007f: stloc.s 4
+		IL_0081: ldloc.0
+		IL_0082: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_008c: stloc.s 9
+		IL_008e: newobj instance void Modules.CommonJS_Require_FunctionValueIdentity/ObjectLiterals/L13C16_holder::.ctor()
+		IL_0093: stloc.s 5
+		IL_0095: ldloc.s 5
+		IL_0097: ldloc.s 9
+		IL_0099: callvirt instance void Modules.CommonJS_Require_FunctionValueIdentity/ObjectLiterals/L13C16_holder::set_value(object)
+		IL_009e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a3: stloc.s 10
+		IL_00a5: ldloc.0
+		IL_00a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_00b0: stloc.s 9
+		IL_00b2: ldloc.s 9
+		IL_00b4: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_00b9: stloc.s 11
+		IL_00bb: ldloc.s 10
+		IL_00bd: ldloc.s 11
+		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c4: pop
+		IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ca: stloc.s 10
+		IL_00cc: ldloc.0
+		IL_00cd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_00d2: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_00d7: stloc.s 9
+		IL_00d9: ldloc.3
+		IL_00da: ldloc.s 9
+		IL_00dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00e1: stloc.s 12
+		IL_00e3: ldloc.s 12
+		IL_00e5: box [System.Runtime]System.Boolean
+		IL_00ea: stloc.s 13
+		IL_00ec: ldloc.s 10
+		IL_00ee: ldloc.s 13
+		IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f5: pop
+		IL_00f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fb: stloc.s 10
+		IL_00fd: ldloc.0
+		IL_00fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_0108: stloc.s 9
+		IL_010a: ldloc.s 4
+		IL_010c: ldloc.s 9
+		IL_010e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0113: stloc.s 12
+		IL_0115: ldloc.s 12
+		IL_0117: box [System.Runtime]System.Boolean
+		IL_011c: stloc.s 13
+		IL_011e: ldloc.s 10
+		IL_0120: ldloc.s 13
+		IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0127: pop
+		IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012d: stloc.s 10
+		IL_012f: ldloc.s 5
+		IL_0131: castclass Modules.CommonJS_Require_FunctionValueIdentity/ObjectLiterals/L13C16_holder
+		IL_0136: callvirt instance object Modules.CommonJS_Require_FunctionValueIdentity/ObjectLiterals/L13C16_holder::get_value()
+		IL_013b: stloc.s 14
+		IL_013d: ldloc.0
+		IL_013e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_0143: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_0148: stloc.s 9
+		IL_014a: ldloc.s 14
+		IL_014c: ldloc.s 9
+		IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0153: stloc.s 12
+		IL_0155: ldloc.s 12
+		IL_0157: box [System.Runtime]System.Boolean
+		IL_015c: stloc.s 13
+		IL_015e: ldloc.s 10
+		IL_0160: ldloc.s 13
+		IL_0162: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0167: pop
+		IL_0168: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016d: stloc.s 10
+		IL_016f: ldloc.0
+		IL_0170: castclass Modules.CommonJS_Require_FunctionValueIdentity/Scope
+		IL_0175: ldnull
+		IL_0176: call object Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire::__js_call__(class Modules.CommonJS_Require_FunctionValueIdentity/Scope, object)
+		IL_017b: stloc.s 14
+		IL_017d: ldloc.0
+		IL_017e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_0183: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_0188: stloc.s 9
+		IL_018a: ldloc.s 14
+		IL_018c: ldloc.s 9
+		IL_018e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0193: stloc.s 12
+		IL_0195: ldloc.s 12
+		IL_0197: box [System.Runtime]System.Boolean
+		IL_019c: stloc.s 13
+		IL_019e: ldloc.s 10
+		IL_01a0: ldloc.s 13
+		IL_01a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a7: pop
+		IL_01a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ad: stloc.s 10
+		IL_01af: volatile.
+		IL_01b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01b6: brfalse IL_01cb
 
-		IL_01c3: ldarg.2
-		IL_01c4: ldstr "require"
-		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ce: br IL_01e8
+		IL_01bb: ldarg.2
+		IL_01bc: ldstr "require"
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c6: br IL_01e0
 
-		IL_01d3: ldarg.2
-		IL_01d4: ldstr "require"
-		IL_01d9: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:59"
-		IL_01de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01cb: ldarg.2
+		IL_01cc: ldstr "require"
+		IL_01d1: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:59"
+		IL_01d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01e8: stloc.s 14
-		IL_01ea: ldloc.0
-		IL_01eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_01f0: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_01f5: stloc.s 9
-		IL_01f7: ldloc.s 14
-		IL_01f9: ldloc.s 9
-		IL_01fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0200: stloc.s 12
-		IL_0202: ldloc.s 12
-		IL_0204: box [System.Runtime]System.Boolean
-		IL_0209: stloc.s 13
-		IL_020b: ldloc.s 10
-		IL_020d: ldloc.s 13
-		IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0214: pop
-		IL_0215: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021a: stloc.s 10
-		IL_021c: ldloc.0
-		IL_021d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_0222: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_0227: volatile.
-		IL_0229: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_022e: brfalse IL_0242
+		IL_01e0: stloc.s 14
+		IL_01e2: ldloc.0
+		IL_01e3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_01ed: stloc.s 9
+		IL_01ef: ldloc.s 14
+		IL_01f1: ldloc.s 9
+		IL_01f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01f8: stloc.s 12
+		IL_01fa: ldloc.s 12
+		IL_01fc: box [System.Runtime]System.Boolean
+		IL_0201: stloc.s 13
+		IL_0203: ldloc.s 10
+		IL_0205: ldloc.s 13
+		IL_0207: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_020c: pop
+		IL_020d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0212: stloc.s 10
+		IL_0214: ldloc.0
+		IL_0215: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_021a: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_021f: volatile.
+		IL_0221: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0226: brfalse IL_023a
 
-		IL_0233: ldstr "main"
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_023d: br IL_0256
+		IL_022b: ldstr "main"
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0235: br IL_024e
 
-		IL_0242: ldstr "main"
-		IL_0247: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:68"
-		IL_024c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_023a: ldstr "main"
+		IL_023f: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:68"
+		IL_0244: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0256: stloc.s 14
-		IL_0258: ldloc.s 14
-		IL_025a: ldarg.2
-		IL_025b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0260: stloc.s 12
-		IL_0262: ldloc.s 12
-		IL_0264: box [System.Runtime]System.Boolean
-		IL_0269: stloc.s 13
-		IL_026b: ldloc.s 10
-		IL_026d: ldloc.s 13
-		IL_026f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0274: pop
-		IL_0275: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_027a: stloc.s 10
-		IL_027c: volatile.
-		IL_027e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0283: brfalse IL_0298
+		IL_024e: stloc.s 14
+		IL_0250: ldloc.s 14
+		IL_0252: ldarg.2
+		IL_0253: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0258: stloc.s 12
+		IL_025a: ldloc.s 12
+		IL_025c: box [System.Runtime]System.Boolean
+		IL_0261: stloc.s 13
+		IL_0263: ldloc.s 10
+		IL_0265: ldloc.s 13
+		IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_026c: pop
+		IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0272: stloc.s 10
+		IL_0274: volatile.
+		IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_027b: brfalse IL_0290
 
-		IL_0288: ldarg.2
-		IL_0289: ldstr "require"
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0293: br IL_02ad
+		IL_0280: ldarg.2
+		IL_0281: ldstr "require"
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028b: br IL_02a5
 
-		IL_0298: ldarg.2
-		IL_0299: ldstr "require"
-		IL_029e: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:77"
-		IL_02a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0290: ldarg.2
+		IL_0291: ldstr "require"
+		IL_0296: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:77"
+		IL_029b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02ad: stloc.s 14
-		IL_02af: volatile.
-		IL_02b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02b6: brfalse IL_02cc
+		IL_02a5: stloc.s 14
+		IL_02a7: volatile.
+		IL_02a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02ae: brfalse IL_02c4
 
-		IL_02bb: ldloc.s 14
-		IL_02bd: ldstr "main"
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02c7: br IL_02e2
+		IL_02b3: ldloc.s 14
+		IL_02b5: ldstr "main"
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02bf: br IL_02da
 
-		IL_02cc: ldloc.s 14
-		IL_02ce: ldstr "main"
-		IL_02d3: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:79"
-		IL_02d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02c4: ldloc.s 14
+		IL_02c6: ldstr "main"
+		IL_02cb: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:79"
+		IL_02d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02e2: stloc.s 14
-		IL_02e4: ldloc.s 14
-		IL_02e6: ldarg.2
-		IL_02e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02ec: stloc.s 12
-		IL_02ee: ldloc.s 12
-		IL_02f0: box [System.Runtime]System.Boolean
-		IL_02f5: stloc.s 13
-		IL_02f7: ldloc.s 10
-		IL_02f9: ldloc.s 13
-		IL_02fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0300: pop
-		IL_0301: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0306: stloc.s 10
-		IL_0308: ldloc.0
-		IL_0309: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_030e: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_0313: volatile.
-		IL_0315: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_031a: brfalse IL_032e
+		IL_02da: stloc.s 14
+		IL_02dc: ldloc.s 14
+		IL_02de: ldarg.2
+		IL_02df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02e4: stloc.s 12
+		IL_02e6: ldloc.s 12
+		IL_02e8: box [System.Runtime]System.Boolean
+		IL_02ed: stloc.s 13
+		IL_02ef: ldloc.s 10
+		IL_02f1: ldloc.s 13
+		IL_02f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02f8: pop
+		IL_02f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02fe: stloc.s 10
+		IL_0300: ldloc.0
+		IL_0301: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_0306: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_030b: volatile.
+		IL_030d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0312: brfalse IL_0326
 
-		IL_031f: ldstr "name"
-		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0329: br IL_0342
+		IL_0317: ldstr "name"
+		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0321: br IL_033a
 
-		IL_032e: ldstr "name"
-		IL_0333: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:88"
-		IL_0338: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0326: ldstr "name"
+		IL_032b: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:88"
+		IL_0330: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0342: stloc.s 14
-		IL_0344: ldloc.s 10
-		IL_0346: ldloc.s 14
-		IL_0348: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_034d: pop
-		IL_034e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0353: stloc.s 10
-		IL_0355: ldloc.0
-		IL_0356: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_035b: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_0360: volatile.
-		IL_0362: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0367: brfalse IL_037b
+		IL_033a: stloc.s 14
+		IL_033c: ldloc.s 10
+		IL_033e: ldloc.s 14
+		IL_0340: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0345: pop
+		IL_0346: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_034b: stloc.s 10
+		IL_034d: ldloc.0
+		IL_034e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_0353: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_0358: volatile.
+		IL_035a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_035f: brfalse IL_0373
 
-		IL_036c: ldstr "length"
-		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0376: br IL_038f
+		IL_0364: ldstr "length"
+		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_036e: br IL_0387
 
-		IL_037b: ldstr "length"
-		IL_0380: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:94"
-		IL_0385: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0373: ldstr "length"
+		IL_0378: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:94"
+		IL_037d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_038f: stloc.s 14
-		IL_0391: ldloc.s 10
-		IL_0393: ldloc.s 14
-		IL_0395: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_039a: pop
-		IL_039b: ldloc.0
-		IL_039c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_03a1: stloc.s 15
-		IL_03a3: ldloc.s 15
-		IL_03a5: ldstr "./CommonJS_Require_FunctionValueIdentity_Dependency"
-		IL_03aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate::Invoke(object)
-		IL_03af: stloc.s 6
-		IL_03b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03b6: stloc.s 8
-		IL_03b8: ldloc.s 4
-		IL_03ba: ldloc.s 8
-		IL_03bc: ldstr "./CommonJS_Require_FunctionValueIdentity_Dependency"
-		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03c6: stloc.s 7
-		IL_03c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03cd: stloc.s 10
-		IL_03cf: ldloc.s 6
-		IL_03d1: ldloc.s 7
-		IL_03d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03d8: stloc.s 12
-		IL_03da: ldloc.s 12
-		IL_03dc: box [System.Runtime]System.Boolean
-		IL_03e1: stloc.s 13
-		IL_03e3: ldloc.s 10
-		IL_03e5: ldloc.s 13
-		IL_03e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03ec: pop
-		IL_03ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03f2: stloc.s 10
-		IL_03f4: volatile.
-		IL_03f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_03fb: brfalse IL_0411
+		IL_0387: stloc.s 14
+		IL_0389: ldloc.s 10
+		IL_038b: ldloc.s 14
+		IL_038d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0392: pop
+		IL_0393: ldloc.0
+		IL_0394: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_0399: stloc.s 15
+		IL_039b: ldloc.s 15
+		IL_039d: ldstr "./CommonJS_Require_FunctionValueIdentity_Dependency"
+		IL_03a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate::Invoke(object)
+		IL_03a7: stloc.s 6
+		IL_03a9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03ae: stloc.s 8
+		IL_03b0: ldloc.s 4
+		IL_03b2: ldloc.s 8
+		IL_03b4: ldstr "./CommonJS_Require_FunctionValueIdentity_Dependency"
+		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_03be: stloc.s 7
+		IL_03c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03c5: stloc.s 10
+		IL_03c7: ldloc.s 6
+		IL_03c9: ldloc.s 7
+		IL_03cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_03d0: stloc.s 12
+		IL_03d2: ldloc.s 12
+		IL_03d4: box [System.Runtime]System.Boolean
+		IL_03d9: stloc.s 13
+		IL_03db: ldloc.s 10
+		IL_03dd: ldloc.s 13
+		IL_03df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03e4: pop
+		IL_03e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03ea: stloc.s 10
+		IL_03ec: volatile.
+		IL_03ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_03f3: brfalse IL_0409
 
-		IL_0400: ldloc.s 7
-		IL_0402: ldstr "answer"
-		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_040c: br IL_0427
+		IL_03f8: ldloc.s 7
+		IL_03fa: ldstr "answer"
+		IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0404: br IL_041f
 
-		IL_0411: ldloc.s 7
-		IL_0413: ldstr "answer"
-		IL_0418: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:114"
-		IL_041d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0409: ldloc.s 7
+		IL_040b: ldstr "answer"
+		IL_0410: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:114"
+		IL_0415: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0427: stloc.s 14
-		IL_0429: ldloc.s 10
-		IL_042b: ldloc.s 14
-		IL_042d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0432: pop
-		IL_0433: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0438: stloc.s 10
-		IL_043a: volatile.
-		IL_043c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0441: brfalse IL_0457
+		IL_041f: stloc.s 14
+		IL_0421: ldloc.s 10
+		IL_0423: ldloc.s 14
+		IL_0425: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_042a: pop
+		IL_042b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0430: stloc.s 10
+		IL_0432: volatile.
+		IL_0434: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0439: brfalse IL_044f
 
-		IL_0446: ldloc.s 7
-		IL_0448: ldstr "requireValue"
-		IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0452: br IL_046d
+		IL_043e: ldloc.s 7
+		IL_0440: ldstr "requireValue"
+		IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_044a: br IL_0465
 
-		IL_0457: ldloc.s 7
-		IL_0459: ldstr "requireValue"
-		IL_045e: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:119"
-		IL_0463: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_044f: ldloc.s 7
+		IL_0451: ldstr "requireValue"
+		IL_0456: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:119"
+		IL_045b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_046d: stloc.s 14
-		IL_046f: ldloc.s 14
-		IL_0471: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0476: stloc.s 11
-		IL_0478: ldloc.s 10
-		IL_047a: ldloc.s 11
-		IL_047c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0481: pop
-		IL_0482: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0487: stloc.s 10
-		IL_0489: volatile.
-		IL_048b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0490: brfalse IL_04a6
+		IL_0465: stloc.s 14
+		IL_0467: ldloc.s 14
+		IL_0469: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_046e: stloc.s 11
+		IL_0470: ldloc.s 10
+		IL_0472: ldloc.s 11
+		IL_0474: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0479: pop
+		IL_047a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_047f: stloc.s 10
+		IL_0481: volatile.
+		IL_0483: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0488: brfalse IL_049e
 
-		IL_0495: ldloc.s 7
-		IL_0497: ldstr "requireValue"
-		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04a1: br IL_04bc
+		IL_048d: ldloc.s 7
+		IL_048f: ldstr "requireValue"
+		IL_0494: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0499: br IL_04b4
 
-		IL_04a6: ldloc.s 7
-		IL_04a8: ldstr "requireValue"
-		IL_04ad: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:125"
-		IL_04b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_049e: ldloc.s 7
+		IL_04a0: ldstr "requireValue"
+		IL_04a5: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:125"
+		IL_04aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04bc: stloc.s 14
-		IL_04be: ldloc.s 7
-		IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c5: volatile.
-		IL_04c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_04cc: brfalse IL_04e0
+		IL_04b4: stloc.s 14
+		IL_04b6: ldloc.s 7
+		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04bd: volatile.
+		IL_04bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_04c4: brfalse IL_04d8
 
-		IL_04d1: ldstr "readRequire"
-		IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_04db: br IL_04f4
+		IL_04c9: ldstr "readRequire"
+		IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_04d3: br IL_04ec
 
-		IL_04e0: ldstr "readRequire"
-		IL_04e5: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:127"
-		IL_04ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_04d8: ldstr "readRequire"
+		IL_04dd: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:127"
+		IL_04e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_04f4: stloc.s 16
-		IL_04f6: ldloc.s 14
-		IL_04f8: ldloc.s 16
-		IL_04fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04ff: stloc.s 12
-		IL_0501: ldloc.s 12
-		IL_0503: box [System.Runtime]System.Boolean
-		IL_0508: stloc.s 13
-		IL_050a: ldloc.s 10
-		IL_050c: ldloc.s 13
-		IL_050e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0513: pop
-		IL_0514: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0519: stloc.s 10
-		IL_051b: volatile.
-		IL_051d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0522: brfalse IL_0538
+		IL_04ec: stloc.s 16
+		IL_04ee: ldloc.s 14
+		IL_04f0: ldloc.s 16
+		IL_04f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04f7: stloc.s 12
+		IL_04f9: ldloc.s 12
+		IL_04fb: box [System.Runtime]System.Boolean
+		IL_0500: stloc.s 13
+		IL_0502: ldloc.s 10
+		IL_0504: ldloc.s 13
+		IL_0506: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_050b: pop
+		IL_050c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0511: stloc.s 10
+		IL_0513: volatile.
+		IL_0515: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_051a: brfalse IL_0530
 
-		IL_0527: ldloc.s 7
-		IL_0529: ldstr "requireValue"
-		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0533: br IL_054e
+		IL_051f: ldloc.s 7
+		IL_0521: ldstr "requireValue"
+		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_052b: br IL_0546
 
-		IL_0538: ldloc.s 7
-		IL_053a: ldstr "requireValue"
-		IL_053f: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:134"
-		IL_0544: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0530: ldloc.s 7
+		IL_0532: ldstr "requireValue"
+		IL_0537: ldstr "CommonJS_Require_FunctionValueIdentity:Modules.CommonJS_Require_FunctionValueIdentity:__js_module_init__:134"
+		IL_053c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_054e: stloc.s 16
-		IL_0550: ldloc.0
-		IL_0551: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
-		IL_0556: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
-		IL_055b: stloc.s 9
-		IL_055d: ldloc.s 16
-		IL_055f: ldloc.s 9
-		IL_0561: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0566: stloc.s 12
-		IL_0568: ldloc.s 12
-		IL_056a: box [System.Runtime]System.Boolean
-		IL_056f: stloc.s 13
-		IL_0571: ldloc.s 10
-		IL_0573: ldloc.s 13
-		IL_0575: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_057a: pop
-		IL_057b: ret
+		IL_0546: stloc.s 16
+		IL_0548: ldloc.0
+		IL_0549: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.CommonJS_Require_FunctionValueIdentity/Scope::require
+		IL_054e: call class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::GetFunctionValue(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate)
+		IL_0553: stloc.s 9
+		IL_0555: ldloc.s 16
+		IL_0557: ldloc.s 9
+		IL_0559: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_055e: stloc.s 12
+		IL_0560: ldloc.s 12
+		IL_0562: box [System.Runtime]System.Boolean
+		IL_0567: stloc.s 13
+		IL_0569: ldloc.s 10
+		IL_056b: ldloc.s 13
+		IL_056d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0572: pop
+		IL_0573: ret
 	} // end of method CommonJS_Require_FunctionValueIdentity::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_FunctionValueIdentity

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -753,7 +753,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 299 (0x12b)
+		// Code size: 300 (0x12c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.b/Scope,
@@ -871,11 +871,12 @@
 		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 		IL_011d: pop
-		IL_011e: ldloc.1
-		IL_011f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0129: pop
-		IL_012a: ret
+		IL_011e: ldloc.0
+		IL_011f: castclass Modules.b/Scope
+		IL_0124: ldnull
+		IL_0125: call object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
+		IL_012a: pop
+		IL_012b: ret
 	} // end of method b::__js_module_init__
 
 } // end of class Modules.b
@@ -1438,7 +1439,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 299 (0x12b)
+		// Code size: 300 (0x12c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.helpers_b/Scope,
@@ -1556,11 +1557,12 @@
 		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 		IL_011d: pop
-		IL_011e: ldloc.1
-		IL_011f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0129: pop
-		IL_012a: ret
+		IL_011e: ldloc.0
+		IL_011f: castclass Modules.helpers_b/Scope
+		IL_0124: ldnull
+		IL_0125: call object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
+		IL_012a: pop
+		IL_012b: ret
 	} // end of method helpers_b::__js_module_init__
 
 } // end of class Modules.helpers_b

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
@@ -633,7 +633,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 88 (0x58)
+		// Code size: 89 (0x59)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope,
@@ -672,15 +672,16 @@
 		IL_003a: nop
 		IL_003b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0040: stloc.3
-		IL_0041: ldloc.1
-		IL_0042: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_004c: stloc.s 4
-		IL_004e: ldloc.3
-		IL_004f: ldloc.s 4
-		IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0056: pop
-		IL_0057: ret
+		IL_0041: ldloc.0
+		IL_0042: castclass Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope
+		IL_0047: ldnull
+		IL_0048: call object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
+		IL_004d: stloc.s 4
+		IL_004f: ldloc.3
+		IL_0050: ldloc.s 4
+		IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0057: pop
+		IL_0058: ret
 	} // end of method CommonJS_Require_OptionalChain_InNestedFunction::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_OptionalChain_InNestedFunction

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Shadowed_Parameter.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Shadowed_Parameter.verified.txt
@@ -376,16 +376,15 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 110 (0x6e)
+		// Code size: 102 (0x66)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Shadowed_Parameter/Scope,
 			[1] class Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[4] object[],
-			[5] class Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18/FunctionObject,
-			[6] object
+			[4] class Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18/FunctionObject,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Require_Shadowed_Parameter/Scope::.ctor()
@@ -409,34 +408,31 @@
 		IL_0026: nop
 		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002c: stloc.3
-		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0032: stloc.2
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: stloc.s 4
-		IL_003f: newobj instance void Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18/FunctionObject::.ctor()
-		IL_0044: ldc.i4.1
-		IL_0045: conv.r8
-		IL_0046: ldstr ""
-		IL_004b: ldc.i4.0
-		IL_004c: ldc.i4.0
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18/FunctionObject>(!!0)
-		IL_0057: stloc.s 5
-		IL_0059: ldloc.1
-		IL_005a: ldloc.2
-		IL_005b: ldloc.s 5
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0062: stloc.s 6
-		IL_0064: ldloc.3
-		IL_0065: ldloc.s 6
-		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006c: pop
-		IL_006d: ret
+		IL_002d: ldc.i4.1
+		IL_002e: newarr [System.Runtime]System.Object
+		IL_0033: dup
+		IL_0034: ldc.i4.0
+		IL_0035: ldloc.0
+		IL_0036: stelem.ref
+		IL_0037: stloc.2
+		IL_0038: newobj instance void Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18/FunctionObject::.ctor()
+		IL_003d: ldc.i4.1
+		IL_003e: conv.r8
+		IL_003f: ldstr ""
+		IL_0044: ldc.i4.0
+		IL_0045: ldc.i4.0
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18/FunctionObject>(!!0)
+		IL_0050: stloc.s 4
+		IL_0052: ldnull
+		IL_0053: ldloc.s 4
+		IL_0055: call object Modules.CommonJS_Require_Shadowed_Parameter/test::__js_call__(object, object)
+		IL_005a: stloc.s 5
+		IL_005c: ldloc.3
+		IL_005d: ldloc.s 5
+		IL_005f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0064: pop
+		IL_0065: ret
 	} // end of method CommonJS_Require_Shadowed_Parameter::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Shadowed_Parameter

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
@@ -273,7 +273,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 178 (0xb2)
+		// Code size: 180 (0xb4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope,
@@ -318,41 +318,43 @@
 		IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 		IL_0058: stloc.s 5
 		IL_005a: ldloc.s 5
-		IL_005c: brfalse IL_0076
+		IL_005c: brfalse IL_0077
 
-		IL_0061: ldloc.1
-		IL_0062: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_006c: stloc.s 6
-		IL_006e: ldloc.s 6
-		IL_0070: stloc.2
-		IL_0071: br IL_0086
+		IL_0061: ldloc.0
+		IL_0062: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
+		IL_0067: ldnull
+		IL_0068: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
+		IL_006d: stloc.s 6
+		IL_006f: ldloc.s 6
+		IL_0071: stloc.2
+		IL_0072: br IL_0088
 
-		IL_0076: ldloc.1
-		IL_0077: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0081: stloc.s 6
-		IL_0083: ldloc.s 6
-		IL_0085: stloc.2
+		IL_0077: ldloc.0
+		IL_0078: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
+		IL_007d: ldnull
+		IL_007e: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
+		IL_0083: stloc.s 6
+		IL_0085: ldloc.s 6
+		IL_0087: stloc.2
 
-		IL_0086: ldloc.2
-		IL_0087: stloc.3
-		IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008d: stloc.s 7
-		IL_008f: ldloc.s 7
-		IL_0091: ldloc.3
-		IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0097: pop
-		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009d: stloc.s 7
-		IL_009f: ldloc.0
-		IL_00a0: ldfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
-		IL_00a5: stloc.s 6
-		IL_00a7: ldloc.s 7
-		IL_00a9: ldloc.s 6
-		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b0: pop
-		IL_00b1: ret
+		IL_0088: ldloc.2
+		IL_0089: stloc.3
+		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008f: stloc.s 7
+		IL_0091: ldloc.s 7
+		IL_0093: ldloc.3
+		IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0099: pop
+		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009f: stloc.s 7
+		IL_00a1: ldloc.0
+		IL_00a2: ldfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
+		IL_00a7: stloc.s 6
+		IL_00a9: ldloc.s 7
+		IL_00ab: ldloc.s 6
+		IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b2: pop
+		IL_00b3: ret
 	} // end of method ControlFlow_Conditional_Ternary_ShortCircuit::__js_module_init__
 
 } // end of class Modules.ControlFlow_Conditional_Ternary_ShortCircuit

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
@@ -764,14 +764,13 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 96 (0x60)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_ClosureCallback/Scope,
 			[1] class Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject,
 			[2] object[],
-			[3] object[],
-			[4] class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject
+			[3] class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/Scope::.ctor()
@@ -797,29 +796,28 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.2
-		IL_0035: ldc.i4.1
-		IL_0036: newarr [System.Runtime]System.Object
-		IL_003b: dup
-		IL_003c: ldc.i4.0
-		IL_003d: ldloc.0
-		IL_003e: stelem.ref
-		IL_003f: stloc.3
-		IL_0040: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject::.ctor()
-		IL_0045: ldc.i4.1
-		IL_0046: conv.r8
-		IL_0047: ldstr ""
-		IL_004c: ldc.i4.0
-		IL_004d: ldc.i4.0
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0053: stloc.s 4
-		IL_0055: ldloc.1
-		IL_0056: ldloc.2
-		IL_0057: ldloc.s 4
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005e: pop
-		IL_005f: ret
+		IL_002f: ldc.i4.1
+		IL_0030: newarr [System.Runtime]System.Object
+		IL_0035: dup
+		IL_0036: ldc.i4.0
+		IL_0037: ldloc.0
+		IL_0038: stelem.ref
+		IL_0039: stloc.2
+		IL_003a: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject::.ctor()
+		IL_003f: ldc.i4.1
+		IL_0040: conv.r8
+		IL_0041: ldstr ""
+		IL_0046: ldc.i4.0
+		IL_0047: ldc.i4.0
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004d: stloc.3
+		IL_004e: ldloc.0
+		IL_004f: castclass Modules.ControlFlow_ForOf_ClosureCallback/Scope
+		IL_0054: ldnull
+		IL_0055: ldloc.3
+		IL_0056: call object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method ControlFlow_ForOf_ClosureCallback::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_ClosureCallback

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
@@ -768,7 +768,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 72 (0x48)
+		// Code size: 73 (0x49)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope,
@@ -800,15 +800,16 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldloc.1
-		IL_0030: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003a: stloc.3
-		IL_003b: ldloc.3
-		IL_003c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0046: pop
-		IL_0047: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope
+		IL_0035: ldnull
+		IL_0036: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
+		IL_003b: stloc.3
+		IL_003c: ldloc.3
+		IL_003d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0047: pop
+		IL_0048: ret
 	} // end of method ControlFlow_LabeledStatement_CapturesParentVar::__js_module_init__
 
 } // end of class Modules.ControlFlow_LabeledStatement_CapturesParentVar

--- a/tests/Jroc.Tests/Function/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Function/ExecutionTests.cs
@@ -147,6 +147,9 @@ namespace Jroc.Tests.Function
         public Task Function_CommonArityDynamicDispatch() { var testName = nameof(Function_CommonArityDynamicDispatch); return ExecutionTest(testName); }
 
         [Fact]
+        public Task Function_StrictBareCalls_PreserveThisAndDirectFastPath() { var testName = nameof(Function_StrictBareCalls_PreserveThisAndDirectFastPath); return ExecutionTest(testName); }
+
+        [Fact]
         public Task Function_ObjectLiteralMethod_ThisBinding() { var testName = nameof(Function_ObjectLiteralMethod_ThisBinding); return ExecutionTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/Function/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Function/GeneratorTests.cs
@@ -239,6 +239,9 @@ namespace Jroc.Tests.Function
         public Task Function_CommonArityDynamicDispatch() { var testName = nameof(Function_CommonArityDynamicDispatch); return GenerateTest(testName); }
 
         [Fact]
+        public Task Function_StrictBareCalls_PreserveThisAndDirectFastPath() { var testName = nameof(Function_StrictBareCalls_PreserveThisAndDirectFastPath); return GenerateTest(testName); }
+
+        [Fact]
         public Task Function_NewExpression_CapturesOuterCtor() { var testName = nameof(Function_NewExpression_CapturesOuterCtor); return GenerateTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/Function/JavaScript/Function_StrictBareCalls_PreserveThisAndDirectFastPath.js
+++ b/tests/Jroc.Tests/Function/JavaScript/Function_StrictBareCalls_PreserveThisAndDirectFastPath.js
@@ -1,0 +1,17 @@
+"use strict";
+
+function increment(value) {
+    return value + 1;
+}
+
+function directThis() {
+    return this;
+}
+
+function nestedArrowThis() {
+    return (() => this)();
+}
+
+console.log(increment(41));
+console.log(directThis() === undefined);
+console.log(nestedArrowThis() === undefined);

--- a/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_StrictBareCalls_PreserveThisAndDirectFastPath.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/ExecutionTests.Function_StrictBareCalls_PreserveThisAndDirectFastPath.verified.txt
@@ -1,0 +1,3 @@
+42
+true
+true

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
@@ -1122,7 +1122,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 77 (0x4d)
+			// Code size: 92 (0x5c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Arguments_Basics/g/Scope,
@@ -1143,18 +1143,25 @@
 			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/g/inner/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.1
 			IL_0020: nop
-			IL_0021: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0026: stloc.2
-			IL_0027: ldloc.1
-			IL_0028: ldloc.2
-			IL_0029: ldc.r8 1
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: ldc.r8 2
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_004a: pop
-			IL_004b: ldnull
-			IL_004c: ret
+			IL_0021: ldloc.1
+			IL_0022: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_002c: ldc.i4.2
+			IL_002d: newarr [System.Runtime]System.Object
+			IL_0032: dup
+			IL_0033: ldc.i4.0
+			IL_0034: ldc.r8 1
+			IL_003d: box [System.Runtime]System.Double
+			IL_0042: stelem.ref
+			IL_0043: dup
+			IL_0044: ldc.i4.1
+			IL_0045: ldc.r8 2
+			IL_004e: box [System.Runtime]System.Double
+			IL_0053: stelem.ref
+			IL_0054: call object Modules.Function_Arguments_Basics/g/inner/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+			IL_0059: pop
+			IL_005a: ldnull
+			IL_005b: ret
 		} // end of method g::__js_call__
 
 	} // end of class g
@@ -1200,7 +1207,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 320 (0x140)
+		// Code size: 326 (0x146)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Basics/Scope,
@@ -1263,53 +1270,83 @@
 		IL_006e: stloc.3
 		IL_006f: nop
 		IL_0070: nop
-		IL_0071: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0076: stloc.s 4
-		IL_0078: ldloc.1
-		IL_0079: ldloc.s 4
-		IL_007b: ldc.r8 1
-		IL_0084: box [System.Runtime]System.Double
-		IL_0089: ldc.r8 2
+		IL_0071: ldloc.1
+		IL_0072: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_0077: ldc.i4.1
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldloc.0
+		IL_0080: stelem.ref
+		IL_0081: ldc.i4.3
+		IL_0082: newarr [System.Runtime]System.Object
+		IL_0087: dup
+		IL_0088: ldc.i4.0
+		IL_0089: ldc.r8 1
 		IL_0092: box [System.Runtime]System.Double
-		IL_0097: ldc.r8 3
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_00aa: pop
-		IL_00ab: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00b0: stloc.s 4
-		IL_00b2: ldloc.1
-		IL_00b3: ldloc.s 4
-		IL_00b5: ldc.r8 1
-		IL_00be: box [System.Runtime]System.Double
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00c8: pop
-		IL_00c9: nop
-		IL_00ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00cf: stloc.s 4
-		IL_00d1: ldloc.2
-		IL_00d2: ldloc.s 4
-		IL_00d4: ldc.r8 7
-		IL_00dd: box [System.Runtime]System.Double
-		IL_00e2: ldc.r8 8
-		IL_00eb: box [System.Runtime]System.Double
-		IL_00f0: ldc.r8 9
-		IL_00f9: box [System.Runtime]System.Double
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0103: pop
-		IL_0104: nop
-		IL_0105: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_010a: stloc.s 4
-		IL_010c: ldloc.3
-		IL_010d: ldloc.s 4
-		IL_010f: ldc.r8 1
-		IL_0118: box [System.Runtime]System.Double
-		IL_011d: ldc.r8 2
-		IL_0126: box [System.Runtime]System.Double
-		IL_012b: ldc.r8 3
-		IL_0134: box [System.Runtime]System.Double
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_013e: pop
-		IL_013f: ret
+		IL_0097: stelem.ref
+		IL_0098: dup
+		IL_0099: ldc.i4.1
+		IL_009a: ldc.r8 2
+		IL_00a3: box [System.Runtime]System.Double
+		IL_00a8: stelem.ref
+		IL_00a9: dup
+		IL_00aa: ldc.i4.2
+		IL_00ab: ldc.r8 3
+		IL_00b4: box [System.Runtime]System.Double
+		IL_00b9: stelem.ref
+		IL_00ba: call object Modules.Function_Arguments_Basics/f/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00bf: pop
+		IL_00c0: ldloc.1
+		IL_00c1: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_00c6: ldc.i4.1
+		IL_00c7: newarr [System.Runtime]System.Object
+		IL_00cc: dup
+		IL_00cd: ldc.i4.0
+		IL_00ce: ldloc.0
+		IL_00cf: stelem.ref
+		IL_00d0: ldc.i4.1
+		IL_00d1: newarr [System.Runtime]System.Object
+		IL_00d6: dup
+		IL_00d7: ldc.i4.0
+		IL_00d8: ldc.r8 1
+		IL_00e1: box [System.Runtime]System.Double
+		IL_00e6: stelem.ref
+		IL_00e7: call object Modules.Function_Arguments_Basics/f/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00ec: pop
+		IL_00ed: nop
+		IL_00ee: ldloc.2
+		IL_00ef: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_00f4: ldc.i4.1
+		IL_00f5: newarr [System.Runtime]System.Object
+		IL_00fa: dup
+		IL_00fb: ldc.i4.0
+		IL_00fc: ldloc.0
+		IL_00fd: stelem.ref
+		IL_00fe: ldc.i4.3
+		IL_00ff: newarr [System.Runtime]System.Object
+		IL_0104: dup
+		IL_0105: ldc.i4.0
+		IL_0106: ldc.r8 7
+		IL_010f: box [System.Runtime]System.Double
+		IL_0114: stelem.ref
+		IL_0115: dup
+		IL_0116: ldc.i4.1
+		IL_0117: ldc.r8 8
+		IL_0120: box [System.Runtime]System.Double
+		IL_0125: stelem.ref
+		IL_0126: dup
+		IL_0127: ldc.i4.2
+		IL_0128: ldc.r8 9
+		IL_0131: box [System.Runtime]System.Double
+		IL_0136: stelem.ref
+		IL_0137: call object Modules.Function_Arguments_Basics/outer/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_013c: pop
+		IL_013d: nop
+		IL_013e: ldnull
+		IL_013f: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
+		IL_0144: pop
+		IL_0145: ret
 	} // end of method Function_Arguments_Basics::__js_module_init__
 
 } // end of class Modules.Function_Arguments_Basics

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_ComputedKey_TriggersBinding.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_ComputedKey_TriggersBinding.verified.txt
@@ -345,7 +345,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 96 (0x60)
+		// Code size: 119 (0x77)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_ComputedKey_TriggersBinding/Scope,
@@ -372,19 +372,34 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldc.r8 1
-		IL_0038: box [System.Runtime]System.Double
-		IL_003d: ldc.r8 2
-		IL_0046: box [System.Runtime]System.Double
-		IL_004b: ldc.r8 3
-		IL_0054: box [System.Runtime]System.Double
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_005e: pop
-		IL_005f: ret
+		IL_0027: ldloc.1
+		IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_002d: ldc.i4.1
+		IL_002e: newarr [System.Runtime]System.Object
+		IL_0033: dup
+		IL_0034: ldc.i4.0
+		IL_0035: ldloc.0
+		IL_0036: stelem.ref
+		IL_0037: ldc.i4.3
+		IL_0038: newarr [System.Runtime]System.Object
+		IL_003d: dup
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.r8 1
+		IL_0048: box [System.Runtime]System.Double
+		IL_004d: stelem.ref
+		IL_004e: dup
+		IL_004f: ldc.i4.1
+		IL_0050: ldc.r8 2
+		IL_0059: box [System.Runtime]System.Double
+		IL_005e: stelem.ref
+		IL_005f: dup
+		IL_0060: ldc.i4.2
+		IL_0061: ldc.r8 3
+		IL_006a: box [System.Runtime]System.Double
+		IL_006f: stelem.ref
+		IL_0070: call object Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0075: pop
+		IL_0076: ret
 	} // end of method Function_Arguments_ComputedKey_TriggersBinding::__js_module_init__
 
 } // end of class Modules.Function_Arguments_ComputedKey_TriggersBinding

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
@@ -339,7 +339,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 60 (0x3c)
+		// Code size: 61 (0x3d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope,
@@ -370,11 +370,12 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldloc.1
-		IL_0030: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003a: pop
-		IL_003b: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope
+		IL_0035: ldnull
+		IL_0036: call object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
+		IL_003b: pop
+		IL_003c: ret
 	} // end of method Function_Arguments_NoFalsePositive_ObjectLiteralKey::__js_module_init__
 
 } // end of class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
@@ -442,15 +442,14 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 141 (0x8d)
+		// Code size: 147 (0x93)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Basic/Scope,
 			[1] class Modules.Function_Call_Spread_Basic/dump/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object[],
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] object[]
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_Basic/Scope::.ctor()
@@ -488,23 +487,27 @@
 		IL_0054: ldc.r8 3
 		IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0062: stloc.2
-		IL_0063: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0068: stloc.3
-		IL_0069: ldc.i4.0
-		IL_006a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_006f: stloc.s 4
-		IL_0071: ldloc.s 4
-		IL_0073: ldloc.2
-		IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_0079: ldloc.s 4
-		IL_007b: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_0080: stloc.s 5
-		IL_0082: ldloc.1
-		IL_0083: ldloc.3
-		IL_0084: ldloc.s 5
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_008b: pop
-		IL_008c: ret
+		IL_0063: ldc.i4.0
+		IL_0064: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0069: stloc.s 4
+		IL_006b: ldloc.s 4
+		IL_006d: ldloc.2
+		IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_0073: ldloc.s 4
+		IL_0075: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_007a: stloc.3
+		IL_007b: ldloc.1
+		IL_007c: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_0081: ldc.i4.1
+		IL_0082: newarr [System.Runtime]System.Object
+		IL_0087: dup
+		IL_0088: ldc.i4.0
+		IL_0089: ldloc.0
+		IL_008a: stelem.ref
+		IL_008b: ldloc.3
+		IL_008c: call object Modules.Function_Call_Spread_Basic/dump/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0091: pop
+		IL_0092: ret
 	} // end of method Function_Call_Spread_Basic::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Basic

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
@@ -750,7 +750,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 252 (0xfc)
+		// Code size: 225 (0xe1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_EvaluationOrder/Scope,
@@ -758,8 +758,8 @@
 			[2] class Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject,
 			[3] class Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject,
 			[4] object[],
-			[5] object[],
-			[6] object,
+			[5] object,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
@@ -818,49 +818,44 @@
 		IL_0070: nop
 		IL_0071: nop
 		IL_0072: nop
-		IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0078: stloc.s 4
-		IL_007a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_007f: stloc.s 5
-		IL_0081: ldloc.2
-		IL_0082: ldloc.s 5
-		IL_0084: ldc.r8 1
-		IL_008d: box [System.Runtime]System.Double
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0097: stloc.s 6
-		IL_0099: ldc.i4.1
-		IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_009f: dup
-		IL_00a0: ldloc.s 6
-		IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_00a7: stloc.s 7
-		IL_00a9: ldloc.3
-		IL_00aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00b4: stloc.s 6
-		IL_00b6: ldloc.s 7
-		IL_00b8: ldloc.s 6
-		IL_00ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_00bf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00c4: stloc.s 5
-		IL_00c6: ldloc.2
-		IL_00c7: ldloc.s 5
-		IL_00c9: ldc.r8 4
-		IL_00d2: box [System.Runtime]System.Double
-		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00dc: stloc.s 6
-		IL_00de: ldloc.s 7
-		IL_00e0: ldloc.s 6
-		IL_00e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_00e7: ldloc.s 7
-		IL_00e9: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_00ee: stloc.s 5
-		IL_00f0: ldloc.1
-		IL_00f1: ldloc.s 4
-		IL_00f3: ldloc.s 5
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_00fa: pop
-		IL_00fb: ret
+		IL_0073: ldnull
+		IL_0074: ldc.r8 1
+		IL_007d: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
+		IL_0082: stloc.s 5
+		IL_0084: ldc.i4.1
+		IL_0085: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_008a: dup
+		IL_008b: ldloc.s 5
+		IL_008d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0092: stloc.s 6
+		IL_0094: ldnull
+		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_Call_Spread_EvaluationOrder/spread::__js_call__(object)
+		IL_009a: stloc.s 7
+		IL_009c: ldloc.s 6
+		IL_009e: ldloc.s 7
+		IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_00a5: ldnull
+		IL_00a6: ldc.r8 4
+		IL_00af: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
+		IL_00b4: stloc.s 5
+		IL_00b6: ldloc.s 6
+		IL_00b8: ldloc.s 5
+		IL_00ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_00bf: ldloc.s 6
+		IL_00c1: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_00c6: stloc.s 4
+		IL_00c8: ldloc.1
+		IL_00c9: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_00ce: ldc.i4.1
+		IL_00cf: newarr [System.Runtime]System.Object
+		IL_00d4: dup
+		IL_00d5: ldc.i4.0
+		IL_00d6: ldloc.0
+		IL_00d7: stelem.ref
+		IL_00d8: ldloc.s 4
+		IL_00da: call object Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00df: pop
+		IL_00e0: ret
 	} // end of method Function_Call_Spread_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_EvaluationOrder

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
@@ -442,15 +442,14 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 155 (0x9b)
+		// Code size: 161 (0xa1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Middle/Scope,
 			[1] class Modules.Function_Call_Spread_Middle/dump/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] object[]
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_Middle/Scope::.ctor()
@@ -476,38 +475,42 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.2
-		IL_0035: ldc.i4.1
-		IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_003b: dup
-		IL_003c: ldc.r8 0.0
-		IL_0045: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_004a: stloc.3
-		IL_004b: ldc.i4.2
-		IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0051: dup
-		IL_0052: ldc.r8 1
-		IL_005b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0060: dup
-		IL_0061: ldc.r8 2
-		IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_006f: stloc.s 4
-		IL_0071: ldloc.3
-		IL_0072: ldloc.s 4
-		IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_0079: ldloc.3
-		IL_007a: ldc.r8 3
-		IL_0083: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0088: ldloc.3
-		IL_0089: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_008e: stloc.s 5
-		IL_0090: ldloc.1
-		IL_0091: ldloc.2
-		IL_0092: ldloc.s 5
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0099: pop
-		IL_009a: ret
+		IL_002f: ldc.i4.1
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0035: dup
+		IL_0036: ldc.r8 0.0
+		IL_003f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0044: stloc.3
+		IL_0045: ldc.i4.2
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_004b: dup
+		IL_004c: ldc.r8 1
+		IL_0055: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_005a: dup
+		IL_005b: ldc.r8 2
+		IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0069: stloc.s 4
+		IL_006b: ldloc.3
+		IL_006c: ldloc.s 4
+		IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_0073: ldloc.3
+		IL_0074: ldc.r8 3
+		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0082: ldloc.3
+		IL_0083: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_0088: stloc.2
+		IL_0089: ldloc.1
+		IL_008a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_008f: ldc.i4.1
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldloc.0
+		IL_0098: stelem.ref
+		IL_0099: ldloc.2
+		IL_009a: call object Modules.Function_Call_Spread_Middle/dump/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_009f: pop
+		IL_00a0: ret
 	} // end of method Function_Call_Spread_Middle::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Middle

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
@@ -442,15 +442,14 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 171 (0xab)
+		// Code size: 177 (0xb1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Multiple/Scope,
 			[1] class Modules.Function_Call_Spread_Multiple/dump/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] object[]
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_Multiple/Scope::.ctor()
@@ -476,44 +475,48 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.2
-		IL_0035: ldc.i4.0
-		IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_003b: stloc.3
-		IL_003c: ldc.i4.1
-		IL_003d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0042: dup
-		IL_0043: ldc.r8 1
-		IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0051: stloc.s 4
-		IL_0053: ldloc.3
-		IL_0054: ldloc.s 4
-		IL_0056: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_005b: ldc.i4.2
-		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0061: dup
-		IL_0062: ldc.r8 2
-		IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0070: dup
-		IL_0071: ldc.r8 3
-		IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_007f: stloc.s 4
-		IL_0081: ldloc.3
-		IL_0082: ldloc.s 4
-		IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_0089: ldloc.3
-		IL_008a: ldc.r8 4
-		IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0098: ldloc.3
-		IL_0099: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_009e: stloc.s 5
-		IL_00a0: ldloc.1
-		IL_00a1: ldloc.2
-		IL_00a2: ldloc.s 5
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_00a9: pop
-		IL_00aa: ret
+		IL_002f: ldc.i4.0
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0035: stloc.3
+		IL_0036: ldc.i4.1
+		IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_003c: dup
+		IL_003d: ldc.r8 1
+		IL_0046: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_004b: stloc.s 4
+		IL_004d: ldloc.3
+		IL_004e: ldloc.s 4
+		IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_0055: ldc.i4.2
+		IL_0056: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_005b: dup
+		IL_005c: ldc.r8 2
+		IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_006a: dup
+		IL_006b: ldc.r8 3
+		IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0079: stloc.s 4
+		IL_007b: ldloc.3
+		IL_007c: ldloc.s 4
+		IL_007e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_0083: ldloc.3
+		IL_0084: ldc.r8 4
+		IL_008d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0092: ldloc.3
+		IL_0093: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_0098: stloc.2
+		IL_0099: ldloc.1
+		IL_009a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_009f: ldc.i4.1
+		IL_00a0: newarr [System.Runtime]System.Object
+		IL_00a5: dup
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldloc.0
+		IL_00a8: stelem.ref
+		IL_00a9: ldloc.2
+		IL_00aa: call object Modules.Function_Call_Spread_Multiple/dump/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00af: pop
+		IL_00b0: ret
 	} // end of method Function_Call_Spread_Multiple::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Multiple

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
@@ -442,14 +442,13 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 90 (0x5a)
+		// Code size: 96 (0x60)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_StringIterable/Scope,
 			[1] class Modules.Function_Call_Spread_StringIterable/dump/FunctionObject,
 			[2] object[],
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] object[]
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_StringIterable/Scope::.ctor()
@@ -475,23 +474,27 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.2
-		IL_0035: ldc.i4.0
-		IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_003b: stloc.3
-		IL_003c: ldloc.3
-		IL_003d: ldstr "ab"
-		IL_0042: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_0047: ldloc.3
-		IL_0048: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_004d: stloc.s 4
-		IL_004f: ldloc.1
-		IL_0050: ldloc.2
-		IL_0051: ldloc.s 4
-		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0058: pop
-		IL_0059: ret
+		IL_002f: ldc.i4.0
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0035: stloc.3
+		IL_0036: ldloc.3
+		IL_0037: ldstr "ab"
+		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_0041: ldloc.3
+		IL_0042: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_0047: stloc.2
+		IL_0048: ldloc.1
+		IL_0049: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_004e: ldc.i4.1
+		IL_004f: newarr [System.Runtime]System.Object
+		IL_0054: dup
+		IL_0055: ldc.i4.0
+		IL_0056: ldloc.0
+		IL_0057: stelem.ref
+		IL_0058: ldloc.2
+		IL_0059: call object Modules.Function_Call_Spread_StringIterable/dump/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_005e: pop
+		IL_005f: ret
 	} // end of method Function_Call_Spread_StringIterable::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_StringIterable

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
@@ -955,7 +955,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 469 (0x1d5)
+		// Code size: 418 (0x1a2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/Scope,
@@ -967,7 +967,9 @@
 			[6] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject,
 			[7] object[],
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[9] object
+			[9] float64,
+			[10] object,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/Scope::.ctor()
@@ -1071,89 +1073,76 @@
 		IL_00cf: nop
 		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00d5: stloc.s 8
-		IL_00d7: ldloc.1
-		IL_00d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00e2: stloc.s 9
-		IL_00e4: ldloc.s 8
-		IL_00e6: ldloc.s 9
-		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ed: pop
-		IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f3: stloc.s 8
-		IL_00f5: ldloc.2
-		IL_00f6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0100: stloc.s 9
-		IL_0102: ldloc.s 8
-		IL_0104: ldloc.s 9
-		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010b: pop
-		IL_010c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0111: stloc.s 8
-		IL_0113: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0118: stloc.s 7
-		IL_011a: ldloc.3
-		IL_011b: ldloc.s 7
-		IL_011d: ldc.i4.1
-		IL_011e: box [System.Runtime]System.Boolean
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0128: stloc.s 9
-		IL_012a: ldloc.s 8
-		IL_012c: ldloc.s 9
-		IL_012e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0133: pop
-		IL_0134: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0139: stloc.s 8
-		IL_013b: ldloc.s 4
-		IL_013d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0147: stloc.s 9
-		IL_0149: ldloc.s 8
-		IL_014b: ldloc.s 9
-		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0152: pop
-		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0158: stloc.s 8
-		IL_015a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_015f: stloc.s 7
-		IL_0161: ldloc.s 5
-		IL_0163: ldloc.s 7
-		IL_0165: ldstr "typed"
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_016f: stloc.s 9
-		IL_0171: ldloc.s 8
-		IL_0173: ldloc.s 9
-		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017a: pop
-		IL_017b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0180: stloc.s 8
-		IL_0182: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0187: stloc.s 7
-		IL_0189: ldloc.s 6
-		IL_018b: ldloc.s 7
-		IL_018d: ldc.r8 1
-		IL_0196: box [System.Runtime]System.Double
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01a0: stloc.s 9
-		IL_01a2: ldloc.s 8
-		IL_01a4: ldloc.s 9
-		IL_01a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ab: pop
-		IL_01ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b1: stloc.s 8
-		IL_01b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b8: stloc.s 7
-		IL_01ba: ldloc.s 6
-		IL_01bc: ldloc.s 7
-		IL_01be: ldstr "dynamic"
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01c8: stloc.s 9
-		IL_01ca: ldloc.s 8
-		IL_01cc: ldloc.s 9
-		IL_01ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d3: pop
-		IL_01d4: ret
+		IL_00d7: ldnull
+		IL_00d8: call float64 Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber::__js_call__(object)
+		IL_00dd: stloc.s 9
+		IL_00df: ldloc.s 9
+		IL_00e1: box [System.Runtime]System.Double
+		IL_00e6: stloc.s 10
+		IL_00e8: ldloc.s 8
+		IL_00ea: ldloc.s 10
+		IL_00ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f1: pop
+		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f7: stloc.s 8
+		IL_00f9: ldnull
+		IL_00fa: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean::__js_call__(object)
+		IL_00ff: stloc.s 11
+		IL_0101: ldloc.s 8
+		IL_0103: ldloc.s 11
+		IL_0105: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010a: pop
+		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0110: stloc.s 8
+		IL_0112: ldnull
+		IL_0113: ldc.i4.1
+		IL_0114: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate::__js_call__(object, bool)
+		IL_0119: stloc.s 11
+		IL_011b: ldloc.s 8
+		IL_011d: ldloc.s 11
+		IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0124: pop
+		IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012a: stloc.s 8
+		IL_012c: ldnull
+		IL_012d: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString::__js_call__(object)
+		IL_0132: stloc.s 11
+		IL_0134: ldloc.s 8
+		IL_0136: ldloc.s 11
+		IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_013d: pop
+		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0143: stloc.s 8
+		IL_0145: ldnull
+		IL_0146: ldstr "typed"
+		IL_014b: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength::__js_call__(object, string)
+		IL_0150: stloc.s 11
+		IL_0152: ldloc.s 8
+		IL_0154: ldloc.s 11
+		IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015b: pop
+		IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0161: stloc.s 8
+		IL_0163: ldnull
+		IL_0164: ldc.r8 1
+		IL_016d: box [System.Runtime]System.Double
+		IL_0172: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity::__js_call__(object, object)
+		IL_0177: stloc.s 11
+		IL_0179: ldloc.s 8
+		IL_017b: ldloc.s 11
+		IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0182: pop
+		IL_0183: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0188: stloc.s 8
+		IL_018a: ldnull
+		IL_018b: ldstr "dynamic"
+		IL_0190: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity::__js_call__(object, object)
+		IL_0195: stloc.s 11
+		IL_0197: ldloc.s 8
+		IL_0199: ldloc.s 11
+		IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a0: pop
+		IL_01a1: ret
 	} // end of method Function_CallableArchitecture_InferredSignatureBaseline::__js_module_init__
 
 } // end of class Modules.Function_CallableArchitecture_InferredSignatureBaseline

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
@@ -261,7 +261,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 96 (0x60)
+		// Code size: 97 (0x61)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Capture_HasScopesParameter/Scope,
@@ -300,15 +300,16 @@
 		IL_0042: nop
 		IL_0043: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0048: stloc.3
-		IL_0049: ldloc.1
-		IL_004a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0054: stloc.s 4
-		IL_0056: ldloc.3
-		IL_0057: ldloc.s 4
-		IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005e: pop
-		IL_005f: ret
+		IL_0049: ldloc.0
+		IL_004a: castclass Modules.Function_Capture_HasScopesParameter/Scope
+		IL_004f: ldnull
+		IL_0050: call object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
+		IL_0055: stloc.s 4
+		IL_0057: ldloc.3
+		IL_0058: ldloc.s 4
+		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005f: pop
+		IL_0060: ret
 	} // end of method Function_Capture_HasScopesParameter::__js_module_init__
 
 } // end of class Modules.Function_Capture_HasScopesParameter

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
@@ -487,7 +487,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 320 (0x140)
+		// Code size: 314 (0x13a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope,
@@ -522,77 +522,75 @@
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
-		IL_0031: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0036: stloc.s 4
-		IL_0038: ldloc.1
-		IL_0039: ldloc.s 4
-		IL_003b: ldc.r8 10
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004e: stloc.2
-		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0054: stloc.s 5
-		IL_0056: ldloc.2
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005c: volatile.
-		IL_005e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0063: brfalse IL_0085
+		IL_0031: ldloc.0
+		IL_0032: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
+		IL_0037: ldnull
+		IL_0038: ldc.r8 10
+		IL_0041: box [System.Runtime]System.Double
+		IL_0046: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
+		IL_004b: stloc.2
+		IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0051: stloc.s 5
+		IL_0053: ldloc.2
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0059: volatile.
+		IL_005b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0060: brfalse IL_0082
 
-		IL_0068: ldstr "multiply"
-		IL_006d: ldc.r8 5
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0080: br IL_00a7
+		IL_0065: ldstr "multiply"
+		IL_006a: ldc.r8 5
+		IL_0073: box [System.Runtime]System.Double
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007d: br IL_00a4
 
-		IL_0085: ldstr "multiply"
-		IL_008a: ldc.r8 5
-		IL_0093: box [System.Runtime]System.Double
-		IL_0098: ldstr "Function_ClosureEscapesScope_ObjectLiteralProperty:Modules.Function_ClosureEscapesScope_ObjectLiteralProperty:__js_module_init__:19"
-		IL_009d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0082: ldstr "multiply"
+		IL_0087: ldc.r8 5
+		IL_0090: box [System.Runtime]System.Double
+		IL_0095: ldstr "Function_ClosureEscapesScope_ObjectLiteralProperty:Modules.Function_ClosureEscapesScope_ObjectLiteralProperty:__js_module_init__:19"
+		IL_009a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00a7: stloc.s 6
-		IL_00a9: ldloc.s 5
-		IL_00ab: ldstr "a.multiply(5):"
-		IL_00b0: ldloc.s 6
-		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00b7: pop
-		IL_00b8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00bd: stloc.s 4
-		IL_00bf: ldloc.1
-		IL_00c0: ldloc.s 4
-		IL_00c2: ldc.r8 3
-		IL_00cb: box [System.Runtime]System.Double
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00d5: stloc.3
-		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00db: stloc.s 5
-		IL_00dd: ldloc.3
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e3: volatile.
-		IL_00e5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_00ea: brfalse IL_010c
+		IL_00a4: stloc.s 6
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldstr "a.multiply(5):"
+		IL_00ad: ldloc.s 6
+		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00b4: pop
+		IL_00b5: ldloc.0
+		IL_00b6: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
+		IL_00bb: ldnull
+		IL_00bc: ldc.r8 3
+		IL_00c5: box [System.Runtime]System.Double
+		IL_00ca: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
+		IL_00cf: stloc.3
+		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d5: stloc.s 5
+		IL_00d7: ldloc.3
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00dd: volatile.
+		IL_00df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00e4: brfalse IL_0106
 
-		IL_00ef: ldstr "multiply"
-		IL_00f4: ldc.r8 7
-		IL_00fd: box [System.Runtime]System.Double
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0107: br IL_012e
+		IL_00e9: ldstr "multiply"
+		IL_00ee: ldc.r8 7
+		IL_00f7: box [System.Runtime]System.Double
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0101: br IL_0128
 
-		IL_010c: ldstr "multiply"
-		IL_0111: ldc.r8 7
-		IL_011a: box [System.Runtime]System.Double
-		IL_011f: ldstr "Function_ClosureEscapesScope_ObjectLiteralProperty:Modules.Function_ClosureEscapesScope_ObjectLiteralProperty:__js_module_init__:33"
-		IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0106: ldstr "multiply"
+		IL_010b: ldc.r8 7
+		IL_0114: box [System.Runtime]System.Double
+		IL_0119: ldstr "Function_ClosureEscapesScope_ObjectLiteralProperty:Modules.Function_ClosureEscapesScope_ObjectLiteralProperty:__js_module_init__:33"
+		IL_011e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_012e: stloc.s 6
-		IL_0130: ldloc.s 5
-		IL_0132: ldstr "b.multiply(7):"
-		IL_0137: ldloc.s 6
-		IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_013e: pop
-		IL_013f: ret
+		IL_0128: stloc.s 6
+		IL_012a: ldloc.s 5
+		IL_012c: ldstr "b.multiply(7):"
+		IL_0131: ldloc.s 6
+		IL_0133: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0138: pop
+		IL_0139: ret
 	} // end of method Function_ClosureEscapesScope_ObjectLiteralProperty::__js_module_init__
 
 } // end of class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
@@ -486,7 +486,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 181 (0xb5)
+		// Code size: 175 (0xaf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureMutatesOuterVariable/Scope,
@@ -520,48 +520,46 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.3
-		IL_0035: ldloc.1
-		IL_0036: ldloc.3
-		IL_0037: ldc.r8 10
-		IL_0040: box [System.Runtime]System.Double
-		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004a: stloc.2
-		IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0050: stloc.s 4
-		IL_0052: ldloc.2
-		IL_0053: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_005d: stloc.s 5
-		IL_005f: ldloc.s 4
-		IL_0061: ldstr "First increment:"
-		IL_0066: ldloc.s 5
-		IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_006d: pop
-		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.2
-		IL_0076: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0080: stloc.s 5
-		IL_0082: ldloc.s 4
-		IL_0084: ldstr "Second increment:"
-		IL_0089: ldloc.s 5
-		IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0090: pop
-		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0096: stloc.s 4
-		IL_0098: ldloc.2
-		IL_0099: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00a3: stloc.s 5
-		IL_00a5: ldloc.s 4
-		IL_00a7: ldstr "Third increment:"
-		IL_00ac: ldloc.s 5
-		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00b3: pop
-		IL_00b4: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.Function_ClosureMutatesOuterVariable/Scope
+		IL_0035: ldnull
+		IL_0036: ldc.r8 10
+		IL_003f: call object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, float64)
+		IL_0044: stloc.2
+		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004a: stloc.s 4
+		IL_004c: ldloc.2
+		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0057: stloc.s 5
+		IL_0059: ldloc.s 4
+		IL_005b: ldstr "First increment:"
+		IL_0060: ldloc.s 5
+		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0067: pop
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: stloc.s 4
+		IL_006f: ldloc.2
+		IL_0070: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_007a: stloc.s 5
+		IL_007c: ldloc.s 4
+		IL_007e: ldstr "Second increment:"
+		IL_0083: ldloc.s 5
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008a: pop
+		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0090: stloc.s 4
+		IL_0092: ldloc.2
+		IL_0093: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_009d: stloc.s 5
+		IL_009f: ldloc.s 4
+		IL_00a1: ldstr "Third increment:"
+		IL_00a6: ldloc.s 5
+		IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00ad: pop
+		IL_00ae: ret
 	} // end of method Function_ClosureMutatesOuterVariable::__js_module_init__
 
 } // end of class Modules.Function_ClosureMutatesOuterVariable

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
@@ -376,7 +376,7 @@
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
 			// Header size: 12
-			// Code size: 128 (0x80)
+			// Code size: 134 (0x86)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope,
@@ -426,26 +426,32 @@
 			IL_004e: ldloc.s 4
 			IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_0055: pop
-			IL_0056: ldloc.1
-			IL_0057: ldc.i4.1
-			IL_0058: newarr [System.Runtime]System.Object
-			IL_005d: dup
-			IL_005e: ldc.i4.0
-			IL_005f: ldarg.0
-			IL_0060: stelem.ref
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0066: pop
-			IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_006c: stloc.3
-			IL_006d: ldloc.0
-			IL_006e: ldfld object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope::flag
-			IL_0073: stloc.s 4
-			IL_0075: ldloc.3
-			IL_0076: ldloc.s 4
-			IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_007d: pop
-			IL_007e: ldnull
-			IL_007f: ret
+			IL_0056: ldc.i4.2
+			IL_0057: newarr [System.Runtime]System.Object
+			IL_005c: dup
+			IL_005d: ldc.i4.0
+			IL_005e: ldarg.0
+			IL_005f: stelem.ref
+			IL_0060: dup
+			IL_0061: ldc.i4.1
+			IL_0062: ldloc.0
+			IL_0063: stelem.ref
+			IL_0064: stloc.2
+			IL_0065: ldloc.2
+			IL_0066: ldnull
+			IL_0067: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue::__js_call__(object[], object)
+			IL_006c: pop
+			IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0072: stloc.3
+			IL_0073: ldloc.0
+			IL_0074: ldfld object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope::flag
+			IL_0079: stloc.s 4
+			IL_007b: ldloc.3
+			IL_007c: ldloc.s 4
+			IL_007e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0083: pop
+			IL_0084: ldnull
+			IL_0085: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -488,7 +494,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 60 (0x3c)
+		// Code size: 61 (0x3d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope,
@@ -519,11 +525,12 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldloc.1
-		IL_0030: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003a: pop
-		IL_003b: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope
+		IL_0035: ldnull
+		IL_0036: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
+		IL_003b: pop
+		IL_003c: ret
 	} // end of method Function_Closure_CapturedBoolean_AssignAndRead::__js_module_init__
 
 } // end of class Modules.Function_Closure_CapturedBoolean_AssignAndRead

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -2046,7 +2046,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2641 (0xa51)
+		// Code size: 2637 (0xa4d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
@@ -2630,325 +2630,324 @@
 		IL_0651: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0656: pop
 		IL_0657: nop
-		IL_0658: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_065d: stloc.s 16
-		IL_065f: ldloc.s 4
-		IL_0661: ldloc.s 16
-		IL_0663: ldc.r8 10
-		IL_066c: box [System.Runtime]System.Double
-		IL_0671: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0676: stloc.s 10
-		IL_0678: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_067d: stloc.s 20
-		IL_067f: ldloc.s 10
-		IL_0681: dup
-		IL_0682: ldc.r8 5
-		IL_068b: box [System.Runtime]System.Double
-		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0695: stloc.s 24
-		IL_0697: volatile.
-		IL_0699: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_069e: brfalse IL_06b4
+		IL_0658: ldloc.0
+		IL_0659: castclass Modules.Function_ConstructedInstance_ObjectSemantics/Scope
+		IL_065e: ldnull
+		IL_065f: ldc.r8 10
+		IL_0668: box [System.Runtime]System.Double
+		IL_066d: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object, object)
+		IL_0672: stloc.s 10
+		IL_0674: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0679: stloc.s 20
+		IL_067b: ldloc.s 10
+		IL_067d: dup
+		IL_067e: ldc.r8 5
+		IL_0687: box [System.Runtime]System.Double
+		IL_068c: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0691: stloc.s 24
+		IL_0693: volatile.
+		IL_0695: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_069a: brfalse IL_06b0
 
-		IL_06a3: ldloc.s 24
-		IL_06a5: ldstr "value"
-		IL_06aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06af: br IL_06ca
+		IL_069f: ldloc.s 24
+		IL_06a1: ldstr "value"
+		IL_06a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06ab: br IL_06c6
 
-		IL_06b4: ldloc.s 24
-		IL_06b6: ldstr "value"
-		IL_06bb: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:165"
-		IL_06c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06b0: ldloc.s 24
+		IL_06b2: ldstr "value"
+		IL_06b7: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:165"
+		IL_06bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06ca: stloc.s 24
-		IL_06cc: ldloc.s 20
-		IL_06ce: ldloc.s 24
-		IL_06d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06d5: pop
-		IL_06d6: ldloc.1
-		IL_06d7: ldstr "bind"
-		IL_06dc: ldc.i4.0
-		IL_06dd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_06e2: ldc.r8 10
-		IL_06eb: box [System.Runtime]System.Double
-		IL_06f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_06f5: stloc.s 11
-		IL_06f7: ldloc.s 11
-		IL_06f9: dup
-		IL_06fa: ldc.r8 5
-		IL_0703: box [System.Runtime]System.Double
-		IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_070d: stloc.s 12
-		IL_070f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0714: stloc.s 20
-		IL_0716: ldloc.s 12
-		IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_071d: volatile.
-		IL_071f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0724: brfalse IL_0738
+		IL_06c6: stloc.s 24
+		IL_06c8: ldloc.s 20
+		IL_06ca: ldloc.s 24
+		IL_06cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06d1: pop
+		IL_06d2: ldloc.1
+		IL_06d3: ldstr "bind"
+		IL_06d8: ldc.i4.0
+		IL_06d9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_06de: ldc.r8 10
+		IL_06e7: box [System.Runtime]System.Double
+		IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_06f1: stloc.s 11
+		IL_06f3: ldloc.s 11
+		IL_06f5: dup
+		IL_06f6: ldc.r8 5
+		IL_06ff: box [System.Runtime]System.Double
+		IL_0704: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0709: stloc.s 12
+		IL_070b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0710: stloc.s 20
+		IL_0712: ldloc.s 12
+		IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0719: volatile.
+		IL_071b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0720: brfalse IL_0734
 
-		IL_0729: ldstr "sum"
-		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0733: br IL_074c
+		IL_0725: ldstr "sum"
+		IL_072a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_072f: br IL_0748
 
-		IL_0738: ldstr "sum"
-		IL_073d: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:182"
-		IL_0742: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0747: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0734: ldstr "sum"
+		IL_0739: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:182"
+		IL_073e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_074c: stloc.s 24
-		IL_074e: ldloc.s 20
-		IL_0750: ldloc.s 24
-		IL_0752: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0757: pop
-		IL_0758: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_075d: stloc.s 20
-		IL_075f: ldloc.s 12
-		IL_0761: ldloc.1
-		IL_0762: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0767: stloc.s 21
-		IL_0769: ldloc.s 21
-		IL_076b: box [System.Runtime]System.Boolean
-		IL_0770: stloc.s 22
-		IL_0772: ldloc.s 20
-		IL_0774: ldloc.s 22
-		IL_0776: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_077b: pop
-		IL_077c: ldc.i4.1
-		IL_077d: newarr [System.Runtime]System.Object
-		IL_0782: dup
-		IL_0783: ldc.i4.0
-		IL_0784: ldloc.0
-		IL_0785: stelem.ref
-		IL_0786: stloc.s 16
-		IL_0788: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject::.ctor()
-		IL_078d: ldc.i4.1
-		IL_078e: conv.r8
-		IL_078f: ldstr ""
-		IL_0794: ldc.i4.0
-		IL_0795: ldc.i4.0
-		IL_0796: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_079b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0)
-		IL_07a0: stloc.s 13
-		IL_07a2: ldloc.s 13
-		IL_07a4: dup
-		IL_07a5: ldc.r8 9
-		IL_07ae: box [System.Runtime]System.Double
-		IL_07b3: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_07b8: stloc.s 14
-		IL_07ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07bf: stloc.s 20
-		IL_07c1: volatile.
-		IL_07c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_07c8: brfalse IL_07de
+		IL_0748: stloc.s 24
+		IL_074a: ldloc.s 20
+		IL_074c: ldloc.s 24
+		IL_074e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0753: pop
+		IL_0754: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0759: stloc.s 20
+		IL_075b: ldloc.s 12
+		IL_075d: ldloc.1
+		IL_075e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0763: stloc.s 21
+		IL_0765: ldloc.s 21
+		IL_0767: box [System.Runtime]System.Boolean
+		IL_076c: stloc.s 22
+		IL_076e: ldloc.s 20
+		IL_0770: ldloc.s 22
+		IL_0772: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0777: pop
+		IL_0778: ldc.i4.1
+		IL_0779: newarr [System.Runtime]System.Object
+		IL_077e: dup
+		IL_077f: ldc.i4.0
+		IL_0780: ldloc.0
+		IL_0781: stelem.ref
+		IL_0782: stloc.s 16
+		IL_0784: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject::.ctor()
+		IL_0789: ldc.i4.1
+		IL_078a: conv.r8
+		IL_078b: ldstr ""
+		IL_0790: ldc.i4.0
+		IL_0791: ldc.i4.0
+		IL_0792: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0797: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0)
+		IL_079c: stloc.s 13
+		IL_079e: ldloc.s 13
+		IL_07a0: dup
+		IL_07a1: ldc.r8 9
+		IL_07aa: box [System.Runtime]System.Double
+		IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_07b4: stloc.s 14
+		IL_07b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07bb: stloc.s 20
+		IL_07bd: volatile.
+		IL_07bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_07c4: brfalse IL_07da
 
-		IL_07cd: ldloc.s 14
-		IL_07cf: ldstr "value"
-		IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07d9: br IL_07f4
+		IL_07c9: ldloc.s 14
+		IL_07cb: ldstr "value"
+		IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07d5: br IL_07f0
 
-		IL_07de: ldloc.s 14
-		IL_07e0: ldstr "value"
-		IL_07e5: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:201"
-		IL_07ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_07ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_07da: ldloc.s 14
+		IL_07dc: ldstr "value"
+		IL_07e1: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:201"
+		IL_07e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_07eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07f4: stloc.s 24
-		IL_07f6: ldloc.s 20
-		IL_07f8: ldloc.s 24
-		IL_07fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07ff: pop
-		IL_0800: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0805: stloc.s 20
-		IL_0807: ldloc.s 14
-		IL_0809: ldloc.s 13
-		IL_080b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_0810: stloc.s 21
-		IL_0812: ldloc.s 21
-		IL_0814: box [System.Runtime]System.Boolean
-		IL_0819: stloc.s 22
-		IL_081b: ldloc.s 20
-		IL_081d: ldloc.s 22
-		IL_081f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0824: pop
-		IL_0825: nop
-		IL_0826: ldloc.s 5
-		IL_0828: ldstr "prototype"
-		IL_082d: ldc.r8 3
-		IL_0836: ldc.i4.1
-		IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_083c: pop
-		IL_083d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0842: stloc.s 20
-		IL_0844: ldloc.s 5
-		IL_0846: dup
-		IL_0847: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_084c: stloc.s 24
-		IL_084e: ldloc.s 24
-		IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0855: stloc.s 24
-		IL_0857: ldstr "Object"
-		IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0861: volatile.
-		IL_0863: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0868: brfalse IL_087c
+		IL_07f0: stloc.s 24
+		IL_07f2: ldloc.s 20
+		IL_07f4: ldloc.s 24
+		IL_07f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07fb: pop
+		IL_07fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0801: stloc.s 20
+		IL_0803: ldloc.s 14
+		IL_0805: ldloc.s 13
+		IL_0807: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_080c: stloc.s 21
+		IL_080e: ldloc.s 21
+		IL_0810: box [System.Runtime]System.Boolean
+		IL_0815: stloc.s 22
+		IL_0817: ldloc.s 20
+		IL_0819: ldloc.s 22
+		IL_081b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0820: pop
+		IL_0821: nop
+		IL_0822: ldloc.s 5
+		IL_0824: ldstr "prototype"
+		IL_0829: ldc.r8 3
+		IL_0832: ldc.i4.1
+		IL_0833: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0838: pop
+		IL_0839: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_083e: stloc.s 20
+		IL_0840: ldloc.s 5
+		IL_0842: dup
+		IL_0843: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_0848: stloc.s 24
+		IL_084a: ldloc.s 24
+		IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0851: stloc.s 24
+		IL_0853: ldstr "Object"
+		IL_0858: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_085d: volatile.
+		IL_085f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0864: brfalse IL_0878
 
-		IL_086d: ldstr "prototype"
-		IL_0872: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0877: br IL_0890
+		IL_0869: ldstr "prototype"
+		IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0873: br IL_088c
 
-		IL_087c: ldstr "prototype"
-		IL_0881: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:220"
-		IL_0886: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_088b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0878: ldstr "prototype"
+		IL_087d: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:220"
+		IL_0882: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0887: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0890: stloc.s 25
-		IL_0892: ldloc.s 24
-		IL_0894: ldloc.s 25
-		IL_0896: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_089b: stloc.s 21
-		IL_089d: ldloc.s 21
-		IL_089f: box [System.Runtime]System.Boolean
-		IL_08a4: stloc.s 22
-		IL_08a6: ldloc.s 20
-		IL_08a8: ldloc.s 22
-		IL_08aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08af: pop
-		IL_08b0: nop
-		IL_08b1: ldloc.s 6
-		IL_08b3: ldstr "prototype"
-		IL_08b8: ldc.i4.0
-		IL_08b9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_08be: ldc.i4.1
-		IL_08bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_08c4: pop
-		IL_08c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08ca: stloc.s 20
-		IL_08cc: ldloc.s 6
-		IL_08ce: dup
-		IL_08cf: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-		IL_08d4: stloc.s 25
-		IL_08d6: ldloc.s 25
-		IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_08dd: stloc.s 25
-		IL_08df: ldstr "Object"
-		IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08e9: volatile.
-		IL_08eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_08f0: brfalse IL_0904
+		IL_088c: stloc.s 25
+		IL_088e: ldloc.s 24
+		IL_0890: ldloc.s 25
+		IL_0892: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0897: stloc.s 21
+		IL_0899: ldloc.s 21
+		IL_089b: box [System.Runtime]System.Boolean
+		IL_08a0: stloc.s 22
+		IL_08a2: ldloc.s 20
+		IL_08a4: ldloc.s 22
+		IL_08a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08ab: pop
+		IL_08ac: nop
+		IL_08ad: ldloc.s 6
+		IL_08af: ldstr "prototype"
+		IL_08b4: ldc.i4.0
+		IL_08b5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_08ba: ldc.i4.1
+		IL_08bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_08c0: pop
+		IL_08c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08c6: stloc.s 20
+		IL_08c8: ldloc.s 6
+		IL_08ca: dup
+		IL_08cb: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+		IL_08d0: stloc.s 25
+		IL_08d2: ldloc.s 25
+		IL_08d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_08d9: stloc.s 25
+		IL_08db: ldstr "Object"
+		IL_08e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08e5: volatile.
+		IL_08e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_08ec: brfalse IL_0900
 
-		IL_08f5: ldstr "prototype"
-		IL_08fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08ff: br IL_0918
+		IL_08f1: ldstr "prototype"
+		IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08fb: br IL_0914
 
-		IL_0904: ldstr "prototype"
-		IL_0909: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:237"
-		IL_090e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0900: ldstr "prototype"
+		IL_0905: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:237"
+		IL_090a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_090f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0918: stloc.s 24
-		IL_091a: ldloc.s 25
-		IL_091c: ldloc.s 24
-		IL_091e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0923: stloc.s 21
-		IL_0925: ldloc.s 21
-		IL_0927: box [System.Runtime]System.Boolean
-		IL_092c: stloc.s 22
-		IL_092e: ldloc.s 20
-		IL_0930: ldloc.s 22
-		IL_0932: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0937: pop
-		IL_0938: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_093d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0942: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
-		IL_0947: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_094c: stloc.s 26
-		IL_094e: volatile.
-		IL_0950: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_0955: brfalse IL_096b
+		IL_0914: stloc.s 24
+		IL_0916: ldloc.s 25
+		IL_0918: ldloc.s 24
+		IL_091a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_091f: stloc.s 21
+		IL_0921: ldloc.s 21
+		IL_0923: box [System.Runtime]System.Boolean
+		IL_0928: stloc.s 22
+		IL_092a: ldloc.s 20
+		IL_092c: ldloc.s 22
+		IL_092e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0933: pop
+		IL_0934: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_0939: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_093e: ldtoken Modules.Function_ConstructedInstance_ObjectSemantics/PointReader
+		IL_0943: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0948: stloc.s 26
+		IL_094a: volatile.
+		IL_094c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0951: brfalse IL_0967
 
-		IL_095a: ldloc.s 26
-		IL_095c: ldstr "prototype"
-		IL_0961: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0966: br IL_0981
+		IL_0956: ldloc.s 26
+		IL_0958: ldstr "prototype"
+		IL_095d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0962: br IL_097d
 
-		IL_096b: ldloc.s 26
-		IL_096d: ldstr "prototype"
-		IL_0972: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:244"
-		IL_0977: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_097c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0967: ldloc.s 26
+		IL_0969: ldstr "prototype"
+		IL_096e: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:244"
+		IL_0973: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_0978: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0981: pop
-		IL_0982: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0987: stloc.s 16
-		IL_0989: ldloc.s 26
-		IL_098b: ldstr "read"
-		IL_0990: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject::.ctor()
-		IL_0995: ldc.i4.1
-		IL_0996: conv.r8
-		IL_0997: ldstr "read"
-		IL_099c: ldc.i4.0
-		IL_099d: ldc.i4.0
-		IL_099e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_09a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0)
-		IL_09a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_09ad: pop
-		IL_09ae: ldc.i4.1
-		IL_09af: newarr [System.Runtime]System.Object
-		IL_09b4: dup
-		IL_09b5: ldc.i4.0
-		IL_09b6: ldloc.0
-		IL_09b7: stelem.ref
-		IL_09b8: stloc.s 16
-		IL_09ba: ldloc.s 16
-		IL_09bc: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject::.ctor(object[])
-		IL_09c1: ldloc.s 26
-		IL_09c3: ldloc.s 16
-		IL_09c5: ldc.i4.0
-		IL_09c6: conv.r8
-		IL_09c7: ldc.i4.0
-		IL_09c8: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_09cd: castclass Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
-		IL_09d2: stloc.s 27
-		IL_09d4: ldloc.s 27
-		IL_09d6: stloc.s 15
-		IL_09d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09dd: stloc.s 20
-		IL_09df: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::.ctor()
-		IL_09e4: stloc.s 19
-		IL_09e6: ldloc.1
-		IL_09e7: ldloc.s 19
-		IL_09e9: ldloc.1
-		IL_09ea: ldc.r8 6
-		IL_09f3: box [System.Runtime]System.Double
-		IL_09f8: ldc.r8 1
-		IL_0a01: box [System.Runtime]System.Double
-		IL_0a06: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2<class Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point>(object, object, object, object, object)
-		IL_0a0b: stloc.s 19
-		IL_0a0d: volatile.
-		IL_0a0f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0a14: brfalse IL_0a2c
+		IL_097d: pop
+		IL_097e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0983: stloc.s 16
+		IL_0985: ldloc.s 26
+		IL_0987: ldstr "read"
+		IL_098c: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject::.ctor()
+		IL_0991: ldc.i4.1
+		IL_0992: conv.r8
+		IL_0993: ldstr "read"
+		IL_0998: ldc.i4.0
+		IL_0999: ldc.i4.0
+		IL_099a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_099f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0)
+		IL_09a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_09a9: pop
+		IL_09aa: ldc.i4.1
+		IL_09ab: newarr [System.Runtime]System.Object
+		IL_09b0: dup
+		IL_09b1: ldc.i4.0
+		IL_09b2: ldloc.0
+		IL_09b3: stelem.ref
+		IL_09b4: stloc.s 16
+		IL_09b6: ldloc.s 16
+		IL_09b8: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject::.ctor(object[])
+		IL_09bd: ldloc.s 26
+		IL_09bf: ldloc.s 16
+		IL_09c1: ldc.i4.0
+		IL_09c2: conv.r8
+		IL_09c3: ldc.i4.0
+		IL_09c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_09c9: castclass Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
+		IL_09ce: stloc.s 27
+		IL_09d0: ldloc.s 27
+		IL_09d2: stloc.s 15
+		IL_09d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_09d9: stloc.s 20
+		IL_09db: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point::.ctor()
+		IL_09e0: stloc.s 19
+		IL_09e2: ldloc.1
+		IL_09e3: ldloc.s 19
+		IL_09e5: ldloc.1
+		IL_09e6: ldc.r8 6
+		IL_09ef: box [System.Runtime]System.Double
+		IL_09f4: ldc.r8 1
+		IL_09fd: box [System.Runtime]System.Double
+		IL_0a02: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver2<class Modules.Function_ConstructedInstance_ObjectSemantics/ObjectLiterals/Ctor_L3C1_Point>(object, object, object, object, object)
+		IL_0a07: stloc.s 19
+		IL_0a09: volatile.
+		IL_0a0b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0a10: brfalse IL_0a28
 
-		IL_0a19: ldloc.s 15
-		IL_0a1b: ldstr "read"
-		IL_0a20: ldloc.s 19
-		IL_0a22: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0a27: br IL_0a44
+		IL_0a15: ldloc.s 15
+		IL_0a17: ldstr "read"
+		IL_0a1c: ldloc.s 19
+		IL_0a1e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a23: br IL_0a40
 
-		IL_0a2c: ldloc.s 15
-		IL_0a2e: ldstr "read"
-		IL_0a33: ldloc.s 19
-		IL_0a35: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:261"
-		IL_0a3a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0a28: ldloc.s 15
+		IL_0a2a: ldstr "read"
+		IL_0a2f: ldloc.s 19
+		IL_0a31: ldstr "Function_ConstructedInstance_ObjectSemantics:Modules.Function_ConstructedInstance_ObjectSemantics:__js_module_init__:261"
+		IL_0a36: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0a3b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0a44: stloc.s 24
-		IL_0a46: ldloc.s 20
-		IL_0a48: ldloc.s 24
-		IL_0a4a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0a4f: pop
-		IL_0a50: ret
+		IL_0a40: stloc.s 24
+		IL_0a42: ldloc.s 20
+		IL_0a44: ldloc.s 24
+		IL_0a46: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0a4b: pop
+		IL_0a4c: ret
 	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
 
 } // end of class Modules.Function_ConstructedInstance_ObjectSemantics

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
@@ -506,7 +506,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 70 (0x46)
+		// Code size: 71 (0x47)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_GlobalScope_NoClosure/Scope,
@@ -540,11 +540,12 @@
 		IL_002e: ldc.r8 10
 		IL_0037: stloc.2
 		IL_0038: nop
-		IL_0039: ldloc.1
-		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0044: pop
-		IL_0045: ret
+		IL_0039: ldloc.0
+		IL_003a: castclass Modules.Function_Constructor_GlobalScope_NoClosure/Scope
+		IL_003f: ldnull
+		IL_0040: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer::__js_call__(class Modules.Function_Constructor_GlobalScope_NoClosure/Scope, object)
+		IL_0045: pop
+		IL_0046: ret
 	} // end of method Function_Constructor_GlobalScope_NoClosure::__js_module_init__
 
 } // end of class Modules.Function_Constructor_GlobalScope_NoClosure

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterExpression.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterExpression.verified.txt
@@ -321,7 +321,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 166 (0xa6)
+		// Code size: 133 (0x85)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_DefaultParameterExpression/Scope,
@@ -348,37 +348,28 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldc.r8 5
-		IL_0038: box [System.Runtime]System.Double
-		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0042: pop
-		IL_0043: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0048: stloc.2
-		IL_0049: ldloc.1
-		IL_004a: ldloc.2
-		IL_004b: ldc.r8 5
-		IL_0054: box [System.Runtime]System.Double
-		IL_0059: ldc.r8 8
-		IL_0062: box [System.Runtime]System.Double
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_006c: pop
-		IL_006d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0072: stloc.2
-		IL_0073: ldloc.1
-		IL_0074: ldloc.2
-		IL_0075: ldc.r8 5
-		IL_007e: box [System.Runtime]System.Double
-		IL_0083: ldc.r8 8
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: ldc.r8 20
-		IL_009a: box [System.Runtime]System.Double
-		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_00a4: pop
-		IL_00a5: ret
+		IL_0027: ldnull
+		IL_0028: ldc.r8 5
+		IL_0031: ldnull
+		IL_0032: ldnull
+		IL_0033: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, float64, object, object)
+		IL_0038: pop
+		IL_0039: ldnull
+		IL_003a: ldc.r8 5
+		IL_0043: ldc.r8 8
+		IL_004c: box [System.Runtime]System.Double
+		IL_0051: ldnull
+		IL_0052: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, float64, object, object)
+		IL_0057: pop
+		IL_0058: ldnull
+		IL_0059: ldc.r8 5
+		IL_0062: ldc.r8 8
+		IL_006b: box [System.Runtime]System.Double
+		IL_0070: ldc.r8 20
+		IL_0079: box [System.Runtime]System.Double
+		IL_007e: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, float64, object, object)
+		IL_0083: pop
+		IL_0084: ret
 	} // end of method Function_DefaultParameterExpression::__js_module_init__
 
 } // end of class Modules.Function_DefaultParameterExpression

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterValue.verified.txt
@@ -702,7 +702,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 358 (0x166)
+		// Code size: 292 (0x124)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_DefaultParameterValue/Scope,
@@ -763,70 +763,56 @@
 		IL_0067: nop
 		IL_0068: nop
 		IL_0069: nop
-		IL_006a: ldloc.1
-		IL_006b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0075: pop
-		IL_0076: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_007b: stloc.s 4
-		IL_007d: ldloc.1
-		IL_007e: ldloc.s 4
-		IL_0080: ldstr "Alice"
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_008a: pop
-		IL_008b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0090: stloc.s 4
-		IL_0092: ldloc.2
-		IL_0093: ldloc.s 4
-		IL_0095: ldc.r8 5
-		IL_009e: box [System.Runtime]System.Double
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00a8: pop
-		IL_00a9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ae: stloc.s 4
-		IL_00b0: ldloc.2
-		IL_00b1: ldloc.s 4
-		IL_00b3: ldc.r8 5
-		IL_00bc: box [System.Runtime]System.Double
-		IL_00c1: ldc.r8 15
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00d4: pop
-		IL_00d5: ldloc.3
-		IL_00d6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00e0: pop
-		IL_00e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00e6: stloc.s 4
-		IL_00e8: ldloc.3
-		IL_00e9: ldloc.s 4
-		IL_00eb: ldc.r8 2
-		IL_00f4: box [System.Runtime]System.Double
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00fe: pop
-		IL_00ff: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0104: stloc.s 4
-		IL_0106: ldloc.3
-		IL_0107: ldloc.s 4
-		IL_0109: ldc.r8 2
-		IL_0112: box [System.Runtime]System.Double
-		IL_0117: ldc.r8 4
-		IL_0120: box [System.Runtime]System.Double
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_012a: pop
-		IL_012b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0130: stloc.s 4
-		IL_0132: ldloc.3
-		IL_0133: ldloc.s 4
-		IL_0135: ldc.r8 2
-		IL_013e: box [System.Runtime]System.Double
-		IL_0143: ldc.r8 4
-		IL_014c: box [System.Runtime]System.Double
-		IL_0151: ldc.r8 3
-		IL_015a: box [System.Runtime]System.Double
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0164: pop
-		IL_0165: ret
+		IL_006a: ldnull
+		IL_006b: ldnull
+		IL_006c: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
+		IL_0071: pop
+		IL_0072: ldnull
+		IL_0073: ldstr "Alice"
+		IL_0078: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
+		IL_007d: pop
+		IL_007e: ldnull
+		IL_007f: ldc.r8 5
+		IL_0088: ldnull
+		IL_0089: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, float64, object)
+		IL_008e: pop
+		IL_008f: ldnull
+		IL_0090: ldc.r8 5
+		IL_0099: ldc.r8 15
+		IL_00a2: box [System.Runtime]System.Double
+		IL_00a7: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, float64, object)
+		IL_00ac: pop
+		IL_00ad: ldnull
+		IL_00ae: ldnull
+		IL_00af: ldnull
+		IL_00b0: ldnull
+		IL_00b1: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
+		IL_00b6: pop
+		IL_00b7: ldnull
+		IL_00b8: ldc.r8 2
+		IL_00c1: box [System.Runtime]System.Double
+		IL_00c6: ldnull
+		IL_00c7: ldnull
+		IL_00c8: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
+		IL_00cd: pop
+		IL_00ce: ldnull
+		IL_00cf: ldc.r8 2
+		IL_00d8: box [System.Runtime]System.Double
+		IL_00dd: ldc.r8 4
+		IL_00e6: box [System.Runtime]System.Double
+		IL_00eb: ldnull
+		IL_00ec: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
+		IL_00f1: pop
+		IL_00f2: ldnull
+		IL_00f3: ldc.r8 2
+		IL_00fc: box [System.Runtime]System.Double
+		IL_0101: ldc.r8 4
+		IL_010a: box [System.Runtime]System.Double
+		IL_010f: ldc.r8 3
+		IL_0118: box [System.Runtime]System.Double
+		IL_011d: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
+		IL_0122: pop
+		IL_0123: ret
 	} // end of method Function_DefaultParameterValue::__js_module_init__
 
 } // end of class Modules.Function_DefaultParameterValue

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
@@ -509,7 +509,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 92 (0x5c)
+		// Code size: 91 (0x5b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope,
@@ -544,19 +544,18 @@
 		IL_002e: nop
 		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0034: stloc.3
-		IL_0035: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003a: stloc.2
-		IL_003b: ldloc.1
-		IL_003c: ldloc.2
-		IL_003d: ldc.r8 10
-		IL_0046: box [System.Runtime]System.Double
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0050: stloc.s 4
-		IL_0052: ldloc.3
-		IL_0053: ldloc.s 4
-		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005a: pop
-		IL_005b: ret
+		IL_0035: ldloc.0
+		IL_0036: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope
+		IL_003b: ldnull
+		IL_003c: ldc.r8 10
+		IL_0045: box [System.Runtime]System.Double
+		IL_004a: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
+		IL_004f: stloc.s 4
+		IL_0051: ldloc.3
+		IL_0052: ldloc.s 4
+		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0059: pop
+		IL_005a: ret
 	} // end of method Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter::__js_module_init__
 
 } // end of class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -210,11 +210,10 @@
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
 			// Header size: 12
-			// Code size: 58 (0x3a)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -225,20 +224,11 @@
 			IL_0015: box [System.Runtime]System.Double
 			IL_001a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_001f: pop
-			IL_0020: ldarg.0
-			IL_0021: ldfld object Modules.Function_GlobalFunctionCallsGlobalFunction/Scope::helloWorld
-			IL_0026: stloc.1
-			IL_0027: ldloc.1
-			IL_0028: ldc.i4.1
-			IL_0029: newarr [System.Runtime]System.Object
-			IL_002e: dup
-			IL_002f: ldc.i4.0
-			IL_0030: ldarg.0
-			IL_0031: stelem.ref
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0037: pop
-			IL_0038: ldnull
-			IL_0039: ret
+			IL_0020: ldnull
+			IL_0021: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld::__js_call__(object)
+			IL_0026: pop
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method helloWorldProxy::__js_call__
 
 	} // end of class helloWorldProxy
@@ -428,7 +418,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 135 (0x87)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope,
@@ -478,22 +468,23 @@
 		IL_004d: ldloc.3
 		IL_004e: stfld object Modules.Function_GlobalFunctionCallsGlobalFunction/Scope::helloWorld
 		IL_0053: nop
-		IL_0054: ldloc.1
-		IL_0055: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_005f: pop
-		IL_0060: nop
+		IL_0054: ldloc.0
+		IL_0055: castclass Modules.Function_GlobalFunctionCallsGlobalFunction/Scope
+		IL_005a: ldnull
+		IL_005b: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
+		IL_0060: pop
 		IL_0061: nop
 		IL_0062: nop
-		IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0068: stloc.s 4
-		IL_006a: ldloc.s 4
-		IL_006c: ldstr "finally is now"
-		IL_0071: ldc.r8 3
-		IL_007a: box [System.Runtime]System.Double
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_0063: nop
+		IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0069: stloc.s 4
+		IL_006b: ldloc.s 4
+		IL_006d: ldstr "finally is now"
+		IL_0072: ldc.r8 3
+		IL_007b: box [System.Runtime]System.Double
+		IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0085: pop
+		IL_0086: ret
 	} // end of method Function_GlobalFunctionCallsGlobalFunction::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionCallsGlobalFunction

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -340,7 +340,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 214 (0xd6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope,
@@ -410,40 +410,41 @@
 		IL_0084: stelem.ref
 		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_008a: pop
-		IL_008b: ldloc.1
-		IL_008c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0096: pop
-		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009c: stloc.3
-		IL_009d: ldloc.0
-		IL_009e: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
-		IL_00a3: stloc.s 5
-		IL_00a5: ldloc.0
-		IL_00a6: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
-		IL_00ab: stloc.s 4
-		IL_00ad: ldloc.3
-		IL_00ae: ldc.i4.4
-		IL_00af: newarr [System.Runtime]System.Object
-		IL_00b4: dup
-		IL_00b5: ldc.i4.0
-		IL_00b6: ldstr "End - counter:"
-		IL_00bb: stelem.ref
-		IL_00bc: dup
-		IL_00bd: ldc.i4.1
-		IL_00be: ldloc.s 5
-		IL_00c0: stelem.ref
-		IL_00c1: dup
-		IL_00c2: ldc.i4.2
-		IL_00c3: ldstr "message:"
-		IL_00c8: stelem.ref
-		IL_00c9: dup
-		IL_00ca: ldc.i4.3
-		IL_00cb: ldloc.s 4
-		IL_00cd: stelem.ref
-		IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00d3: pop
-		IL_00d4: ret
+		IL_008b: ldloc.0
+		IL_008c: castclass Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope
+		IL_0091: ldnull
+		IL_0092: call object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
+		IL_0097: pop
+		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009d: stloc.3
+		IL_009e: ldloc.0
+		IL_009f: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
+		IL_00a4: stloc.s 5
+		IL_00a6: ldloc.0
+		IL_00a7: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
+		IL_00ac: stloc.s 4
+		IL_00ae: ldloc.3
+		IL_00af: ldc.i4.4
+		IL_00b0: newarr [System.Runtime]System.Object
+		IL_00b5: dup
+		IL_00b6: ldc.i4.0
+		IL_00b7: ldstr "End - counter:"
+		IL_00bc: stelem.ref
+		IL_00bd: dup
+		IL_00be: ldc.i4.1
+		IL_00bf: ldloc.s 5
+		IL_00c1: stelem.ref
+		IL_00c2: dup
+		IL_00c3: ldc.i4.2
+		IL_00c4: ldstr "message:"
+		IL_00c9: stelem.ref
+		IL_00ca: dup
+		IL_00cb: ldc.i4.3
+		IL_00cc: ldloc.s 4
+		IL_00ce: stelem.ref
+		IL_00cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00d4: pop
+		IL_00d5: ret
 	} // end of method Function_GlobalFunctionChangesGlobalVariableValue::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionChangesGlobalVariableValue

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
@@ -344,7 +344,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 112 (0x70)
+			// Code size: 107 (0x6b)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/Scope,
@@ -379,19 +379,18 @@
 			IL_003e: ldstr "After nested function declaration"
 			IL_0043: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_0048: pop
-			IL_0049: ldloc.1
-			IL_004a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0054: stloc.2
-			IL_0055: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_005a: stloc.s 4
-			IL_005c: ldloc.s 4
-			IL_005e: ldstr "Nested function returned:"
-			IL_0063: ldloc.2
-			IL_0064: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0069: pop
-			IL_006a: ldstr "outer result"
-			IL_006f: ret
+			IL_0049: ldnull
+			IL_004a: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction::__js_call__(object)
+			IL_004f: stloc.2
+			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0055: stloc.s 4
+			IL_0057: ldloc.s 4
+			IL_0059: ldstr "Nested function returned:"
+			IL_005e: ldloc.2
+			IL_005f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0064: pop
+			IL_0065: ldstr "outer result"
+			IL_006a: ret
 		} // end of method outerFunction::__js_call__
 
 	} // end of class outerFunction
@@ -435,7 +434,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 113 (0x71)
+		// Code size: 108 (0x6c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/Scope,
@@ -470,24 +469,23 @@
 		IL_0030: ldstr "Start"
 		IL_0035: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_003a: pop
-		IL_003b: ldloc.1
-		IL_003c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0046: stloc.2
-		IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004c: stloc.s 4
-		IL_004e: ldloc.s 4
-		IL_0050: ldstr "Main result:"
-		IL_0055: ldloc.2
-		IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_005b: pop
-		IL_005c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0061: stloc.s 4
-		IL_0063: ldloc.s 4
-		IL_0065: ldstr "End"
-		IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006f: pop
-		IL_0070: ret
+		IL_003b: ldnull
+		IL_003c: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction::__js_call__(object)
+		IL_0041: stloc.2
+		IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0047: stloc.s 4
+		IL_0049: ldloc.s 4
+		IL_004b: ldstr "Main result:"
+		IL_0050: ldloc.2
+		IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0056: pop
+		IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_005c: stloc.s 4
+		IL_005e: ldloc.s 4
+		IL_0060: ldstr "End"
+		IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006a: pop
+		IL_006b: ret
 	} // end of method Function_GlobalFunctionDeclaresAndCallsNestedFunction::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -288,7 +288,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 91 (0x5b)
+		// Code size: 92 (0x5c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope,
@@ -326,11 +326,12 @@
 		IL_0043: box [System.Runtime]System.Double
 		IL_0048: stfld object Modules.Function_GlobalFunctionLogsGlobalVariable/Scope::globalNumber
 		IL_004d: nop
-		IL_004e: ldloc.1
-		IL_004f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0059: pop
-		IL_005a: ret
+		IL_004e: ldloc.0
+		IL_004f: castclass Modules.Function_GlobalFunctionLogsGlobalVariable/Scope
+		IL_0054: ldnull
+		IL_0055: call object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
+		IL_005a: pop
+		IL_005b: ret
 	} // end of method Function_GlobalFunctionLogsGlobalVariable::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionLogsGlobalVariable

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -526,7 +526,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 133 (0x85)
+		// Code size: 130 (0x82)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope,
@@ -564,26 +564,25 @@
 		IL_003a: box [System.Runtime]System.Double
 		IL_003f: stfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::outerVar
 		IL_0044: nop
-		IL_0045: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004a: stloc.s 4
-		IL_004c: ldloc.1
-		IL_004d: ldloc.s 4
-		IL_004f: ldc.r8 7
-		IL_0058: box [System.Runtime]System.Double
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0062: stloc.2
-		IL_0063: ldloc.2
-		IL_0064: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_006e: stloc.3
-		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0074: stloc.s 5
-		IL_0076: ldloc.s 5
-		IL_0078: ldstr "Result:"
-		IL_007d: ldloc.3
-		IL_007e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0083: pop
-		IL_0084: ret
+		IL_0045: ldloc.0
+		IL_0046: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
+		IL_004b: ldnull
+		IL_004c: ldc.r8 7
+		IL_0055: box [System.Runtime]System.Double
+		IL_005a: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
+		IL_005f: stloc.2
+		IL_0060: ldloc.2
+		IL_0061: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_006b: stloc.3
+		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0071: stloc.s 5
+		IL_0073: ldloc.s 5
+		IL_0075: ldstr "Result:"
+		IL_007a: ldloc.3
+		IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0080: pop
+		IL_0081: ret
 	} // end of method Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -317,16 +317,16 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 203 (0xcb)
+		// Code size: 160 (0xa0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithArrayIteration/Scope,
 			[1] class Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[3] object,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] object[],
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[6] object
+			[6] string
 		)
 
 		IL_0000: newobj instance void Modules.Function_GlobalFunctionWithArrayIteration/Scope::.ctor()
@@ -363,36 +363,27 @@
 		IL_005c: ldc.r8 4
 		IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_006a: stloc.2
-		IL_006b: ldloc.1
-		IL_006c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0071: ldloc.2
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_006b: ldnull
+		IL_006c: ldloc.2
+		IL_006d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_GlobalFunctionWithArrayIteration/processArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 		IL_0077: stloc.3
 		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_007d: stloc.s 5
 		IL_007f: ldloc.3
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0085: volatile.
-		IL_0087: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_008c: brfalse IL_00a5
-
-		IL_0091: ldstr "join"
-		IL_0096: ldstr ","
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a0: br IL_00be
-
-		IL_00a5: ldstr "join"
-		IL_00aa: ldstr ","
-		IL_00af: ldstr "Function_GlobalFunctionWithArrayIteration:Modules.Function_GlobalFunctionWithArrayIteration:__js_module_init__:22"
-		IL_00b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
-
-		IL_00be: stloc.s 6
-		IL_00c0: ldloc.s 5
-		IL_00c2: ldloc.s 6
-		IL_00c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c9: pop
-		IL_00ca: ret
+		IL_0080: ldc.i4.1
+		IL_0081: newarr [System.Runtime]System.Object
+		IL_0086: dup
+		IL_0087: ldc.i4.0
+		IL_0088: ldstr ","
+		IL_008d: stelem.ref
+		IL_008e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0093: stloc.s 6
+		IL_0095: ldloc.s 5
+		IL_0097: ldloc.s 6
+		IL_0099: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009e: pop
+		IL_009f: ret
 	} // end of method Function_GlobalFunctionWithArrayIteration::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithArrayIteration
@@ -417,12 +408,4 @@
 	} // end of method Program::Main
 
 } // end of class Program
-
-.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
-	extends [System.Runtime]System.Object
-{
-	// Fields
-	.field assembly static int32 __jroc_dynamicLookup_2
-
-} // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
@@ -1278,7 +1278,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 626 (0x272)
+		// Code size: 440 (0x1b8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithMultipleParameters/Scope,
@@ -1390,105 +1390,46 @@
 		IL_00cd: nop
 		IL_00ce: nop
 		IL_00cf: nop
-		IL_00d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00d5: stloc.s 7
-		IL_00d7: ldloc.1
-		IL_00d8: ldloc.s 7
-		IL_00da: ldc.r8 1
-		IL_00e3: box [System.Runtime]System.Double
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00ed: pop
-		IL_00ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00f3: stloc.s 7
-		IL_00f5: ldloc.2
-		IL_00f6: ldloc.s 7
-		IL_00f8: ldc.r8 1
-		IL_0101: box [System.Runtime]System.Double
-		IL_0106: ldc.r8 2
-		IL_010f: box [System.Runtime]System.Double
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0119: pop
-		IL_011a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_011f: stloc.s 7
-		IL_0121: ldloc.3
-		IL_0122: ldloc.s 7
-		IL_0124: ldc.r8 1
-		IL_012d: box [System.Runtime]System.Double
-		IL_0132: ldc.r8 2
-		IL_013b: box [System.Runtime]System.Double
-		IL_0140: ldc.r8 3
-		IL_0149: box [System.Runtime]System.Double
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0153: pop
-		IL_0154: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0159: stloc.s 7
-		IL_015b: ldloc.s 4
-		IL_015d: ldloc.s 7
-		IL_015f: ldc.r8 1
-		IL_0168: box [System.Runtime]System.Double
-		IL_016d: ldc.r8 2
-		IL_0176: box [System.Runtime]System.Double
-		IL_017b: ldc.r8 3
-		IL_0184: box [System.Runtime]System.Double
-		IL_0189: ldc.r8 4
-		IL_0192: box [System.Runtime]System.Double
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_019c: pop
-		IL_019d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01a2: stloc.s 7
-		IL_01a4: ldloc.s 5
-		IL_01a6: ldloc.s 7
-		IL_01a8: ldc.r8 1
-		IL_01b1: box [System.Runtime]System.Double
-		IL_01b6: ldc.r8 2
-		IL_01bf: box [System.Runtime]System.Double
-		IL_01c4: ldc.r8 3
-		IL_01cd: box [System.Runtime]System.Double
-		IL_01d2: ldc.r8 4
-		IL_01db: box [System.Runtime]System.Double
-		IL_01e0: ldc.r8 5
-		IL_01e9: box [System.Runtime]System.Double
-		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs5(object, object[], object, object, object, object, object)
-		IL_01f3: pop
-		IL_01f4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01f9: stloc.s 7
-		IL_01fb: ldloc.s 6
-		IL_01fd: ldloc.s 7
-		IL_01ff: ldc.i4.6
-		IL_0200: newarr [System.Runtime]System.Object
-		IL_0205: dup
-		IL_0206: ldc.i4.0
-		IL_0207: ldc.r8 1
-		IL_0210: box [System.Runtime]System.Double
-		IL_0215: stelem.ref
-		IL_0216: dup
-		IL_0217: ldc.i4.1
-		IL_0218: ldc.r8 2
-		IL_0221: box [System.Runtime]System.Double
-		IL_0226: stelem.ref
-		IL_0227: dup
-		IL_0228: ldc.i4.2
-		IL_0229: ldc.r8 3
-		IL_0232: box [System.Runtime]System.Double
-		IL_0237: stelem.ref
-		IL_0238: dup
-		IL_0239: ldc.i4.3
-		IL_023a: ldc.r8 4
-		IL_0243: box [System.Runtime]System.Double
-		IL_0248: stelem.ref
-		IL_0249: dup
-		IL_024a: ldc.i4.4
-		IL_024b: ldc.r8 5
-		IL_0254: box [System.Runtime]System.Double
-		IL_0259: stelem.ref
-		IL_025a: dup
-		IL_025b: ldc.i4.5
-		IL_025c: ldc.r8 6
-		IL_0265: box [System.Runtime]System.Double
-		IL_026a: stelem.ref
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0270: pop
-		IL_0271: ret
+		IL_00d0: ldnull
+		IL_00d1: ldc.r8 1
+		IL_00da: call object Modules.Function_GlobalFunctionWithMultipleParameters/f1::__js_call__(object, float64)
+		IL_00df: pop
+		IL_00e0: ldnull
+		IL_00e1: ldc.r8 1
+		IL_00ea: ldc.r8 2
+		IL_00f3: call object Modules.Function_GlobalFunctionWithMultipleParameters/f2::__js_call__(object, float64, float64)
+		IL_00f8: pop
+		IL_00f9: ldnull
+		IL_00fa: ldc.r8 1
+		IL_0103: ldc.r8 2
+		IL_010c: ldc.r8 3
+		IL_0115: call object Modules.Function_GlobalFunctionWithMultipleParameters/f3::__js_call__(object, float64, float64, float64)
+		IL_011a: pop
+		IL_011b: ldnull
+		IL_011c: ldc.r8 1
+		IL_0125: ldc.r8 2
+		IL_012e: ldc.r8 3
+		IL_0137: ldc.r8 4
+		IL_0140: call object Modules.Function_GlobalFunctionWithMultipleParameters/f4::__js_call__(object, float64, float64, float64, float64)
+		IL_0145: pop
+		IL_0146: ldnull
+		IL_0147: ldc.r8 1
+		IL_0150: ldc.r8 2
+		IL_0159: ldc.r8 3
+		IL_0162: ldc.r8 4
+		IL_016b: ldc.r8 5
+		IL_0174: call object Modules.Function_GlobalFunctionWithMultipleParameters/f5::__js_call__(object, float64, float64, float64, float64, float64)
+		IL_0179: pop
+		IL_017a: ldnull
+		IL_017b: ldc.r8 1
+		IL_0184: ldc.r8 2
+		IL_018d: ldc.r8 3
+		IL_0196: ldc.r8 4
+		IL_019f: ldc.r8 5
+		IL_01a8: ldc.r8 6
+		IL_01b1: call object Modules.Function_GlobalFunctionWithMultipleParameters/f6::__js_call__(object, float64, float64, float64, float64, float64, float64)
+		IL_01b6: pop
+		IL_01b7: ret
 	} // end of method Function_GlobalFunctionWithMultipleParameters::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithMultipleParameters

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
@@ -262,7 +262,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 59 (0x3b)
+		// Code size: 52 (0x34)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithParameter/Scope,
@@ -289,14 +289,11 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "Hello, Jroc!"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: ret
+		IL_0027: ldnull
+		IL_0028: ldstr "Hello, Jroc!"
+		IL_002d: call object Modules.Function_GlobalFunctionWithParameter/printMessage::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: ret
 	} // end of method Function_GlobalFunctionWithParameter::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithParameter

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_HelloWorld.verified.txt
@@ -252,7 +252,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 52 (0x34)
+		// Code size: 47 (0x2f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_HelloWorld/Scope,
@@ -279,11 +279,10 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldloc.1
-		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0032: pop
-		IL_0033: ret
+		IL_0027: ldnull
+		IL_0028: call object Modules.Function_HelloWorld/helloWorld::__js_call__(object)
+		IL_002d: pop
+		IL_002e: ret
 	} // end of method Function_HelloWorld::__js_module_init__
 
 } // end of class Modules.Function_HelloWorld

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
@@ -260,7 +260,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 363 (0x16b)
+			// Code size: 354 (0x162)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -271,8 +271,7 @@
 				[5] bool,
 				[6] float64,
 				[7] object,
-				[8] object[],
-				[9] object
+				[8] object
 			)
 
 			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentCallee()
@@ -359,7 +358,7 @@
 				IL_00ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
 				IL_00f1: stloc.s 5
 				IL_00f3: ldloc.s 5
-				IL_00f5: brfalse IL_0169
+				IL_00f5: brfalse IL_0160
 
 				IL_00fa: volatile.
 				IL_00fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
@@ -381,27 +380,24 @@
 				IL_012d: ldloc.1
 				IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 				IL_0133: stloc.2
-				IL_0134: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-				IL_0139: stloc.s 8
-				IL_013b: ldarg.2
-				IL_013c: ldc.r8 1
-				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_014a: stloc.s 9
-				IL_014c: ldloc.0
-				IL_014d: ldloc.s 8
-				IL_014f: ldloc.2
-				IL_0150: ldloc.s 9
-				IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0157: pop
-				IL_0158: ldloc.1
-				IL_0159: ldc.r8 1
-				IL_0162: add
-				IL_0163: stloc.1
-				IL_0164: br IL_0079
+				IL_0134: ldarg.2
+				IL_0135: ldc.r8 1
+				IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0143: stloc.s 8
+				IL_0145: ldnull
+				IL_0146: ldloc.2
+				IL_0147: ldloc.s 8
+				IL_0149: call object Modules.Function_IIFE_Recursive/walk::__js_call__(object, object, object)
+				IL_014e: pop
+				IL_014f: ldloc.1
+				IL_0150: ldc.r8 1
+				IL_0159: add
+				IL_015a: stloc.1
+				IL_015b: br IL_0079
 			// end loop
 
-			IL_0169: ldnull
-			IL_016a: ret
+			IL_0160: ldnull
+			IL_0161: ret
 		} // end of method walk::__js_call__
 
 	} // end of class walk

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IsEven_CompareResultToTrue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IsEven_CompareResultToTrue.verified.txt
@@ -256,7 +256,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 108 (0x6c)
+		// Code size: 96 (0x60)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_IsEven_CompareResultToTrue/Scope,
@@ -289,27 +289,23 @@
 		IL_0026: nop
 		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002c: stloc.3
-		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0032: stloc.2
-		IL_0033: ldloc.1
-		IL_0034: ldloc.2
-		IL_0035: ldc.r8 4
-		IL_003e: box [System.Runtime]System.Double
-		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0048: stloc.s 4
-		IL_004a: ldloc.s 4
-		IL_004c: ldc.i4.1
-		IL_004d: box [System.Runtime]System.Boolean
-		IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-		IL_0057: stloc.s 5
-		IL_0059: ldloc.s 5
-		IL_005b: box [System.Runtime]System.Boolean
-		IL_0060: stloc.s 6
-		IL_0062: ldloc.3
-		IL_0063: ldloc.s 6
-		IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006a: pop
-		IL_006b: ret
+		IL_002d: ldnull
+		IL_002e: ldc.r8 4
+		IL_0037: call object Modules.Function_IsEven_CompareResultToTrue/isEven::__js_call__(object, float64)
+		IL_003c: stloc.s 4
+		IL_003e: ldloc.s 4
+		IL_0040: ldc.i4.1
+		IL_0041: box [System.Runtime]System.Boolean
+		IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+		IL_004b: stloc.s 5
+		IL_004d: ldloc.s 5
+		IL_004f: box [System.Runtime]System.Boolean
+		IL_0054: stloc.s 6
+		IL_0056: ldloc.3
+		IL_0057: ldloc.s 6
+		IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005e: pop
+		IL_005f: ret
 	} // end of method Function_IsEven_CompareResultToTrue::__js_module_init__
 
 } // end of class Modules.Function_IsEven_CompareResultToTrue

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_16.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_16.verified.txt
@@ -353,8 +353,8 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 357 (0x165)
-		.maxstack 8
+		// Code size: 288 (0x120)
+		.maxstack 18
 		.locals init (
 			[0] class Modules.Function_MaxParameters_16/Scope,
 			[1] class Modules.Function_MaxParameters_16/f/FunctionObject,
@@ -384,99 +384,46 @@
 		IL_0027: nop
 		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002d: stloc.3
-		IL_002e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0033: stloc.2
-		IL_0034: ldloc.1
-		IL_0035: ldloc.2
-		IL_0036: ldc.i4.s 16
-		IL_0038: newarr [System.Runtime]System.Object
-		IL_003d: dup
-		IL_003e: ldc.i4.0
-		IL_003f: ldc.r8 1
-		IL_0048: box [System.Runtime]System.Double
-		IL_004d: stelem.ref
-		IL_004e: dup
-		IL_004f: ldc.i4.1
-		IL_0050: ldc.r8 2
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: stelem.ref
-		IL_005f: dup
-		IL_0060: ldc.i4.2
-		IL_0061: ldc.r8 3
-		IL_006a: box [System.Runtime]System.Double
-		IL_006f: stelem.ref
-		IL_0070: dup
-		IL_0071: ldc.i4.3
-		IL_0072: ldc.r8 4
-		IL_007b: box [System.Runtime]System.Double
-		IL_0080: stelem.ref
-		IL_0081: dup
-		IL_0082: ldc.i4.4
-		IL_0083: ldc.r8 5
+		IL_002e: ldnull
+		IL_002f: ldc.r8 1
+		IL_0038: box [System.Runtime]System.Double
+		IL_003d: ldc.r8 2
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: ldc.r8 3
+		IL_0054: box [System.Runtime]System.Double
+		IL_0059: ldc.r8 4
+		IL_0062: box [System.Runtime]System.Double
+		IL_0067: ldc.r8 5
+		IL_0070: box [System.Runtime]System.Double
+		IL_0075: ldc.r8 6
+		IL_007e: box [System.Runtime]System.Double
+		IL_0083: ldc.r8 7
 		IL_008c: box [System.Runtime]System.Double
-		IL_0091: stelem.ref
-		IL_0092: dup
-		IL_0093: ldc.i4.5
-		IL_0094: ldc.r8 6
-		IL_009d: box [System.Runtime]System.Double
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.6
-		IL_00a5: ldc.r8 7
-		IL_00ae: box [System.Runtime]System.Double
-		IL_00b3: stelem.ref
-		IL_00b4: dup
-		IL_00b5: ldc.i4.7
-		IL_00b6: ldc.r8 8
-		IL_00bf: box [System.Runtime]System.Double
-		IL_00c4: stelem.ref
-		IL_00c5: dup
-		IL_00c6: ldc.i4.8
-		IL_00c7: ldc.r8 9
-		IL_00d0: box [System.Runtime]System.Double
-		IL_00d5: stelem.ref
-		IL_00d6: dup
-		IL_00d7: ldc.i4.s 9
-		IL_00d9: ldc.r8 10
-		IL_00e2: box [System.Runtime]System.Double
-		IL_00e7: stelem.ref
-		IL_00e8: dup
-		IL_00e9: ldc.i4.s 10
-		IL_00eb: ldc.r8 11
-		IL_00f4: box [System.Runtime]System.Double
-		IL_00f9: stelem.ref
-		IL_00fa: dup
-		IL_00fb: ldc.i4.s 11
-		IL_00fd: ldc.r8 12
-		IL_0106: box [System.Runtime]System.Double
-		IL_010b: stelem.ref
-		IL_010c: dup
-		IL_010d: ldc.i4.s 12
-		IL_010f: ldc.r8 13
-		IL_0118: box [System.Runtime]System.Double
-		IL_011d: stelem.ref
-		IL_011e: dup
-		IL_011f: ldc.i4.s 13
-		IL_0121: ldc.r8 14
-		IL_012a: box [System.Runtime]System.Double
-		IL_012f: stelem.ref
-		IL_0130: dup
-		IL_0131: ldc.i4.s 14
-		IL_0133: ldc.r8 15
-		IL_013c: box [System.Runtime]System.Double
-		IL_0141: stelem.ref
-		IL_0142: dup
-		IL_0143: ldc.i4.s 15
-		IL_0145: ldc.r8 16
-		IL_014e: box [System.Runtime]System.Double
-		IL_0153: stelem.ref
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0159: stloc.s 4
-		IL_015b: ldloc.3
-		IL_015c: ldloc.s 4
-		IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0163: pop
-		IL_0164: ret
+		IL_0091: ldc.r8 8
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: ldc.r8 9
+		IL_00a8: box [System.Runtime]System.Double
+		IL_00ad: ldc.r8 10
+		IL_00b6: box [System.Runtime]System.Double
+		IL_00bb: ldc.r8 11
+		IL_00c4: box [System.Runtime]System.Double
+		IL_00c9: ldc.r8 12
+		IL_00d2: box [System.Runtime]System.Double
+		IL_00d7: ldc.r8 13
+		IL_00e0: box [System.Runtime]System.Double
+		IL_00e5: ldc.r8 14
+		IL_00ee: box [System.Runtime]System.Double
+		IL_00f3: ldc.r8 15
+		IL_00fc: box [System.Runtime]System.Double
+		IL_0101: ldc.r8 16
+		IL_010a: box [System.Runtime]System.Double
+		IL_010f: call object Modules.Function_MaxParameters_16/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
+		IL_0114: stloc.s 4
+		IL_0116: ldloc.3
+		IL_0117: ldloc.s 4
+		IL_0119: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011e: pop
+		IL_011f: ret
 	} // end of method Function_MaxParameters_16::__js_module_init__
 
 } // end of class Modules.Function_MaxParameters_16

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -415,7 +415,7 @@
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
 			// Header size: 12
-			// Code size: 89 (0x59)
+			// Code size: 95 (0x5f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope,
@@ -457,17 +457,23 @@
 			IL_003b: ldstr "I am outer"
 			IL_0040: stfld string Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope::outerVar
 			IL_0045: nop
-			IL_0046: ldloc.1
-			IL_0047: ldc.i4.1
-			IL_0048: newarr [System.Runtime]System.Object
-			IL_004d: dup
-			IL_004e: ldc.i4.0
-			IL_004f: ldarg.0
-			IL_0050: stelem.ref
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0056: pop
-			IL_0057: ldnull
-			IL_0058: ret
+			IL_0046: ldc.i4.2
+			IL_0047: newarr [System.Runtime]System.Object
+			IL_004c: dup
+			IL_004d: ldc.i4.0
+			IL_004e: ldarg.0
+			IL_004f: stelem.ref
+			IL_0050: dup
+			IL_0051: ldc.i4.1
+			IL_0052: ldloc.0
+			IL_0053: stelem.ref
+			IL_0054: stloc.2
+			IL_0055: ldloc.2
+			IL_0056: ldnull
+			IL_0057: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction::__js_call__(object[], object)
+			IL_005c: pop
+			IL_005d: ldnull
+			IL_005e: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction
@@ -513,7 +519,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 71 (0x47)
+		// Code size: 72 (0x48)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope,
@@ -547,11 +553,12 @@
 		IL_002f: ldstr "I am global"
 		IL_0034: stfld string Modules.Function_NestedFunctionAccessesMultipleScopes/Scope::globalVar
 		IL_0039: nop
-		IL_003a: ldloc.1
-		IL_003b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0045: pop
-		IL_0046: ret
+		IL_003a: ldloc.0
+		IL_003b: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/Scope
+		IL_0040: ldnull
+		IL_0041: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
+		IL_0046: pop
+		IL_0047: ret
 	} // end of method Function_NestedFunctionAccessesMultipleScopes::__js_module_init__
 
 } // end of class Modules.Function_NestedFunctionAccessesMultipleScopes

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
@@ -491,7 +491,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 86 (0x56)
+		// Code size: 85 (0x55)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionLogsOuterParameter/Scope,
@@ -523,21 +523,20 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.3
-		IL_0035: ldloc.1
-		IL_0036: ldloc.3
-		IL_0037: ldstr "Value from outer"
-		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0041: stloc.2
-		IL_0042: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0047: stloc.3
-		IL_0048: ldloc.2
-		IL_0049: ldloc.3
-		IL_004a: ldstr "Value from inner"
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0054: pop
-		IL_0055: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.Function_NestedFunctionLogsOuterParameter/Scope
+		IL_0035: ldnull
+		IL_0036: ldstr "Value from outer"
+		IL_003b: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
+		IL_0040: stloc.2
+		IL_0041: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0046: stloc.3
+		IL_0047: ldloc.2
+		IL_0048: ldloc.3
+		IL_0049: ldstr "Value from inner"
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0053: pop
+		IL_0054: ret
 	} // end of method Function_NestedFunctionLogsOuterParameter::__js_module_init__
 
 } // end of class Modules.Function_NestedFunctionLogsOuterParameter

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
@@ -776,7 +776,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 76 (0x4c)
+		// Code size: 77 (0x4d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewExpression_CapturesOuterCtor/Scope,
@@ -811,15 +811,16 @@
 		IL_002e: nop
 		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0034: stloc.3
-		IL_0035: ldloc.1
-		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0040: stloc.s 4
-		IL_0042: ldloc.3
-		IL_0043: ldloc.s 4
-		IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_004a: pop
-		IL_004b: ret
+		IL_0035: ldloc.0
+		IL_0036: castclass Modules.Function_NewExpression_CapturesOuterCtor/Scope
+		IL_003b: ldnull
+		IL_003c: call object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
+		IL_0041: stloc.s 4
+		IL_0043: ldloc.3
+		IL_0044: ldloc.s 4
+		IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004b: pop
+		IL_004c: ret
 	} // end of method Function_NewExpression_CapturesOuterCtor::__js_module_init__
 
 } // end of class Modules.Function_NewExpression_CapturesOuterCtor

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
@@ -472,7 +472,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 89 (0x59)
+		// Code size: 83 (0x53)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewTarget_Arrow_Inherits/Scope,
@@ -515,13 +515,11 @@
 		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
 		IL_0044: pop
 		IL_0045: ldloc.0
-		IL_0046: ldfld object Modules.Function_NewTarget_Arrow_Inherits/Scope::Outer
-		IL_004b: stloc.3
-		IL_004c: ldloc.3
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0057: pop
-		IL_0058: ret
+		IL_0046: castclass Modules.Function_NewTarget_Arrow_Inherits/Scope
+		IL_004b: ldnull
+		IL_004c: call object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
+		IL_0051: pop
+		IL_0052: ret
 	} // end of method Function_NewTarget_Arrow_Inherits::__js_module_init__
 
 } // end of class Modules.Function_NewTarget_Arrow_Inherits

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
@@ -309,7 +309,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 89 (0x59)
+		// Code size: 83 (0x53)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewTarget_NewVsCall/Scope,
@@ -352,13 +352,11 @@
 		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
 		IL_0044: pop
 		IL_0045: ldloc.0
-		IL_0046: ldfld object Modules.Function_NewTarget_NewVsCall/Scope::C
-		IL_004b: stloc.3
-		IL_004c: ldloc.3
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0057: pop
-		IL_0058: ret
+		IL_0046: castclass Modules.Function_NewTarget_NewVsCall/Scope
+		IL_004b: ldnull
+		IL_004c: call object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
+		IL_0051: pop
+		IL_0052: ret
 	} // end of method Function_NewTarget_NewVsCall::__js_module_init__
 
 } // end of class Modules.Function_NewTarget_NewVsCall

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NoCapture_NoScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NoCapture_NoScopesParameter.verified.txt
@@ -263,7 +263,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 98 (0x62)
+		// Code size: 81 (0x51)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NoCapture_NoScopesParameter/Scope,
@@ -294,21 +294,16 @@
 		IL_0026: nop
 		IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_002c: stloc.3
-		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0032: stloc.2
-		IL_0033: ldloc.1
-		IL_0034: ldloc.2
-		IL_0035: ldc.r8 5
-		IL_003e: box [System.Runtime]System.Double
-		IL_0043: ldc.r8 3
-		IL_004c: box [System.Runtime]System.Double
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0056: stloc.s 4
-		IL_0058: ldloc.3
-		IL_0059: ldloc.s 4
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0060: pop
-		IL_0061: ret
+		IL_002d: ldnull
+		IL_002e: ldc.r8 5
+		IL_0037: ldc.r8 3
+		IL_0040: call object Modules.Function_NoCapture_NoScopesParameter/'add'::__js_call__(object, float64, float64)
+		IL_0045: stloc.s 4
+		IL_0047: ldloc.3
+		IL_0048: ldloc.s 4
+		IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004f: pop
+		IL_0050: ret
 	} // end of method Function_NoCapture_NoScopesParameter::__js_module_init__
 
 } // end of class Modules.Function_NoCapture_NoScopesParameter

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterDestructuring_Object.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterDestructuring_Object.verified.txt
@@ -621,7 +621,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 268 (0x10c)
+		// Code size: 240 (0xf0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterDestructuring_Object/Scope,
@@ -665,68 +665,56 @@
 		IL_0043: stloc.2
 		IL_0044: nop
 		IL_0045: nop
-		IL_0046: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004b: stloc.3
-		IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0051: dup
-		IL_0052: ldstr "a"
-		IL_0057: ldc.r8 10
-		IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0065: dup
-		IL_0066: ldstr "b"
-		IL_006b: ldc.r8 20
-		IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0079: stloc.s 4
-		IL_007b: ldloc.1
-		IL_007c: ldloc.3
-		IL_007d: ldloc.s 4
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0084: pop
-		IL_0085: nop
-		IL_0086: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008b: stloc.3
-		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0091: dup
-		IL_0092: ldstr "host"
-		IL_0097: ldstr "example.com"
-		IL_009c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00a1: stloc.s 4
-		IL_00a3: ldloc.2
-		IL_00a4: ldloc.3
-		IL_00a5: ldloc.s 4
-		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00ac: pop
-		IL_00ad: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00b2: stloc.3
-		IL_00b3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00b8: dup
-		IL_00b9: ldstr "host"
-		IL_00be: ldstr "api.test.com"
-		IL_00c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_004b: dup
+		IL_004c: ldstr "a"
+		IL_0051: ldc.r8 10
+		IL_005a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_005f: dup
+		IL_0060: ldstr "b"
+		IL_0065: ldc.r8 20
+		IL_006e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0073: stloc.s 4
+		IL_0075: ldnull
+		IL_0076: ldloc.s 4
+		IL_0078: call object Modules.Function_ParameterDestructuring_Object/show::__js_call__(object, object)
+		IL_007d: pop
+		IL_007e: nop
+		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0084: dup
+		IL_0085: ldstr "host"
+		IL_008a: ldstr "example.com"
+		IL_008f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0094: stloc.s 4
+		IL_0096: ldnull
+		IL_0097: ldloc.s 4
+		IL_0099: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
+		IL_009e: pop
+		IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00a4: dup
+		IL_00a5: ldstr "host"
+		IL_00aa: ldstr "api.test.com"
+		IL_00af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00b4: dup
+		IL_00b5: ldstr "port"
+		IL_00ba: ldc.r8 3000
+		IL_00c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_00c8: dup
-		IL_00c9: ldstr "port"
-		IL_00ce: ldc.r8 3000
-		IL_00d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00dc: dup
-		IL_00dd: ldstr "secure"
-		IL_00e2: ldc.i4.1
-		IL_00e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00e8: stloc.s 4
-		IL_00ea: ldloc.2
-		IL_00eb: ldloc.3
-		IL_00ec: ldloc.s 4
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00f3: pop
-		IL_00f4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00f9: stloc.3
-		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00ff: stloc.s 4
-		IL_0101: ldloc.2
-		IL_0102: ldloc.3
-		IL_0103: ldloc.s 4
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_010a: pop
-		IL_010b: ret
+		IL_00c9: ldstr "secure"
+		IL_00ce: ldc.i4.1
+		IL_00cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_00d4: stloc.s 4
+		IL_00d6: ldnull
+		IL_00d7: ldloc.s 4
+		IL_00d9: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
+		IL_00de: pop
+		IL_00df: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00e4: stloc.s 4
+		IL_00e6: ldnull
+		IL_00e7: ldloc.s 4
+		IL_00e9: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
+		IL_00ee: pop
+		IL_00ef: ret
 	} // end of method Function_ParameterDestructuring_Object::__js_module_init__
 
 } // end of class Modules.Function_ParameterDestructuring_Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_DirectRotateArrayArgument.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_DirectRotateArrayArgument.verified.txt
@@ -700,7 +700,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 349 (0x15d)
+		// Code size: 322 (0x142)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/Scope,
@@ -789,50 +789,41 @@
 		IL_00c4: stloc.s 4
 		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00cb: stloc.s 6
-		IL_00cd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00d2: stloc.s 5
-		IL_00d4: ldloc.1
-		IL_00d5: ldloc.s 5
-		IL_00d7: ldloc.s 4
-		IL_00d9: ldc.r8 30
-		IL_00e2: box [System.Runtime]System.Double
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00ec: stloc.s 7
-		IL_00ee: ldloc.s 6
-		IL_00f0: ldloc.s 7
-		IL_00f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f7: pop
-		IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fd: stloc.s 6
-		IL_00ff: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0104: stloc.s 5
-		IL_0106: ldloc.2
-		IL_0107: ldloc.s 5
-		IL_0109: ldloc.s 4
-		IL_010b: ldc.r8 45
-		IL_0114: box [System.Runtime]System.Double
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_011e: stloc.s 7
-		IL_0120: ldloc.s 6
-		IL_0122: ldloc.s 7
-		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0129: pop
-		IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012f: stloc.s 6
-		IL_0131: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0136: stloc.s 5
-		IL_0138: ldloc.3
-		IL_0139: ldloc.s 5
-		IL_013b: ldloc.s 4
-		IL_013d: ldc.r8 60
-		IL_0146: box [System.Runtime]System.Double
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0150: stloc.s 7
-		IL_0152: ldloc.s 6
-		IL_0154: ldloc.s 7
-		IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015b: pop
-		IL_015c: ret
+		IL_00cd: ldnull
+		IL_00ce: ldloc.s 4
+		IL_00d0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_00d5: ldc.r8 30
+		IL_00de: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+		IL_00e3: stloc.s 7
+		IL_00e5: ldloc.s 6
+		IL_00e7: ldloc.s 7
+		IL_00e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ee: pop
+		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f4: stloc.s 6
+		IL_00f6: ldnull
+		IL_00f7: ldloc.s 4
+		IL_00f9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_00fe: ldc.r8 45
+		IL_0107: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+		IL_010c: stloc.s 7
+		IL_010e: ldloc.s 6
+		IL_0110: ldloc.s 7
+		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0117: pop
+		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011d: stloc.s 6
+		IL_011f: ldnull
+		IL_0120: ldloc.s 4
+		IL_0122: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0127: ldc.r8 60
+		IL_0130: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+		IL_0135: stloc.s 7
+		IL_0137: ldloc.s 6
+		IL_0139: ldloc.s 7
+		IL_013b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0140: pop
+		IL_0141: ret
 	} // end of method Function_ParameterTypeInference_DirectRotateArrayArgument::__js_module_init__
 
 } // end of class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
@@ -505,7 +505,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 112 (0x70)
+		// Code size: 105 (0x69)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scope,
@@ -542,21 +542,18 @@
 		IL_0034: pop
 		IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_003a: stloc.3
-		IL_003b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0040: stloc.2
-		IL_0041: ldloc.1
-		IL_0042: ldloc.2
-		IL_0043: ldc.r8 1
-		IL_004c: box [System.Runtime]System.Double
-		IL_0051: ldc.r8 2
-		IL_005a: box [System.Runtime]System.Double
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0064: stloc.s 4
-		IL_0066: ldloc.3
-		IL_0067: ldloc.s 4
-		IL_0069: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006e: pop
-		IL_006f: ret
+		IL_003b: ldnull
+		IL_003c: ldc.r8 1
+		IL_0045: box [System.Runtime]System.Double
+		IL_004a: ldc.r8 2
+		IL_0053: box [System.Runtime]System.Double
+		IL_0058: call object Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'::__js_call__(object, object, object)
+		IL_005d: stloc.s 4
+		IL_005f: ldloc.3
+		IL_0060: ldloc.s 4
+		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0067: pop
+		IL_0068: ret
 	} // end of method Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature::__js_module_init__
 
 } // end of class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
@@ -394,7 +394,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 206 (0xce)
+		// Code size: 265 (0x109)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_Basic/Scope,
@@ -429,49 +429,84 @@
 		IL_002e: nop
 		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0034: stloc.3
-		IL_0035: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003a: stloc.2
-		IL_003b: ldloc.1
-		IL_003c: ldloc.2
-		IL_003d: ldc.r8 1
-		IL_0046: box [System.Runtime]System.Double
-		IL_004b: ldc.r8 2
-		IL_0054: box [System.Runtime]System.Double
-		IL_0059: ldc.r8 3
-		IL_0062: box [System.Runtime]System.Double
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_006c: stloc.s 4
-		IL_006e: ldloc.3
-		IL_006f: ldloc.s 4
-		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0076: pop
-		IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007c: stloc.3
-		IL_007d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0082: stloc.2
-		IL_0083: ldloc.1
-		IL_0084: ldloc.2
-		IL_0085: ldc.r8 10
-		IL_008e: box [System.Runtime]System.Double
-		IL_0093: ldc.r8 20
-		IL_009c: box [System.Runtime]System.Double
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00a6: stloc.s 4
-		IL_00a8: ldloc.3
-		IL_00a9: ldloc.s 4
-		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b0: pop
-		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b6: stloc.3
-		IL_00b7: ldloc.1
-		IL_00b8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00c2: stloc.s 4
-		IL_00c4: ldloc.3
-		IL_00c5: ldloc.s 4
-		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cc: pop
-		IL_00cd: ret
+		IL_0035: ldloc.1
+		IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_003b: ldc.i4.1
+		IL_003c: newarr [System.Runtime]System.Object
+		IL_0041: dup
+		IL_0042: ldc.i4.0
+		IL_0043: ldloc.0
+		IL_0044: stelem.ref
+		IL_0045: ldc.i4.3
+		IL_0046: newarr [System.Runtime]System.Object
+		IL_004b: dup
+		IL_004c: ldc.i4.0
+		IL_004d: ldc.r8 1
+		IL_0056: box [System.Runtime]System.Double
+		IL_005b: stelem.ref
+		IL_005c: dup
+		IL_005d: ldc.i4.1
+		IL_005e: ldc.r8 2
+		IL_0067: box [System.Runtime]System.Double
+		IL_006c: stelem.ref
+		IL_006d: dup
+		IL_006e: ldc.i4.2
+		IL_006f: ldc.r8 3
+		IL_0078: box [System.Runtime]System.Double
+		IL_007d: stelem.ref
+		IL_007e: call object Modules.Function_RestParameters_Basic/sum/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0083: stloc.s 4
+		IL_0085: ldloc.3
+		IL_0086: ldloc.s 4
+		IL_0088: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008d: pop
+		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0093: stloc.3
+		IL_0094: ldloc.1
+		IL_0095: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_009a: ldc.i4.1
+		IL_009b: newarr [System.Runtime]System.Object
+		IL_00a0: dup
+		IL_00a1: ldc.i4.0
+		IL_00a2: ldloc.0
+		IL_00a3: stelem.ref
+		IL_00a4: ldc.i4.2
+		IL_00a5: newarr [System.Runtime]System.Object
+		IL_00aa: dup
+		IL_00ab: ldc.i4.0
+		IL_00ac: ldc.r8 10
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: stelem.ref
+		IL_00bb: dup
+		IL_00bc: ldc.i4.1
+		IL_00bd: ldc.r8 20
+		IL_00c6: box [System.Runtime]System.Double
+		IL_00cb: stelem.ref
+		IL_00cc: call object Modules.Function_RestParameters_Basic/sum/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00d1: stloc.s 4
+		IL_00d3: ldloc.3
+		IL_00d4: ldloc.s 4
+		IL_00d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00db: pop
+		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e1: stloc.3
+		IL_00e2: ldloc.1
+		IL_00e3: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_00e8: ldc.i4.1
+		IL_00e9: newarr [System.Runtime]System.Object
+		IL_00ee: dup
+		IL_00ef: ldc.i4.0
+		IL_00f0: ldloc.0
+		IL_00f1: stelem.ref
+		IL_00f2: ldc.i4.0
+		IL_00f3: newarr [System.Runtime]System.Object
+		IL_00f8: call object Modules.Function_RestParameters_Basic/sum/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00fd: stloc.s 4
+		IL_00ff: ldloc.3
+		IL_0100: ldloc.s 4
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0107: pop
+		IL_0108: ret
 	} // end of method Function_RestParameters_Basic::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_Basic

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
@@ -346,7 +346,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 100 (0x64)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_Empty/Scope,
@@ -374,26 +374,58 @@
 		IL_0025: nop
 		IL_0026: nop
 		IL_0027: ldloc.1
-		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0032: pop
-		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0038: stloc.2
-		IL_0039: ldloc.1
-		IL_003a: ldloc.2
-		IL_003b: ldstr "hello"
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0045: pop
-		IL_0046: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004b: stloc.2
-		IL_004c: ldloc.1
-		IL_004d: ldloc.2
-		IL_004e: ldstr "a"
-		IL_0053: ldstr "b"
-		IL_0058: ldstr "c"
-		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0062: pop
-		IL_0063: ret
+		IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_002d: ldc.i4.1
+		IL_002e: newarr [System.Runtime]System.Object
+		IL_0033: dup
+		IL_0034: ldc.i4.0
+		IL_0035: ldloc.0
+		IL_0036: stelem.ref
+		IL_0037: ldc.i4.0
+		IL_0038: newarr [System.Runtime]System.Object
+		IL_003d: call object Modules.Function_RestParameters_Empty/logArgs/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0042: pop
+		IL_0043: ldloc.1
+		IL_0044: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_0049: ldc.i4.1
+		IL_004a: newarr [System.Runtime]System.Object
+		IL_004f: dup
+		IL_0050: ldc.i4.0
+		IL_0051: ldloc.0
+		IL_0052: stelem.ref
+		IL_0053: ldc.i4.1
+		IL_0054: newarr [System.Runtime]System.Object
+		IL_0059: dup
+		IL_005a: ldc.i4.0
+		IL_005b: ldstr "hello"
+		IL_0060: stelem.ref
+		IL_0061: call object Modules.Function_RestParameters_Empty/logArgs/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0066: pop
+		IL_0067: ldloc.1
+		IL_0068: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_006d: ldc.i4.1
+		IL_006e: newarr [System.Runtime]System.Object
+		IL_0073: dup
+		IL_0074: ldc.i4.0
+		IL_0075: ldloc.0
+		IL_0076: stelem.ref
+		IL_0077: ldc.i4.3
+		IL_0078: newarr [System.Runtime]System.Object
+		IL_007d: dup
+		IL_007e: ldc.i4.0
+		IL_007f: ldstr "a"
+		IL_0084: stelem.ref
+		IL_0085: dup
+		IL_0086: ldc.i4.1
+		IL_0087: ldstr "b"
+		IL_008c: stelem.ref
+		IL_008d: dup
+		IL_008e: ldc.i4.2
+		IL_008f: ldstr "c"
+		IL_0094: stelem.ref
+		IL_0095: call object Modules.Function_RestParameters_Empty/logArgs/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method Function_RestParameters_Empty::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_Empty

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
@@ -421,7 +421,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 188 (0xbc)
+		// Code size: 260 (0x104)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_MultipleNamed/Scope,
@@ -456,51 +456,99 @@
 		IL_002e: nop
 		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0034: stloc.3
-		IL_0035: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003a: stloc.2
-		IL_003b: ldloc.1
-		IL_003c: ldloc.2
-		IL_003d: ldstr "["
-		IL_0042: ldstr "]"
-		IL_0047: ldstr "a"
-		IL_004c: ldstr "b"
-		IL_0051: ldstr "c"
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs5(object, object[], object, object, object, object, object)
-		IL_005b: stloc.s 4
-		IL_005d: ldloc.3
-		IL_005e: ldloc.s 4
-		IL_0060: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0065: pop
-		IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006b: stloc.3
-		IL_006c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0071: stloc.2
-		IL_0072: ldloc.1
-		IL_0073: ldloc.2
-		IL_0074: ldstr "<"
-		IL_0079: ldstr ">"
-		IL_007e: ldstr "hello"
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0088: stloc.s 4
-		IL_008a: ldloc.3
-		IL_008b: ldloc.s 4
-		IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0092: pop
-		IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0098: stloc.3
-		IL_0099: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_009e: stloc.2
-		IL_009f: ldloc.1
-		IL_00a0: ldloc.2
-		IL_00a1: ldstr "{"
-		IL_00a6: ldstr "}"
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00b0: stloc.s 4
-		IL_00b2: ldloc.3
-		IL_00b3: ldloc.s 4
-		IL_00b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ba: pop
-		IL_00bb: ret
+		IL_0035: ldloc.1
+		IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_003b: ldc.i4.1
+		IL_003c: newarr [System.Runtime]System.Object
+		IL_0041: dup
+		IL_0042: ldc.i4.0
+		IL_0043: ldloc.0
+		IL_0044: stelem.ref
+		IL_0045: ldc.i4.5
+		IL_0046: newarr [System.Runtime]System.Object
+		IL_004b: dup
+		IL_004c: ldc.i4.0
+		IL_004d: ldstr "["
+		IL_0052: stelem.ref
+		IL_0053: dup
+		IL_0054: ldc.i4.1
+		IL_0055: ldstr "]"
+		IL_005a: stelem.ref
+		IL_005b: dup
+		IL_005c: ldc.i4.2
+		IL_005d: ldstr "a"
+		IL_0062: stelem.ref
+		IL_0063: dup
+		IL_0064: ldc.i4.3
+		IL_0065: ldstr "b"
+		IL_006a: stelem.ref
+		IL_006b: dup
+		IL_006c: ldc.i4.4
+		IL_006d: ldstr "c"
+		IL_0072: stelem.ref
+		IL_0073: call object Modules.Function_RestParameters_MultipleNamed/format/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0078: stloc.s 4
+		IL_007a: ldloc.3
+		IL_007b: ldloc.s 4
+		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0082: pop
+		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0088: stloc.3
+		IL_0089: ldloc.1
+		IL_008a: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_008f: ldc.i4.1
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldloc.0
+		IL_0098: stelem.ref
+		IL_0099: ldc.i4.3
+		IL_009a: newarr [System.Runtime]System.Object
+		IL_009f: dup
+		IL_00a0: ldc.i4.0
+		IL_00a1: ldstr "<"
+		IL_00a6: stelem.ref
+		IL_00a7: dup
+		IL_00a8: ldc.i4.1
+		IL_00a9: ldstr ">"
+		IL_00ae: stelem.ref
+		IL_00af: dup
+		IL_00b0: ldc.i4.2
+		IL_00b1: ldstr "hello"
+		IL_00b6: stelem.ref
+		IL_00b7: call object Modules.Function_RestParameters_MultipleNamed/format/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00bc: stloc.s 4
+		IL_00be: ldloc.3
+		IL_00bf: ldloc.s 4
+		IL_00c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c6: pop
+		IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00cc: stloc.3
+		IL_00cd: ldloc.1
+		IL_00ce: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_00d3: ldc.i4.1
+		IL_00d4: newarr [System.Runtime]System.Object
+		IL_00d9: dup
+		IL_00da: ldc.i4.0
+		IL_00db: ldloc.0
+		IL_00dc: stelem.ref
+		IL_00dd: ldc.i4.2
+		IL_00de: newarr [System.Runtime]System.Object
+		IL_00e3: dup
+		IL_00e4: ldc.i4.0
+		IL_00e5: ldstr "{"
+		IL_00ea: stelem.ref
+		IL_00eb: dup
+		IL_00ec: ldc.i4.1
+		IL_00ed: ldstr "}"
+		IL_00f2: stelem.ref
+		IL_00f3: call object Modules.Function_RestParameters_MultipleNamed/format/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00f8: stloc.s 4
+		IL_00fa: ldloc.3
+		IL_00fb: ldloc.s 4
+		IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0102: pop
+		IL_0103: ret
 	} // end of method Function_RestParameters_MultipleNamed::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_MultipleNamed

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
@@ -440,7 +440,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 178 (0xb2)
+		// Code size: 244 (0xf4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_WithNamedParams/Scope,
@@ -475,49 +475,91 @@
 		IL_002e: nop
 		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0034: stloc.3
-		IL_0035: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003a: stloc.2
-		IL_003b: ldloc.1
-		IL_003c: ldloc.2
-		IL_003d: ldstr "-"
-		IL_0042: ldstr "a"
-		IL_0047: ldstr "b"
-		IL_004c: ldstr "c"
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_0056: stloc.s 4
-		IL_0058: ldloc.3
-		IL_0059: ldloc.s 4
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0060: pop
-		IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0066: stloc.3
-		IL_0067: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006c: stloc.2
-		IL_006d: ldloc.1
-		IL_006e: ldloc.2
-		IL_006f: ldstr " "
-		IL_0074: ldstr "hello"
-		IL_0079: ldstr "world"
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0083: stloc.s 4
-		IL_0085: ldloc.3
-		IL_0086: ldloc.s 4
-		IL_0088: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008d: pop
-		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0093: stloc.3
-		IL_0094: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0099: stloc.2
-		IL_009a: ldloc.1
-		IL_009b: ldloc.2
-		IL_009c: ldstr ","
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00a6: stloc.s 4
-		IL_00a8: ldloc.3
-		IL_00a9: ldloc.s 4
-		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b0: pop
-		IL_00b1: ret
+		IL_0035: ldloc.1
+		IL_0036: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_003b: ldc.i4.1
+		IL_003c: newarr [System.Runtime]System.Object
+		IL_0041: dup
+		IL_0042: ldc.i4.0
+		IL_0043: ldloc.0
+		IL_0044: stelem.ref
+		IL_0045: ldc.i4.4
+		IL_0046: newarr [System.Runtime]System.Object
+		IL_004b: dup
+		IL_004c: ldc.i4.0
+		IL_004d: ldstr "-"
+		IL_0052: stelem.ref
+		IL_0053: dup
+		IL_0054: ldc.i4.1
+		IL_0055: ldstr "a"
+		IL_005a: stelem.ref
+		IL_005b: dup
+		IL_005c: ldc.i4.2
+		IL_005d: ldstr "b"
+		IL_0062: stelem.ref
+		IL_0063: dup
+		IL_0064: ldc.i4.3
+		IL_0065: ldstr "c"
+		IL_006a: stelem.ref
+		IL_006b: call object Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.3
+		IL_0073: ldloc.s 4
+		IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007a: pop
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: stloc.3
+		IL_0081: ldloc.1
+		IL_0082: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_0087: ldc.i4.1
+		IL_0088: newarr [System.Runtime]System.Object
+		IL_008d: dup
+		IL_008e: ldc.i4.0
+		IL_008f: ldloc.0
+		IL_0090: stelem.ref
+		IL_0091: ldc.i4.3
+		IL_0092: newarr [System.Runtime]System.Object
+		IL_0097: dup
+		IL_0098: ldc.i4.0
+		IL_0099: ldstr " "
+		IL_009e: stelem.ref
+		IL_009f: dup
+		IL_00a0: ldc.i4.1
+		IL_00a1: ldstr "hello"
+		IL_00a6: stelem.ref
+		IL_00a7: dup
+		IL_00a8: ldc.i4.2
+		IL_00a9: ldstr "world"
+		IL_00ae: stelem.ref
+		IL_00af: call object Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00b4: stloc.s 4
+		IL_00b6: ldloc.3
+		IL_00b7: ldloc.s 4
+		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00be: pop
+		IL_00bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c4: stloc.3
+		IL_00c5: ldloc.1
+		IL_00c6: castclass [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		IL_00cb: ldc.i4.1
+		IL_00cc: newarr [System.Runtime]System.Object
+		IL_00d1: dup
+		IL_00d2: ldc.i4.0
+		IL_00d3: ldloc.0
+		IL_00d4: stelem.ref
+		IL_00d5: ldc.i4.1
+		IL_00d6: newarr [System.Runtime]System.Object
+		IL_00db: dup
+		IL_00dc: ldc.i4.0
+		IL_00dd: ldstr ","
+		IL_00e2: stelem.ref
+		IL_00e3: call object Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00e8: stloc.s 4
+		IL_00ea: ldloc.3
+		IL_00eb: ldloc.s 4
+		IL_00ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f2: pop
+		IL_00f3: ret
 	} // end of method Function_RestParameters_WithNamedParams::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_WithNamedParams

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
@@ -495,7 +495,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 393 (0x189)
+		// Code size: 387 (0x183)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnObjectWithClosure/Scope,
@@ -530,100 +530,98 @@
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
-		IL_0031: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0036: stloc.s 4
-		IL_0038: ldloc.1
-		IL_0039: ldloc.s 4
-		IL_003b: ldc.r8 10
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004e: stloc.2
-		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0054: stloc.s 5
-		IL_0056: ldloc.2
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005c: volatile.
-		IL_005e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0063: brfalse IL_0085
+		IL_0031: ldloc.0
+		IL_0032: castclass Modules.Function_ReturnObjectWithClosure/Scope
+		IL_0037: ldnull
+		IL_0038: ldc.r8 10
+		IL_0041: box [System.Runtime]System.Double
+		IL_0046: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
+		IL_004b: stloc.2
+		IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0051: stloc.s 5
+		IL_0053: ldloc.2
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0059: volatile.
+		IL_005b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0060: brfalse IL_0082
 
-		IL_0068: ldstr "multiply"
-		IL_006d: ldc.r8 5
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0080: br IL_00a7
+		IL_0065: ldstr "multiply"
+		IL_006a: ldc.r8 5
+		IL_0073: box [System.Runtime]System.Double
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_007d: br IL_00a4
 
-		IL_0085: ldstr "multiply"
-		IL_008a: ldc.r8 5
-		IL_0093: box [System.Runtime]System.Double
-		IL_0098: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:19"
-		IL_009d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0082: ldstr "multiply"
+		IL_0087: ldc.r8 5
+		IL_0090: box [System.Runtime]System.Double
+		IL_0095: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:19"
+		IL_009a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00a7: stloc.s 6
-		IL_00a9: ldloc.s 5
-		IL_00ab: ldstr "multiply(5):"
-		IL_00b0: ldloc.s 6
-		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00b7: pop
-		IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bd: stloc.s 5
-		IL_00bf: volatile.
-		IL_00c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_00c6: brfalse IL_00db
+		IL_00a4: stloc.s 6
+		IL_00a6: ldloc.s 5
+		IL_00a8: ldstr "multiply(5):"
+		IL_00ad: ldloc.s 6
+		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00b4: pop
+		IL_00b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ba: stloc.s 5
+		IL_00bc: volatile.
+		IL_00be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00c3: brfalse IL_00d8
 
-		IL_00cb: ldloc.2
-		IL_00cc: ldstr "factor"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d6: br IL_00f0
+		IL_00c8: ldloc.2
+		IL_00c9: ldstr "factor"
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d3: br IL_00ed
 
-		IL_00db: ldloc.2
-		IL_00dc: ldstr "factor"
-		IL_00e1: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:25"
-		IL_00e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00d8: ldloc.2
+		IL_00d9: ldstr "factor"
+		IL_00de: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:25"
+		IL_00e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00f0: stloc.s 6
-		IL_00f2: ldloc.s 5
-		IL_00f4: ldstr "factor:"
-		IL_00f9: ldloc.s 6
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0100: pop
-		IL_0101: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0106: stloc.s 4
-		IL_0108: ldloc.1
-		IL_0109: ldloc.s 4
-		IL_010b: ldc.r8 3
-		IL_0114: box [System.Runtime]System.Double
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_011e: stloc.3
-		IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0124: stloc.s 5
-		IL_0126: ldloc.3
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012c: volatile.
-		IL_012e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0133: brfalse IL_0155
+		IL_00ed: stloc.s 6
+		IL_00ef: ldloc.s 5
+		IL_00f1: ldstr "factor:"
+		IL_00f6: ldloc.s 6
+		IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00fd: pop
+		IL_00fe: ldloc.0
+		IL_00ff: castclass Modules.Function_ReturnObjectWithClosure/Scope
+		IL_0104: ldnull
+		IL_0105: ldc.r8 3
+		IL_010e: box [System.Runtime]System.Double
+		IL_0113: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
+		IL_0118: stloc.3
+		IL_0119: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011e: stloc.s 5
+		IL_0120: ldloc.3
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0126: volatile.
+		IL_0128: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_012d: brfalse IL_014f
 
-		IL_0138: ldstr "multiply"
-		IL_013d: ldc.r8 7
-		IL_0146: box [System.Runtime]System.Double
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0150: br IL_0177
+		IL_0132: ldstr "multiply"
+		IL_0137: ldc.r8 7
+		IL_0140: box [System.Runtime]System.Double
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014a: br IL_0171
 
-		IL_0155: ldstr "multiply"
-		IL_015a: ldc.r8 7
-		IL_0163: box [System.Runtime]System.Double
-		IL_0168: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:39"
-		IL_016d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_014f: ldstr "multiply"
+		IL_0154: ldc.r8 7
+		IL_015d: box [System.Runtime]System.Double
+		IL_0162: ldstr "Function_ReturnObjectWithClosure:Modules.Function_ReturnObjectWithClosure:__js_module_init__:39"
+		IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0177: stloc.s 6
-		IL_0179: ldloc.s 5
-		IL_017b: ldstr "calc2.multiply(7):"
-		IL_0180: ldloc.s 6
-		IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0187: pop
-		IL_0188: ret
+		IL_0171: stloc.s 6
+		IL_0173: ldloc.s 5
+		IL_0175: ldstr "calc2.multiply(7):"
+		IL_017a: ldloc.s 6
+		IL_017c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0181: pop
+		IL_0182: ret
 	} // end of method Function_ReturnObjectWithClosure::__js_module_init__
 
 } // end of class Modules.Function_ReturnObjectWithClosure

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
@@ -254,16 +254,15 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 91 (0x5b)
+		// Code size: 77 (0x4d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnsStaticValueAndLogs/Scope,
 			[1] class Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject,
 			[2] float64,
 			[3] object[],
-			[4] object,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[6] object
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_ReturnsStaticValueAndLogs/Scope::.ctor()
@@ -285,24 +284,20 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldloc.1
-		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0032: stloc.s 4
-		IL_0034: ldloc.s 4
-		IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_003b: stloc.2
-		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0041: stloc.s 5
-		IL_0043: ldloc.2
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: stloc.s 6
-		IL_004b: ldloc.s 5
-		IL_004d: ldstr "Output:"
-		IL_0052: ldloc.s 6
-		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0059: pop
-		IL_005a: ret
+		IL_0027: ldnull
+		IL_0028: call float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
+		IL_002d: stloc.2
+		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0033: stloc.s 4
+		IL_0035: ldloc.2
+		IL_0036: box [System.Runtime]System.Double
+		IL_003b: stloc.s 5
+		IL_003d: ldloc.s 4
+		IL_003f: ldstr "Output:"
+		IL_0044: ldloc.s 5
+		IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_004b: pop
+		IL_004c: ret
 	} // end of method Function_ReturnsStaticValueAndLogs::__js_module_init__
 
 } // end of class Modules.Function_ReturnsStaticValueAndLogs

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
@@ -1317,7 +1317,7 @@
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
 			// Header size: 12
-			// Code size: 92 (0x5c)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1330,42 +1330,32 @@
 			IL_0001: ldstr ""
 			IL_0006: stfld object Modules.Function_SchedulerCallResults/Scope::order
 			IL_000b: ldarg.0
-			IL_000c: ldfld object Modules.Function_SchedulerCallResults/Scope::g
-			IL_0011: ldc.i4.1
-			IL_0012: newarr [System.Runtime]System.Object
-			IL_0017: dup
-			IL_0018: ldc.i4.0
-			IL_0019: ldarg.0
-			IL_001a: stelem.ref
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0020: stloc.1
-			IL_0021: ldarg.0
-			IL_0022: ldfld object Modules.Function_SchedulerCallResults/Scope::h
-			IL_0027: ldc.i4.1
-			IL_0028: newarr [System.Runtime]System.Object
-			IL_002d: dup
-			IL_002e: ldc.i4.0
-			IL_002f: ldarg.0
-			IL_0030: stelem.ref
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0036: stloc.2
-			IL_0037: ldloc.1
-			IL_0038: ldloc.2
-			IL_0039: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, object)
-			IL_003e: stloc.0
-			IL_003f: ldloc.0
-			IL_0040: ldstr ","
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
-			IL_004a: stloc.3
-			IL_004b: ldarg.0
-			IL_004c: ldfld object Modules.Function_SchedulerCallResults/Scope::order
-			IL_0051: stloc.2
-			IL_0052: ldloc.3
-			IL_0053: ldloc.2
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0059: stloc.3
-			IL_005a: ldloc.3
-			IL_005b: ret
+			IL_000c: castclass Modules.Function_SchedulerCallResults/Scope
+			IL_0011: ldnull
+			IL_0012: call object Modules.Function_SchedulerCallResults/g::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+			IL_0017: stloc.1
+			IL_0018: ldarg.0
+			IL_0019: castclass Modules.Function_SchedulerCallResults/Scope
+			IL_001e: ldnull
+			IL_001f: call object Modules.Function_SchedulerCallResults/h::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+			IL_0024: stloc.2
+			IL_0025: ldloc.1
+			IL_0026: ldloc.2
+			IL_0027: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, object)
+			IL_002c: stloc.0
+			IL_002d: ldloc.0
+			IL_002e: ldstr ","
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
+			IL_0038: stloc.3
+			IL_0039: ldarg.0
+			IL_003a: ldfld object Modules.Function_SchedulerCallResults/Scope::order
+			IL_003f: stloc.2
+			IL_0040: ldloc.3
+			IL_0041: ldloc.2
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0047: stloc.3
+			IL_0048: ldloc.3
+			IL_0049: ret
 		} // end of method ordered::__js_call__
 
 	} // end of class ordered
@@ -1698,7 +1688,7 @@
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
 			// Header size: 12
-			// Code size: 202 (0xca)
+			// Code size: 193 (0xc1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_SchedulerCallResults/throwing/Scope,
@@ -1722,96 +1712,91 @@
 			{
 				IL_0011: nop
 				IL_0012: ldarg.0
-				IL_0013: ldfld object Modules.Function_SchedulerCallResults/Scope::g
-				IL_0018: ldc.i4.1
-				IL_0019: newarr [System.Runtime]System.Object
-				IL_001e: dup
-				IL_001f: ldc.i4.0
-				IL_0020: ldarg.0
-				IL_0021: stelem.ref
-				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0027: stloc.s 5
-				IL_0029: ldc.i4.2
-				IL_002a: newarr [System.Runtime]System.Object
-				IL_002f: dup
-				IL_0030: ldc.i4.0
-				IL_0031: ldarg.0
-				IL_0032: stelem.ref
-				IL_0033: dup
-				IL_0034: ldc.i4.1
-				IL_0035: ldloc.0
-				IL_0036: stelem.ref
-				IL_0037: stloc.s 6
+				IL_0013: castclass Modules.Function_SchedulerCallResults/Scope
+				IL_0018: ldnull
+				IL_0019: call object Modules.Function_SchedulerCallResults/g::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_001e: stloc.s 5
+				IL_0020: ldc.i4.2
+				IL_0021: newarr [System.Runtime]System.Object
+				IL_0026: dup
+				IL_0027: ldc.i4.0
+				IL_0028: ldarg.0
+				IL_0029: stelem.ref
+				IL_002a: dup
+				IL_002b: ldc.i4.1
+				IL_002c: ldloc.0
+				IL_002d: stelem.ref
+				IL_002e: stloc.s 6
+				IL_0030: ldloc.s 6
+				IL_0032: ldc.i4.0
+				IL_0033: ldelem.ref
+				IL_0034: castclass Modules.Function_SchedulerCallResults/Scope
 				IL_0039: ldloc.s 6
-				IL_003b: ldc.i4.0
-				IL_003c: ldelem.ref
-				IL_003d: castclass Modules.Function_SchedulerCallResults/Scope
-				IL_0042: ldloc.s 6
-				IL_0044: newobj instance void Modules.Function_SchedulerCallResults/throwing/ArrowFunction_L44C23/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope, object[])
-				IL_0049: ldc.i4.0
-				IL_004a: conv.r8
-				IL_004b: ldstr ""
-				IL_0050: ldc.i4.0
-				IL_0051: ldc.i4.0
-				IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/throwing/ArrowFunction_L44C23/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/throwing/ArrowFunction_L44C23/FunctionObject>(!!0)
-				IL_005c: stloc.s 7
-				IL_005e: ldloc.s 7
-				IL_0060: ldc.i4.1
-				IL_0061: newarr [System.Runtime]System.Object
-				IL_0066: dup
-				IL_0067: ldc.i4.0
-				IL_0068: ldarg.0
-				IL_0069: stelem.ref
-				IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_006f: stloc.s 8
-				IL_0071: ldloc.s 5
-				IL_0073: ldloc.s 8
-				IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_007a: stloc.s 9
-				IL_007c: ldnull
-				IL_007d: stloc.1
-				IL_007e: ldloc.s 9
-				IL_0080: stloc.1
-				IL_0081: leave IL_00c8
+				IL_003b: newobj instance void Modules.Function_SchedulerCallResults/throwing/ArrowFunction_L44C23/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope, object[])
+				IL_0040: ldc.i4.0
+				IL_0041: conv.r8
+				IL_0042: ldstr ""
+				IL_0047: ldc.i4.0
+				IL_0048: ldc.i4.0
+				IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/throwing/ArrowFunction_L44C23/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/throwing/ArrowFunction_L44C23/FunctionObject>(!!0)
+				IL_0053: stloc.s 7
+				IL_0055: ldloc.s 7
+				IL_0057: ldc.i4.1
+				IL_0058: newarr [System.Runtime]System.Object
+				IL_005d: dup
+				IL_005e: ldc.i4.0
+				IL_005f: ldarg.0
+				IL_0060: stelem.ref
+				IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0066: stloc.s 8
+				IL_0068: ldloc.s 5
+				IL_006a: ldloc.s 8
+				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0071: stloc.s 9
+				IL_0073: ldnull
+				IL_0074: stloc.1
+				IL_0075: ldloc.s 9
+				IL_0077: stloc.1
+				IL_0078: leave IL_00bf
 
-				IL_0086: leave IL_00c8
+				IL_007d: leave IL_00bf
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_008b: stloc.2
-				IL_008c: ldloc.2
-				IL_008d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0092: dup
-				IL_0093: brtrue IL_00a8
+				IL_0082: stloc.2
+				IL_0083: ldloc.2
+				IL_0084: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0089: dup
+				IL_008a: brtrue IL_009f
 
-				IL_0098: pop
-				IL_0099: ldloc.2
-				IL_009a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_009f: dup
-				IL_00a0: brtrue IL_00b3
+				IL_008f: pop
+				IL_0090: ldloc.2
+				IL_0091: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0096: dup
+				IL_0097: brtrue IL_00aa
 
-				IL_00a5: pop
-				IL_00a6: rethrow
+				IL_009c: pop
+				IL_009d: rethrow
 
-				IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_00ad: stloc.3
-				IL_00ae: br IL_00b4
+				IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_00a4: stloc.3
+				IL_00a5: br IL_00ab
 
-				IL_00b3: stloc.3
+				IL_00aa: stloc.3
 
-				IL_00b4: ldloc.3
-				IL_00b5: stloc.s 4
-				IL_00b7: ldarg.0
-				IL_00b8: ldfld object Modules.Function_SchedulerCallResults/Scope::order
-				IL_00bd: stloc.1
-				IL_00be: leave IL_00c8
+				IL_00ab: ldloc.3
+				IL_00ac: stloc.s 4
+				IL_00ae: ldarg.0
+				IL_00af: ldfld object Modules.Function_SchedulerCallResults/Scope::order
+				IL_00b4: stloc.1
+				IL_00b5: leave IL_00bf
 
-				IL_00c3: leave IL_00c8
+				IL_00ba: leave IL_00bf
 			} // end handler
 
-			IL_00c8: ldloc.1
-			IL_00c9: ret
+			IL_00bf: ldloc.1
+			IL_00c0: ret
 		} // end of method throwing::__js_call__
 
 	} // end of class throwing
@@ -1954,7 +1939,7 @@
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
 			// Header size: 12
-			// Code size: 73 (0x49)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1967,35 +1952,30 @@
 			IL_0001: ldstr ""
 			IL_0006: stfld object Modules.Function_SchedulerCallResults/Scope::order
 			IL_000b: ldarg.0
-			IL_000c: ldfld object Modules.Function_SchedulerCallResults/Scope::g
-			IL_0011: ldc.i4.1
-			IL_0012: newarr [System.Runtime]System.Object
-			IL_0017: dup
-			IL_0018: ldc.i4.0
-			IL_0019: ldarg.0
-			IL_001a: stelem.ref
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0020: stloc.1
-			IL_0021: ldloc.1
-			IL_0022: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0027: stloc.0
-			IL_0028: ldloc.0
-			IL_0029: ldloc.0
-			IL_002a: add
-			IL_002b: stloc.2
-			IL_002c: ldloc.2
-			IL_002d: ldstr ","
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
-			IL_0037: stloc.3
-			IL_0038: ldarg.0
-			IL_0039: ldfld object Modules.Function_SchedulerCallResults/Scope::order
-			IL_003e: stloc.1
-			IL_003f: ldloc.3
-			IL_0040: ldloc.1
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0046: stloc.3
-			IL_0047: ldloc.3
-			IL_0048: ret
+			IL_000c: castclass Modules.Function_SchedulerCallResults/Scope
+			IL_0011: ldnull
+			IL_0012: call object Modules.Function_SchedulerCallResults/g::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+			IL_0017: stloc.1
+			IL_0018: ldloc.1
+			IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: ldloc.0
+			IL_0021: add
+			IL_0022: stloc.2
+			IL_0023: ldloc.2
+			IL_0024: ldstr ","
+			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
+			IL_002e: stloc.3
+			IL_002f: ldarg.0
+			IL_0030: ldfld object Modules.Function_SchedulerCallResults/Scope::order
+			IL_0035: stloc.1
+			IL_0036: ldloc.3
+			IL_0037: ldloc.1
+			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_003d: stloc.3
+			IL_003e: ldloc.3
+			IL_003f: ret
 		} // end of method multiUse::__js_call__
 
 	} // end of class multiUse
@@ -4322,7 +4302,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1691 (0x69b)
+		// Code size: 1609 (0x649)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerCallResults/Scope,
@@ -4811,166 +4791,152 @@
 		IL_047c: nop
 		IL_047d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0482: stloc.s 20
-		IL_0484: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0489: stloc.s 14
-		IL_048b: ldloc.1
-		IL_048c: ldloc.s 14
-		IL_048e: ldc.r8 9
-		IL_0497: box [System.Runtime]System.Double
-		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_04a1: stloc.s 18
-		IL_04a3: ldloc.s 20
-		IL_04a5: ldloc.s 18
-		IL_04a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ac: pop
-		IL_04ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04b2: stloc.s 20
-		IL_04b4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04b9: stloc.s 14
-		IL_04bb: ldc.r8 2.7
-		IL_04c4: neg
-		IL_04c5: stloc.s 21
-		IL_04c7: ldloc.s 21
-		IL_04c9: box [System.Runtime]System.Double
-		IL_04ce: stloc.s 22
-		IL_04d0: ldloc.2
-		IL_04d1: ldloc.s 14
-		IL_04d3: ldloc.s 22
-		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_04da: stloc.s 18
-		IL_04dc: ldloc.s 20
-		IL_04de: ldloc.s 18
-		IL_04e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04e5: pop
-		IL_04e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04eb: stloc.s 20
-		IL_04ed: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04f2: stloc.s 14
-		IL_04f4: ldloc.3
-		IL_04f5: ldloc.s 14
-		IL_04f7: ldc.r8 1.2
-		IL_0500: box [System.Runtime]System.Double
-		IL_0505: ldc.r8 1.1
-		IL_050e: box [System.Runtime]System.Double
-		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0518: stloc.s 18
-		IL_051a: ldloc.s 20
-		IL_051c: ldloc.s 18
-		IL_051e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0523: pop
-		IL_0524: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0529: stloc.s 20
-		IL_052b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0530: stloc.s 14
-		IL_0532: ldloc.s 4
-		IL_0534: ldloc.s 14
-		IL_0536: ldc.r8 9
-		IL_053f: box [System.Runtime]System.Double
-		IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0549: stloc.s 18
-		IL_054b: ldloc.s 20
-		IL_054d: ldloc.s 18
-		IL_054f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0554: pop
-		IL_0555: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_055a: stloc.s 20
-		IL_055c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0561: stloc.s 14
-		IL_0563: ldloc.s 5
-		IL_0565: ldloc.s 14
-		IL_0567: ldc.r8 2
-		IL_0570: box [System.Runtime]System.Double
-		IL_0575: ldc.r8 3
-		IL_057e: box [System.Runtime]System.Double
-		IL_0583: ldc.r8 2
-		IL_058c: box [System.Runtime]System.Double
-		IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0596: stloc.s 18
-		IL_0598: ldloc.s 20
-		IL_059a: ldloc.s 18
-		IL_059c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05a1: pop
-		IL_05a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05a7: stloc.s 20
-		IL_05a9: ldloc.s 6
-		IL_05ab: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_05b5: stloc.s 18
-		IL_05b7: ldloc.s 20
-		IL_05b9: ldloc.s 18
-		IL_05bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05c0: pop
-		IL_05c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05c6: stloc.s 20
-		IL_05c8: ldloc.s 7
-		IL_05ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_05d4: stloc.s 18
-		IL_05d6: ldloc.s 20
-		IL_05d8: ldloc.s 18
-		IL_05da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05df: pop
-		IL_05e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05e5: stloc.s 20
-		IL_05e7: ldloc.s 8
-		IL_05e9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_05f3: stloc.s 18
-		IL_05f5: ldloc.s 20
-		IL_05f7: ldloc.s 18
-		IL_05f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05fe: pop
-		IL_05ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0604: stloc.s 20
-		IL_0606: ldloc.s 9
-		IL_0608: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0612: stloc.s 18
-		IL_0614: ldloc.s 20
-		IL_0616: ldloc.s 18
-		IL_0618: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_061d: pop
-		IL_061e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0623: stloc.s 20
-		IL_0625: ldloc.s 10
-		IL_0627: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0631: stloc.s 18
-		IL_0633: ldloc.s 20
-		IL_0635: ldloc.s 18
-		IL_0637: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_063c: pop
-		IL_063d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0642: stloc.s 20
-		IL_0644: ldloc.s 11
-		IL_0646: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_064b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0650: stloc.s 18
-		IL_0652: ldloc.s 20
-		IL_0654: ldloc.s 18
-		IL_0656: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_065b: pop
-		IL_065c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0661: stloc.s 20
-		IL_0663: ldloc.s 12
-		IL_0665: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_066f: stloc.s 18
-		IL_0671: ldloc.s 20
-		IL_0673: ldloc.s 18
-		IL_0675: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_067a: pop
-		IL_067b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0680: stloc.s 20
-		IL_0682: ldloc.s 13
-		IL_0684: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_068e: stloc.s 18
-		IL_0690: ldloc.s 20
-		IL_0692: ldloc.s 18
-		IL_0694: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0699: pop
-		IL_069a: ret
+		IL_0484: ldnull
+		IL_0485: ldc.r8 9
+		IL_048e: call object Modules.Function_SchedulerCallResults/math::__js_call__(object, float64)
+		IL_0493: stloc.s 18
+		IL_0495: ldloc.s 20
+		IL_0497: ldloc.s 18
+		IL_0499: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_049e: pop
+		IL_049f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04a4: stloc.s 20
+		IL_04a6: ldc.r8 2.7
+		IL_04af: neg
+		IL_04b0: stloc.s 21
+		IL_04b2: ldloc.s 21
+		IL_04b4: box [System.Runtime]System.Double
+		IL_04b9: stloc.s 22
+		IL_04bb: ldnull
+		IL_04bc: ldloc.s 21
+		IL_04be: call object Modules.Function_SchedulerCallResults/nestedCall::__js_call__(object, float64)
+		IL_04c3: stloc.s 18
+		IL_04c5: ldloc.s 20
+		IL_04c7: ldloc.s 18
+		IL_04c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04ce: pop
+		IL_04cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04d4: stloc.s 20
+		IL_04d6: ldnull
+		IL_04d7: ldc.r8 1.2
+		IL_04e0: ldc.r8 1.1
+		IL_04e9: call object Modules.Function_SchedulerCallResults/compareCall::__js_call__(object, float64, float64)
+		IL_04ee: stloc.s 18
+		IL_04f0: ldloc.s 20
+		IL_04f2: ldloc.s 18
+		IL_04f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04f9: pop
+		IL_04fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04ff: stloc.s 20
+		IL_0501: ldnull
+		IL_0502: ldc.r8 9
+		IL_050b: call object Modules.Function_SchedulerCallResults/argumentCall::__js_call__(object, float64)
+		IL_0510: stloc.s 18
+		IL_0512: ldloc.s 20
+		IL_0514: ldloc.s 18
+		IL_0516: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_051b: pop
+		IL_051c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0521: stloc.s 20
+		IL_0523: ldnull
+		IL_0524: ldc.r8 2
+		IL_052d: ldc.r8 3
+		IL_0536: ldc.r8 2
+		IL_053f: call object Modules.Function_SchedulerCallResults/argumentDependency::__js_call__(object, float64, float64, float64)
+		IL_0544: stloc.s 18
+		IL_0546: ldloc.s 20
+		IL_0548: ldloc.s 18
+		IL_054a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_054f: pop
+		IL_0550: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0555: stloc.s 20
+		IL_0557: ldloc.0
+		IL_0558: castclass Modules.Function_SchedulerCallResults/Scope
+		IL_055d: ldnull
+		IL_055e: call object Modules.Function_SchedulerCallResults/ordered::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+		IL_0563: stloc.s 18
+		IL_0565: ldloc.s 20
+		IL_0567: ldloc.s 18
+		IL_0569: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_056e: pop
+		IL_056f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0574: stloc.s 20
+		IL_0576: ldloc.0
+		IL_0577: castclass Modules.Function_SchedulerCallResults/Scope
+		IL_057c: ldnull
+		IL_057d: call object Modules.Function_SchedulerCallResults/throwing::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+		IL_0582: stloc.s 18
+		IL_0584: ldloc.s 20
+		IL_0586: ldloc.s 18
+		IL_0588: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_058d: pop
+		IL_058e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0593: stloc.s 20
+		IL_0595: ldloc.0
+		IL_0596: castclass Modules.Function_SchedulerCallResults/Scope
+		IL_059b: ldnull
+		IL_059c: call object Modules.Function_SchedulerCallResults/multiUse::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+		IL_05a1: stloc.s 18
+		IL_05a3: ldloc.s 20
+		IL_05a5: ldloc.s 18
+		IL_05a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05ac: pop
+		IL_05ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05b2: stloc.s 20
+		IL_05b4: ldloc.0
+		IL_05b5: castclass Modules.Function_SchedulerCallResults/Scope
+		IL_05ba: ldnull
+		IL_05bb: call object Modules.Function_SchedulerCallResults/fluentTypedCalls::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+		IL_05c0: stloc.s 18
+		IL_05c2: ldloc.s 20
+		IL_05c4: ldloc.s 18
+		IL_05c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05cb: pop
+		IL_05cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05d1: stloc.s 20
+		IL_05d3: ldloc.0
+		IL_05d4: castclass Modules.Function_SchedulerCallResults/Scope
+		IL_05d9: ldnull
+		IL_05da: call object Modules.Function_SchedulerCallResults/singleTypedCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+		IL_05df: stloc.s 18
+		IL_05e1: ldloc.s 20
+		IL_05e3: ldloc.s 18
+		IL_05e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05ea: pop
+		IL_05eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05f0: stloc.s 20
+		IL_05f2: ldloc.0
+		IL_05f3: castclass Modules.Function_SchedulerCallResults/Scope
+		IL_05f8: ldnull
+		IL_05f9: call object Modules.Function_SchedulerCallResults/scheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+		IL_05fe: stloc.s 18
+		IL_0600: ldloc.s 20
+		IL_0602: ldloc.s 18
+		IL_0604: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0609: pop
+		IL_060a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_060f: stloc.s 20
+		IL_0611: ldloc.0
+		IL_0612: castclass Modules.Function_SchedulerCallResults/Scope
+		IL_0617: ldnull
+		IL_0618: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+		IL_061d: stloc.s 18
+		IL_061f: ldloc.s 20
+		IL_0621: ldloc.s 18
+		IL_0623: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0628: pop
+		IL_0629: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_062e: stloc.s 20
+		IL_0630: ldloc.0
+		IL_0631: castclass Modules.Function_SchedulerCallResults/Scope
+		IL_0636: ldnull
+		IL_0637: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+		IL_063c: stloc.s 18
+		IL_063e: ldloc.s 20
+		IL_0640: ldloc.s 18
+		IL_0642: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0647: pop
+		IL_0648: ret
 	} // end of method Function_SchedulerCallResults::__js_module_init__
 
 } // end of class Modules.Function_SchedulerCallResults

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
@@ -812,7 +812,7 @@
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_000f: stloc.0
 			IL_0010: volatile.
-			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0012: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_0017: brfalse IL_002c
 
 			IL_001c: ldarg.1
@@ -823,7 +823,7 @@
 			IL_002c: ldarg.1
 			IL_002d: ldstr "length"
 			IL_0032: ldstr "Function_SchedulerConversionsStableLoads:<TwoPhaseDummy_M8>:__js_call__:6"
-			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0037: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
 			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
 			IL_0041: stloc.1
@@ -1229,7 +1229,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1098 (0x44a)
+		// Code size: 998 (0x3e6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerConversionsStableLoads/Scope,
@@ -1252,11 +1252,12 @@
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[19] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[20] object,
+			[20] string,
 			[21] object,
-			[22] class [JavaScriptRuntime]JavaScriptRuntime.ReferenceError,
-			[23] bool,
-			[24] object
+			[22] object,
+			[23] class [JavaScriptRuntime]JavaScriptRuntime.ReferenceError,
+			[24] bool,
+			[25] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_SchedulerConversionsStableLoads/Scope::.ctor()
@@ -1399,259 +1400,232 @@
 		IL_013f: stloc.s 7
 		IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0146: stloc.s 17
-		IL_0148: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_014d: stloc.s 13
-		IL_014f: ldloc.1
-		IL_0150: ldloc.s 13
-		IL_0152: ldc.r8 3
-		IL_015b: box [System.Runtime]System.Double
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0165: stloc.s 16
-		IL_0167: ldloc.s 17
-		IL_0169: ldloc.s 16
-		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0170: pop
-		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0176: stloc.s 17
-		IL_0178: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_017d: stloc.s 13
-		IL_017f: ldloc.2
-		IL_0180: ldloc.s 13
-		IL_0182: ldstr "abc"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_018c: stloc.s 16
-		IL_018e: ldloc.s 17
-		IL_0190: ldloc.s 16
-		IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0197: pop
-		IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_019d: stloc.s 17
-		IL_019f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01a4: stloc.s 13
-		IL_01a6: ldc.i4.3
-		IL_01a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0148: ldnull
+		IL_0149: ldc.r8 3
+		IL_0152: call object Modules.Function_SchedulerConversionsStableLoads/concat::__js_call__(object, float64)
+		IL_0157: stloc.s 16
+		IL_0159: ldloc.s 17
+		IL_015b: ldloc.s 16
+		IL_015d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0162: pop
+		IL_0163: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0168: stloc.s 17
+		IL_016a: ldnull
+		IL_016b: ldstr "abc"
+		IL_0170: call object Modules.Function_SchedulerConversionsStableLoads/stringLength::__js_call__(object, string)
+		IL_0175: stloc.s 16
+		IL_0177: ldloc.s 17
+		IL_0179: ldloc.s 16
+		IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0180: pop
+		IL_0181: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0186: stloc.s 17
+		IL_0188: ldc.i4.3
+		IL_0189: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_018e: dup
+		IL_018f: ldc.r8 1
+		IL_0198: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_019d: dup
+		IL_019e: ldc.r8 2
+		IL_01a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_01ac: dup
-		IL_01ad: ldc.r8 1
+		IL_01ad: ldc.r8 3
 		IL_01b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01bb: dup
-		IL_01bc: ldc.r8 2
-		IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01ca: dup
-		IL_01cb: ldc.r8 3
-		IL_01d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01d9: stloc.s 18
-		IL_01db: ldloc.3
-		IL_01dc: ldloc.s 13
-		IL_01de: ldloc.s 18
-		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01e5: stloc.s 16
-		IL_01e7: ldloc.s 17
-		IL_01e9: ldloc.s 16
-		IL_01eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01f0: pop
-		IL_01f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f6: stloc.s 17
-		IL_01f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01fd: stloc.s 13
-		IL_01ff: ldc.i4.1
-		IL_0200: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0205: dup
-		IL_0206: ldc.r8 4
-		IL_020f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0214: stloc.s 18
-		IL_0216: ldloc.s 4
-		IL_0218: ldloc.s 13
-		IL_021a: ldloc.s 18
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0221: stloc.s 16
-		IL_0223: ldloc.s 17
-		IL_0225: ldloc.s 16
-		IL_0227: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_022c: pop
-		IL_022d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0232: stloc.s 17
-		IL_0234: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0239: stloc.s 13
-		IL_023b: ldc.i4.2
-		IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0241: dup
-		IL_0242: ldc.r8 5
-		IL_024b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0250: dup
-		IL_0251: ldc.r8 6
-		IL_025a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_025f: stloc.s 18
-		IL_0261: ldloc.s 18
-		IL_0263: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_0268: stloc.s 19
-		IL_026a: ldloc.s 5
-		IL_026c: ldloc.s 13
-		IL_026e: ldloc.s 19
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0275: stloc.s 16
-		IL_0277: ldloc.s 17
-		IL_0279: ldloc.s 16
-		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0280: pop
-		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0286: stloc.s 17
-		IL_0288: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_028d: stloc.s 13
-		IL_028f: ldloc.s 6
-		IL_0291: ldloc.s 13
-		IL_0293: ldc.r8 3
-		IL_029c: box [System.Runtime]System.Double
-		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02a6: stloc.s 16
-		IL_02a8: ldloc.s 16
-		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02af: volatile.
-		IL_02b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02b6: brfalse IL_02cf
+		IL_01bb: stloc.s 18
+		IL_01bd: ldnull
+		IL_01be: ldloc.s 18
+		IL_01c0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_01c5: call object Modules.Function_SchedulerConversionsStableLoads/arrayLength::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+		IL_01ca: stloc.s 16
+		IL_01cc: ldloc.s 17
+		IL_01ce: ldloc.s 16
+		IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d5: pop
+		IL_01d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01db: stloc.s 17
+		IL_01dd: ldc.i4.1
+		IL_01de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01e3: dup
+		IL_01e4: ldc.r8 4
+		IL_01ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01f2: stloc.s 18
+		IL_01f4: ldnull
+		IL_01f5: ldloc.s 18
+		IL_01f7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_01fc: call object Modules.Function_SchedulerConversionsStableLoads/arrayElement::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+		IL_0201: stloc.s 16
+		IL_0203: ldloc.s 17
+		IL_0205: ldloc.s 16
+		IL_0207: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_020c: pop
+		IL_020d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0212: stloc.s 17
+		IL_0214: ldc.i4.2
+		IL_0215: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_021a: dup
+		IL_021b: ldc.r8 5
+		IL_0224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0229: dup
+		IL_022a: ldc.r8 6
+		IL_0233: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0238: stloc.s 18
+		IL_023a: ldloc.s 18
+		IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_0241: stloc.s 19
+		IL_0243: ldnull
+		IL_0244: ldloc.s 19
+		IL_0246: call object Modules.Function_SchedulerConversionsStableLoads/typedArray::__js_call__(object, object)
+		IL_024b: stloc.s 16
+		IL_024d: ldloc.s 17
+		IL_024f: ldloc.s 16
+		IL_0251: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0256: pop
+		IL_0257: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025c: stloc.s 17
+		IL_025e: ldnull
+		IL_025f: ldc.r8 3
+		IL_0268: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerConversionsStableLoads/postfix::__js_call__(object, float64)
+		IL_026d: stloc.s 18
+		IL_026f: ldloc.s 18
+		IL_0271: ldc.i4.1
+		IL_0272: newarr [System.Runtime]System.Object
+		IL_0277: dup
+		IL_0278: ldc.i4.0
+		IL_0279: ldstr ","
+		IL_027e: stelem.ref
+		IL_027f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0284: stloc.s 20
+		IL_0286: ldloc.s 17
+		IL_0288: ldloc.s 20
+		IL_028a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_028f: pop
+		IL_0290: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0295: stloc.s 17
+		IL_0297: volatile.
+		IL_0299: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_029e: brfalse IL_02b4
 
-		IL_02bb: ldstr "join"
-		IL_02c0: ldstr ","
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ca: br IL_02e8
+		IL_02a3: ldloc.s 7
+		IL_02a5: ldstr "x"
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02af: br IL_02ca
 
-		IL_02cf: ldstr "join"
-		IL_02d4: ldstr ","
-		IL_02d9: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:87"
-		IL_02de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_02b4: ldloc.s 7
+		IL_02b6: ldstr "x"
+		IL_02bb: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:91"
+		IL_02c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02e8: stloc.s 16
-		IL_02ea: ldloc.s 17
-		IL_02ec: ldloc.s 16
-		IL_02ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02f3: pop
-		IL_02f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f9: stloc.s 17
-		IL_02fb: volatile.
-		IL_02fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0302: brfalse IL_0318
+		IL_02ca: stloc.s 16
+		IL_02cc: volatile.
+		IL_02ce: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02d3: brfalse IL_02e9
 
-		IL_0307: ldloc.s 7
-		IL_0309: ldstr "x"
-		IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0313: br IL_032e
+		IL_02d8: ldloc.s 7
+		IL_02da: ldstr "x"
+		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02e4: br IL_02ff
 
-		IL_0318: ldloc.s 7
-		IL_031a: ldstr "x"
-		IL_031f: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:92"
-		IL_0324: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02e9: ldloc.s 7
+		IL_02eb: ldstr "x"
+		IL_02f0: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:93"
+		IL_02f5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_032e: stloc.s 16
-		IL_0330: volatile.
-		IL_0332: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_0337: brfalse IL_034d
-
-		IL_033c: ldloc.s 7
-		IL_033e: ldstr "x"
-		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0348: br IL_0363
-
-		IL_034d: ldloc.s 7
-		IL_034f: ldstr "x"
-		IL_0354: ldstr "Function_SchedulerConversionsStableLoads:Modules.Function_SchedulerConversionsStableLoads:__js_module_init__:94"
-		IL_0359: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0363: stloc.s 20
-		IL_0365: ldloc.s 16
-		IL_0367: ldloc.s 20
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_036e: stloc.s 21
-		IL_0370: ldloc.0
-		IL_0371: ldfld object Modules.Function_SchedulerConversionsStableLoads/Scope::getterCount
-		IL_0376: stloc.s 20
-		IL_0378: ldloc.s 17
-		IL_037a: ldloc.s 21
-		IL_037c: ldloc.s 20
-		IL_037e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0383: pop
+		IL_02ff: stloc.s 21
+		IL_0301: ldloc.s 16
+		IL_0303: ldloc.s 21
+		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_030a: stloc.s 22
+		IL_030c: ldloc.0
+		IL_030d: ldfld object Modules.Function_SchedulerConversionsStableLoads/Scope::getterCount
+		IL_0312: stloc.s 21
+		IL_0314: ldloc.s 17
+		IL_0316: ldloc.s 22
+		IL_0318: ldloc.s 21
+		IL_031a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_031f: pop
 		.try
 		{
-			IL_0384: nop
-			IL_0385: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_038a: stloc.s 17
-			IL_038c: ldstr "Cannot access 'tdzValue' before initialization"
-			IL_0391: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
-			IL_0396: stloc.s 22
-			IL_0398: ldloc.s 22
-			IL_039a: isinst [System.Runtime]System.Exception
-			IL_039f: dup
-			IL_03a0: brtrue IL_03ae
+			IL_0320: nop
+			IL_0321: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0326: stloc.s 17
+			IL_0328: ldstr "Cannot access 'tdzValue' before initialization"
+			IL_032d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.ReferenceError::.ctor(string)
+			IL_0332: stloc.s 23
+			IL_0334: ldloc.s 23
+			IL_0336: isinst [System.Runtime]System.Exception
+			IL_033b: dup
+			IL_033c: brtrue IL_034a
 
-			IL_03a5: pop
-			IL_03a6: ldloc.s 22
-			IL_03a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03ad: throw
+			IL_0341: pop
+			IL_0342: ldloc.s 23
+			IL_0344: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0349: throw
 
-			IL_03ae: throw
+			IL_034a: throw
 
-			IL_03af: ldnull
-			IL_03b0: ldc.r8 1
-			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_03be: stloc.s 21
-			IL_03c0: ldloc.s 17
-			IL_03c2: ldloc.s 21
-			IL_03c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03c9: pop
-			IL_03ca: leave IL_043b
+			IL_034b: ldnull
+			IL_034c: ldc.r8 1
+			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_035a: stloc.s 22
+			IL_035c: ldloc.s 17
+			IL_035e: ldloc.s 22
+			IL_0360: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0365: pop
+			IL_0366: leave IL_03d7
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03cf: stloc.s 8
-			IL_03d1: ldloc.s 8
-			IL_03d3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03d8: dup
-			IL_03d9: brtrue IL_03ef
+			IL_036b: stloc.s 8
+			IL_036d: ldloc.s 8
+			IL_036f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0374: dup
+			IL_0375: brtrue IL_038b
 
-			IL_03de: pop
-			IL_03df: ldloc.s 8
-			IL_03e1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03e6: dup
-			IL_03e7: brtrue IL_03fb
+			IL_037a: pop
+			IL_037b: ldloc.s 8
+			IL_037d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0382: dup
+			IL_0383: brtrue IL_0397
 
-			IL_03ec: pop
-			IL_03ed: rethrow
+			IL_0388: pop
+			IL_0389: rethrow
 
-			IL_03ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03f4: stloc.s 9
-			IL_03f6: br IL_03fd
+			IL_038b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0390: stloc.s 9
+			IL_0392: br IL_0399
 
-			IL_03fb: stloc.s 9
+			IL_0397: stloc.s 9
 
-			IL_03fd: ldloc.s 9
-			IL_03ff: stloc.s 10
-			IL_0401: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0406: stloc.s 17
-			IL_0408: ldloc.s 10
-			IL_040a: stloc.s 20
-			IL_040c: ldstr "ReferenceError"
-			IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0416: stloc.s 16
-			IL_0418: ldloc.s 20
-			IL_041a: ldloc.s 16
-			IL_041c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0421: stloc.s 23
-			IL_0423: ldloc.s 23
-			IL_0425: box [System.Runtime]System.Boolean
-			IL_042a: stloc.s 24
-			IL_042c: ldloc.s 17
-			IL_042e: ldloc.s 24
-			IL_0430: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0435: pop
-			IL_0436: leave IL_043b
+			IL_0399: ldloc.s 9
+			IL_039b: stloc.s 10
+			IL_039d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03a2: stloc.s 17
+			IL_03a4: ldloc.s 10
+			IL_03a6: stloc.s 21
+			IL_03a8: ldstr "ReferenceError"
+			IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03b2: stloc.s 16
+			IL_03b4: ldloc.s 21
+			IL_03b6: ldloc.s 16
+			IL_03b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_03bd: stloc.s 24
+			IL_03bf: ldloc.s 24
+			IL_03c1: box [System.Runtime]System.Boolean
+			IL_03c6: stloc.s 25
+			IL_03c8: ldloc.s 17
+			IL_03ca: ldloc.s 25
+			IL_03cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03d1: pop
+			IL_03d2: leave IL_03d7
 		} // end handler
 
-		IL_043b: ldc.r8 2
-		IL_0444: stloc.s 11
-		IL_0446: ldnull
-		IL_0447: stloc.s 12
-		IL_0449: ret
+		IL_03d7: ldc.r8 2
+		IL_03e0: stloc.s 11
+		IL_03e2: ldnull
+		IL_03e3: stloc.s 12
+		IL_03e5: ret
 	} // end of method Function_SchedulerConversionsStableLoads::__js_module_init__
 
 } // end of class Modules.Function_SchedulerConversionsStableLoads
@@ -1684,7 +1658,6 @@
 	.field assembly static int32 __jroc_dynamicLookup_9
 	.field assembly static int32 __jroc_dynamicLookup_10
 	.field assembly static int32 __jroc_dynamicLookup_11
-	.field assembly static int32 __jroc_dynamicLookup_12
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
@@ -930,7 +930,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 142 (0x8e)
+			// Code size: 115 (0x73)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -947,56 +947,41 @@
 			IL_0015: ldstr ""
 			IL_001a: stfld object Modules.Function_SchedulerGeneralRegions/Scope::order
 			IL_001f: ldarg.0
-			IL_0020: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::read
-			IL_0025: ldc.i4.1
-			IL_0026: newarr [System.Runtime]System.Object
-			IL_002b: dup
-			IL_002c: ldc.i4.0
-			IL_002d: ldarg.0
-			IL_002e: stelem.ref
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0034: stloc.1
-			IL_0035: ldarg.0
-			IL_0036: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::write
-			IL_003b: ldc.i4.1
-			IL_003c: newarr [System.Runtime]System.Object
-			IL_0041: dup
-			IL_0042: ldc.i4.0
-			IL_0043: ldarg.0
-			IL_0044: stelem.ref
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_004a: stloc.2
-			IL_004b: ldloc.1
-			IL_004c: ldloc.2
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0052: stloc.3
-			IL_0053: ldarg.0
-			IL_0054: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::read
-			IL_0059: ldc.i4.1
-			IL_005a: newarr [System.Runtime]System.Object
-			IL_005f: dup
-			IL_0060: ldc.i4.0
-			IL_0061: ldarg.0
-			IL_0062: stelem.ref
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0020: castclass Modules.Function_SchedulerGeneralRegions/Scope
+			IL_0025: ldnull
+			IL_0026: call object Modules.Function_SchedulerGeneralRegions/read::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+			IL_002b: stloc.1
+			IL_002c: ldarg.0
+			IL_002d: castclass Modules.Function_SchedulerGeneralRegions/Scope
+			IL_0032: ldnull
+			IL_0033: call object Modules.Function_SchedulerGeneralRegions/write::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+			IL_0038: stloc.2
+			IL_0039: ldloc.1
+			IL_003a: ldloc.2
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0040: stloc.3
+			IL_0041: ldarg.0
+			IL_0042: castclass Modules.Function_SchedulerGeneralRegions/Scope
+			IL_0047: ldnull
+			IL_0048: call object Modules.Function_SchedulerGeneralRegions/read::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+			IL_004d: stloc.2
+			IL_004e: ldloc.3
+			IL_004f: ldloc.2
+			IL_0050: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, object)
+			IL_0055: stloc.0
+			IL_0056: ldloc.0
+			IL_0057: ldstr ","
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
+			IL_0061: stloc.3
+			IL_0062: ldarg.0
+			IL_0063: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
 			IL_0068: stloc.2
 			IL_0069: ldloc.3
 			IL_006a: ldloc.2
-			IL_006b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(object, object)
-			IL_0070: stloc.0
-			IL_0071: ldloc.0
-			IL_0072: ldstr ","
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
-			IL_007c: stloc.3
-			IL_007d: ldarg.0
-			IL_007e: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
-			IL_0083: stloc.2
-			IL_0084: ldloc.3
-			IL_0085: ldloc.2
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_008b: stloc.3
-			IL_008c: ldloc.3
-			IL_008d: ret
+			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0070: stloc.3
+			IL_0071: ldloc.3
+			IL_0072: ret
 		} // end of method ordered::__js_call__
 
 	} // end of class ordered
@@ -1809,7 +1794,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 217 (0xd9)
+			// Code size: 199 (0xc7)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1832,89 +1817,79 @@
 			{
 				IL_001f: nop
 				IL_0020: ldarg.0
-				IL_0021: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::read
-				IL_0026: ldc.i4.1
-				IL_0027: newarr [System.Runtime]System.Object
-				IL_002c: dup
-				IL_002d: ldc.i4.0
+				IL_0021: castclass Modules.Function_SchedulerGeneralRegions/Scope
+				IL_0026: ldnull
+				IL_0027: call object Modules.Function_SchedulerGeneralRegions/read::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_002c: stloc.s 4
 				IL_002e: ldarg.0
-				IL_002f: stelem.ref
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0035: stloc.s 4
-				IL_0037: ldarg.0
-				IL_0038: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::write
-				IL_003d: ldc.i4.1
-				IL_003e: newarr [System.Runtime]System.Object
-				IL_0043: dup
-				IL_0044: ldc.i4.0
-				IL_0045: ldarg.0
-				IL_0046: stelem.ref
-				IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_004c: stloc.s 5
-				IL_004e: ldloc.s 4
-				IL_0050: ldloc.s 5
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0057: stloc.s 6
-				IL_0059: ldloc.s 6
-				IL_005b: ldstr ","
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0065: stloc.s 6
-				IL_0067: ldarg.0
-				IL_0068: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
-				IL_006d: stloc.s 5
-				IL_006f: ldloc.s 6
-				IL_0071: ldloc.s 5
-				IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0078: stloc.s 6
-				IL_007a: ldnull
-				IL_007b: stloc.0
-				IL_007c: ldloc.s 6
-				IL_007e: stloc.0
-				IL_007f: leave IL_00d7
+				IL_002f: castclass Modules.Function_SchedulerGeneralRegions/Scope
+				IL_0034: ldnull
+				IL_0035: call object Modules.Function_SchedulerGeneralRegions/write::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_003a: stloc.s 5
+				IL_003c: ldloc.s 4
+				IL_003e: ldloc.s 5
+				IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0045: stloc.s 6
+				IL_0047: ldloc.s 6
+				IL_0049: ldstr ","
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0053: stloc.s 6
+				IL_0055: ldarg.0
+				IL_0056: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
+				IL_005b: stloc.s 5
+				IL_005d: ldloc.s 6
+				IL_005f: ldloc.s 5
+				IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0066: stloc.s 6
+				IL_0068: ldnull
+				IL_0069: stloc.0
+				IL_006a: ldloc.s 6
+				IL_006c: stloc.0
+				IL_006d: leave IL_00c5
 
-				IL_0084: leave IL_00d7
+				IL_0072: leave IL_00c5
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0089: stloc.1
-				IL_008a: ldloc.1
-				IL_008b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0090: dup
-				IL_0091: brtrue IL_00a6
+				IL_0077: stloc.1
+				IL_0078: ldloc.1
+				IL_0079: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_007e: dup
+				IL_007f: brtrue IL_0094
 
-				IL_0096: pop
-				IL_0097: ldloc.1
-				IL_0098: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_009d: dup
-				IL_009e: brtrue IL_00b1
+				IL_0084: pop
+				IL_0085: ldloc.1
+				IL_0086: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_008b: dup
+				IL_008c: brtrue IL_009f
 
-				IL_00a3: pop
-				IL_00a4: rethrow
+				IL_0091: pop
+				IL_0092: rethrow
 
-				IL_00a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_00ab: stloc.2
-				IL_00ac: br IL_00b2
+				IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0099: stloc.2
+				IL_009a: br IL_00a0
 
-				IL_00b1: stloc.2
+				IL_009f: stloc.2
 
-				IL_00b2: ldloc.2
-				IL_00b3: stloc.3
-				IL_00b4: ldarg.0
-				IL_00b5: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
-				IL_00ba: stloc.s 5
-				IL_00bc: ldstr "-1,"
-				IL_00c1: ldloc.s 5
-				IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00c8: stloc.s 6
-				IL_00ca: ldloc.s 6
-				IL_00cc: stloc.0
-				IL_00cd: leave IL_00d7
+				IL_00a0: ldloc.2
+				IL_00a1: stloc.3
+				IL_00a2: ldarg.0
+				IL_00a3: ldfld object Modules.Function_SchedulerGeneralRegions/Scope::order
+				IL_00a8: stloc.s 5
+				IL_00aa: ldstr "-1,"
+				IL_00af: ldloc.s 5
+				IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00b6: stloc.s 6
+				IL_00b8: ldloc.s 6
+				IL_00ba: stloc.0
+				IL_00bb: leave IL_00c5
 
-				IL_00d2: leave IL_00d7
+				IL_00c0: leave IL_00c5
 			} // end handler
 
-			IL_00d7: ldloc.0
-			IL_00d8: ret
+			IL_00c5: ldloc.0
+			IL_00c6: ret
 		} // end of method caught::__js_call__
 
 	} // end of class caught
@@ -1972,7 +1947,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 803 (0x323)
+		// Code size: 753 (0x2f1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerGeneralRegions/Scope,
@@ -2144,133 +2119,123 @@
 		IL_0156: nop
 		IL_0157: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_015c: stloc.s 10
-		IL_015e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0163: stloc.s 7
-		IL_0165: ldloc.1
-		IL_0166: ldloc.s 7
-		IL_0168: ldc.r8 2
-		IL_0171: box [System.Runtime]System.Double
-		IL_0176: ldc.r8 4
-		IL_017f: box [System.Runtime]System.Double
-		IL_0184: ldc.r8 6
-		IL_018d: box [System.Runtime]System.Double
-		IL_0192: ldc.r8 5
-		IL_019b: box [System.Runtime]System.Double
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_01a5: stloc.s 11
-		IL_01a7: ldloc.s 10
-		IL_01a9: ldloc.s 11
-		IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b0: pop
-		IL_01b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b6: stloc.s 7
-		IL_01b8: ldloc.2
-		IL_01b9: ldloc.s 7
-		IL_01bb: ldc.r8 2
-		IL_01c4: box [System.Runtime]System.Double
-		IL_01c9: ldc.r8 4
-		IL_01d2: box [System.Runtime]System.Double
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01dc: stloc.s 6
-		IL_01de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e3: stloc.s 10
-		IL_01e5: volatile.
-		IL_01e7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_01ec: brfalse IL_0202
+		IL_015e: ldnull
+		IL_015f: ldc.r8 2
+		IL_0168: ldc.r8 4
+		IL_0171: ldc.r8 6
+		IL_017a: ldc.r8 5
+		IL_0183: call object Modules.Function_SchedulerGeneralRegions/mixed::__js_call__(object, float64, float64, float64, float64)
+		IL_0188: stloc.s 11
+		IL_018a: ldloc.s 10
+		IL_018c: ldloc.s 11
+		IL_018e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0193: pop
+		IL_0194: ldloc.0
+		IL_0195: castclass Modules.Function_SchedulerGeneralRegions/Scope
+		IL_019a: ldnull
+		IL_019b: ldc.r8 2
+		IL_01a4: ldc.r8 4
+		IL_01ad: call object Modules.Function_SchedulerGeneralRegions/'nested'::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64, float64)
+		IL_01b2: stloc.s 6
+		IL_01b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b9: stloc.s 10
+		IL_01bb: volatile.
+		IL_01bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_01c2: brfalse IL_01d8
 
-		IL_01f1: ldloc.s 6
-		IL_01f3: ldstr "x"
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01fd: br IL_0218
+		IL_01c7: ldloc.s 6
+		IL_01c9: ldstr "x"
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01d3: br IL_01ee
 
-		IL_0202: ldloc.s 6
-		IL_0204: ldstr "x"
-		IL_0209: ldstr "Function_SchedulerGeneralRegions:Modules.Function_SchedulerGeneralRegions:__js_module_init__:62"
-		IL_020e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01d8: ldloc.s 6
+		IL_01da: ldstr "x"
+		IL_01df: ldstr "Function_SchedulerGeneralRegions:Modules.Function_SchedulerGeneralRegions:__js_module_init__:62"
+		IL_01e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0218: stloc.s 11
-		IL_021a: ldloc.s 11
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0221: volatile.
-		IL_0223: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0228: brfalse IL_0241
+		IL_01ee: stloc.s 11
+		IL_01f0: ldloc.s 11
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f7: volatile.
+		IL_01f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_01fe: brfalse IL_0217
 
-		IL_022d: ldstr "join"
-		IL_0232: ldstr ","
-		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023c: br IL_025a
+		IL_0203: ldstr "join"
+		IL_0208: ldstr ","
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0212: br IL_0230
 
-		IL_0241: ldstr "join"
-		IL_0246: ldstr ","
-		IL_024b: ldstr "Function_SchedulerGeneralRegions:Modules.Function_SchedulerGeneralRegions:__js_module_init__:65"
-		IL_0250: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0217: ldstr "join"
+		IL_021c: ldstr ","
+		IL_0221: ldstr "Function_SchedulerGeneralRegions:Modules.Function_SchedulerGeneralRegions:__js_module_init__:65"
+		IL_0226: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_025a: stloc.s 11
-		IL_025c: ldloc.s 11
-		IL_025e: ldstr ":"
-		IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0268: stloc.s 12
-		IL_026a: volatile.
-		IL_026c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0271: brfalse IL_0287
+		IL_0230: stloc.s 11
+		IL_0232: ldloc.s 11
+		IL_0234: ldstr ":"
+		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_023e: stloc.s 12
+		IL_0240: volatile.
+		IL_0242: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0247: brfalse IL_025d
 
-		IL_0276: ldloc.s 6
-		IL_0278: ldstr "y"
-		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0282: br IL_029d
+		IL_024c: ldloc.s 6
+		IL_024e: ldstr "y"
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0258: br IL_0273
 
-		IL_0287: ldloc.s 6
-		IL_0289: ldstr "y"
-		IL_028e: ldstr "Function_SchedulerGeneralRegions:Modules.Function_SchedulerGeneralRegions:__js_module_init__:69"
-		IL_0293: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_025d: ldloc.s 6
+		IL_025f: ldstr "y"
+		IL_0264: ldstr "Function_SchedulerGeneralRegions:Modules.Function_SchedulerGeneralRegions:__js_module_init__:69"
+		IL_0269: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
+		IL_0273: stloc.s 11
+		IL_0275: ldloc.s 12
+		IL_0277: ldloc.s 11
+		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_027e: stloc.s 12
+		IL_0280: ldloc.s 10
+		IL_0282: ldloc.s 12
+		IL_0284: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0289: pop
+		IL_028a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_028f: stloc.s 10
+		IL_0291: ldloc.0
+		IL_0292: castclass Modules.Function_SchedulerGeneralRegions/Scope
+		IL_0297: ldnull
+		IL_0298: call object Modules.Function_SchedulerGeneralRegions/ordered::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
 		IL_029d: stloc.s 11
-		IL_029f: ldloc.s 12
+		IL_029f: ldloc.s 10
 		IL_02a1: ldloc.s 11
-		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02a8: stloc.s 12
-		IL_02aa: ldloc.s 10
-		IL_02ac: ldloc.s 12
-		IL_02ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b3: pop
-		IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b9: stloc.s 10
-		IL_02bb: ldloc.3
-		IL_02bc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_02c6: stloc.s 11
-		IL_02c8: ldloc.s 10
-		IL_02ca: ldloc.s 11
-		IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d1: pop
-		IL_02d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02d7: stloc.s 10
-		IL_02d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02de: stloc.s 7
-		IL_02e0: ldloc.s 4
-		IL_02e2: ldloc.s 7
-		IL_02e4: ldc.r8 1
-		IL_02ed: box [System.Runtime]System.Double
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02f7: stloc.s 11
-		IL_02f9: ldloc.s 10
-		IL_02fb: ldloc.s 11
-		IL_02fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0302: pop
-		IL_0303: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0308: stloc.s 10
-		IL_030a: ldloc.s 5
-		IL_030c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0316: stloc.s 11
-		IL_0318: ldloc.s 10
-		IL_031a: ldloc.s 11
-		IL_031c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0321: pop
-		IL_0322: ret
+		IL_02a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02a8: pop
+		IL_02a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ae: stloc.s 10
+		IL_02b0: ldloc.0
+		IL_02b1: castclass Modules.Function_SchedulerGeneralRegions/Scope
+		IL_02b6: ldnull
+		IL_02b7: ldc.r8 1
+		IL_02c0: call object Modules.Function_SchedulerGeneralRegions/getter::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64)
+		IL_02c5: stloc.s 11
+		IL_02c7: ldloc.s 10
+		IL_02c9: ldloc.s 11
+		IL_02cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d0: pop
+		IL_02d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d6: stloc.s 10
+		IL_02d8: ldloc.0
+		IL_02d9: castclass Modules.Function_SchedulerGeneralRegions/Scope
+		IL_02de: ldnull
+		IL_02df: call object Modules.Function_SchedulerGeneralRegions/caught::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+		IL_02e4: stloc.s 11
+		IL_02e6: ldloc.s 10
+		IL_02e8: ldloc.s 11
+		IL_02ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ef: pop
+		IL_02f0: ret
 	} // end of method Function_SchedulerGeneralRegions::__js_module_init__
 
 } // end of class Modules.Function_SchedulerGeneralRegions

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
@@ -1302,106 +1302,91 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 251 (0xfb)
+			// Code size: 225 (0xe1)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object[],
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[4] object,
-				[5] object
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[3] object,
+				[4] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldstr ""
 			IL_0006: stfld object Modules.Function_SchedulerLiteralArguments/Scope::order
 			IL_000b: ldarg.0
-			IL_000c: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::f
-			IL_0011: ldc.i4.1
-			IL_0012: newarr [System.Runtime]System.Object
-			IL_0017: dup
-			IL_0018: ldc.i4.0
-			IL_0019: ldarg.0
-			IL_001a: stelem.ref
-			IL_001b: stloc.1
-			IL_001c: ldloc.1
-			IL_001d: ldstr "a"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0027: stloc.2
-			IL_0028: ldc.i4.1
-			IL_0029: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_002e: dup
-			IL_002f: ldloc.2
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0035: stloc.3
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::f
-			IL_003c: ldc.i4.1
-			IL_003d: newarr [System.Runtime]System.Object
-			IL_0042: dup
-			IL_0043: ldc.i4.0
-			IL_0044: ldarg.0
-			IL_0045: stelem.ref
-			IL_0046: stloc.1
-			IL_0047: ldloc.1
-			IL_0048: ldstr "b"
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0052: stloc.2
-			IL_0053: ldarg.0
-			IL_0054: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
-			IL_0059: stloc.s 4
-			IL_005b: ldc.i4.3
-			IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0061: dup
-			IL_0062: ldloc.3
-			IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0068: dup
-			IL_0069: ldloc.2
-			IL_006a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_006f: dup
-			IL_0070: ldloc.s 4
-			IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0077: stloc.0
-			IL_0078: ldloc.0
-			IL_0079: ldc.r8 0.0
-			IL_0082: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0087: ldc.r8 0.0
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_000c: castclass Modules.Function_SchedulerLiteralArguments/Scope
+			IL_0011: ldnull
+			IL_0012: ldstr "a"
+			IL_0017: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+			IL_001c: stloc.1
+			IL_001d: ldc.i4.1
+			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0023: dup
+			IL_0024: ldloc.1
+			IL_0025: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_002a: stloc.2
+			IL_002b: ldarg.0
+			IL_002c: castclass Modules.Function_SchedulerLiteralArguments/Scope
+			IL_0031: ldnull
+			IL_0032: ldstr "b"
+			IL_0037: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+			IL_003c: stloc.1
+			IL_003d: ldarg.0
+			IL_003e: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
+			IL_0043: stloc.3
+			IL_0044: ldc.i4.3
+			IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_004a: dup
+			IL_004b: ldloc.2
+			IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0051: dup
+			IL_0052: ldloc.1
+			IL_0053: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0058: dup
+			IL_0059: ldloc.3
+			IL_005a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_005f: stloc.0
+			IL_0060: ldloc.0
+			IL_0061: ldc.r8 0.0
+			IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_006f: ldc.r8 0.0
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_007d: stloc.3
+			IL_007e: ldloc.0
+			IL_007f: ldc.r8 1
+			IL_0088: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_008d: stloc.1
+			IL_008e: ldloc.3
+			IL_008f: ldloc.1
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0095: stloc.s 4
-			IL_0097: ldloc.0
-			IL_0098: ldc.r8 1
-			IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_00a6: stloc.2
-			IL_00a7: ldloc.s 4
-			IL_00a9: ldloc.2
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00af: stloc.s 5
-			IL_00b1: ldloc.s 5
-			IL_00b3: ldstr ":"
+			IL_0097: ldloc.s 4
+			IL_0099: ldstr ":"
+			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00a3: stloc.s 4
+			IL_00a5: ldloc.0
+			IL_00a6: ldc.r8 2
+			IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00b4: stloc.1
+			IL_00b5: ldloc.s 4
+			IL_00b7: ldloc.1
 			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.0
-			IL_00c0: ldc.r8 2
-			IL_00c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_00ce: stloc.2
-			IL_00cf: ldloc.s 5
-			IL_00d1: ldloc.2
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00d7: stloc.s 5
-			IL_00d9: ldloc.s 5
-			IL_00db: ldstr ":"
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00e5: stloc.s 5
-			IL_00e7: ldarg.0
-			IL_00e8: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
-			IL_00ed: stloc.2
-			IL_00ee: ldloc.s 5
-			IL_00f0: ldloc.2
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00f6: stloc.s 5
-			IL_00f8: ldloc.s 5
-			IL_00fa: ret
+			IL_00bd: stloc.s 4
+			IL_00bf: ldloc.s 4
+			IL_00c1: ldstr ":"
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00cb: stloc.s 4
+			IL_00cd: ldarg.0
+			IL_00ce: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
+			IL_00d3: stloc.1
+			IL_00d4: ldloc.s 4
+			IL_00d6: ldloc.1
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00dc: stloc.s 4
+			IL_00de: ldloc.s 4
+			IL_00e0: ret
 		} // end of method arrayOrder::__js_call__
 
 	} // end of class arrayOrder
@@ -1544,116 +1529,101 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 267 (0x10b)
+			// Code size: 241 (0xf1)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[1] object[],
+				[1] object,
 				[2] object,
-				[3] object,
-				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[5] object
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[4] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldstr ""
 			IL_0006: stfld object Modules.Function_SchedulerLiteralArguments/Scope::order
 			IL_000b: ldarg.0
-			IL_000c: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::f
-			IL_0011: ldc.i4.1
-			IL_0012: newarr [System.Runtime]System.Object
-			IL_0017: dup
-			IL_0018: ldc.i4.0
-			IL_0019: ldarg.0
-			IL_001a: stelem.ref
-			IL_001b: stloc.1
-			IL_001c: ldloc.1
-			IL_001d: ldstr "k"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0027: stloc.2
-			IL_0028: ldarg.0
-			IL_0029: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::f
-			IL_002e: ldc.i4.1
-			IL_002f: newarr [System.Runtime]System.Object
-			IL_0034: dup
-			IL_0035: ldc.i4.0
-			IL_0036: ldarg.0
-			IL_0037: stelem.ref
-			IL_0038: stloc.1
-			IL_0039: ldloc.1
-			IL_003a: ldstr "v"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0044: stloc.3
-			IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_004a: stloc.s 4
-			IL_004c: ldloc.s 4
-			IL_004e: ldloc.2
-			IL_004f: ldloc.3
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-			IL_0055: pop
-			IL_0056: ldarg.0
-			IL_0057: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
-			IL_005c: stloc.3
-			IL_005d: ldloc.s 4
-			IL_005f: ldstr "order"
-			IL_0064: ldloc.3
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_006a: pop
-			IL_006b: ldloc.s 4
-			IL_006d: stloc.0
-			IL_006e: volatile.
-			IL_0070: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_0075: brfalse IL_008a
+			IL_000c: castclass Modules.Function_SchedulerLiteralArguments/Scope
+			IL_0011: ldnull
+			IL_0012: ldstr "k"
+			IL_0017: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+			IL_001c: stloc.1
+			IL_001d: ldarg.0
+			IL_001e: castclass Modules.Function_SchedulerLiteralArguments/Scope
+			IL_0023: ldnull
+			IL_0024: ldstr "v"
+			IL_0029: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+			IL_002e: stloc.2
+			IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0034: stloc.3
+			IL_0035: ldloc.3
+			IL_0036: ldloc.1
+			IL_0037: ldloc.2
+			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+			IL_003d: pop
+			IL_003e: ldarg.0
+			IL_003f: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
+			IL_0044: stloc.2
+			IL_0045: ldloc.3
+			IL_0046: ldstr "order"
+			IL_004b: ldloc.2
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0051: pop
+			IL_0052: ldloc.3
+			IL_0053: stloc.0
+			IL_0054: volatile.
+			IL_0056: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_005b: brfalse IL_0070
 
-			IL_007a: ldloc.0
-			IL_007b: ldstr "k"
-			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0085: br IL_009f
+			IL_0060: ldloc.0
+			IL_0061: ldstr "k"
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_006b: br IL_0085
 
-			IL_008a: ldloc.0
-			IL_008b: ldstr "k"
-			IL_0090: ldstr "Function_SchedulerLiteralArguments:<TwoPhaseDummy_M11>:__js_call__:20"
-			IL_0095: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0070: ldloc.0
+			IL_0071: ldstr "k"
+			IL_0076: ldstr "Function_SchedulerLiteralArguments:<TwoPhaseDummy_M11>:__js_call__:18"
+			IL_007b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_009f: stloc.3
-			IL_00a0: ldloc.3
-			IL_00a1: ldstr ":"
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00ab: stloc.s 5
-			IL_00ad: volatile.
-			IL_00af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_00b4: brfalse IL_00c9
+			IL_0085: stloc.2
+			IL_0086: ldloc.2
+			IL_0087: ldstr ":"
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0091: stloc.s 4
+			IL_0093: volatile.
+			IL_0095: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_009a: brfalse IL_00af
 
-			IL_00b9: ldloc.0
-			IL_00ba: ldstr "order"
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c4: br IL_00de
+			IL_009f: ldloc.0
+			IL_00a0: ldstr "order"
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00aa: br IL_00c4
 
-			IL_00c9: ldloc.0
-			IL_00ca: ldstr "order"
-			IL_00cf: ldstr "Function_SchedulerLiteralArguments:<TwoPhaseDummy_M11>:__js_call__:24"
-			IL_00d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00af: ldloc.0
+			IL_00b0: ldstr "order"
+			IL_00b5: ldstr "Function_SchedulerLiteralArguments:<TwoPhaseDummy_M11>:__js_call__:22"
+			IL_00ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00de: stloc.3
-			IL_00df: ldloc.s 5
-			IL_00e1: ldloc.3
-			IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00e7: stloc.s 5
-			IL_00e9: ldloc.s 5
-			IL_00eb: ldstr ":"
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00f5: stloc.s 5
-			IL_00f7: ldarg.0
-			IL_00f8: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
-			IL_00fd: stloc.3
-			IL_00fe: ldloc.s 5
-			IL_0100: ldloc.3
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0106: stloc.s 5
-			IL_0108: ldloc.s 5
-			IL_010a: ret
+			IL_00c4: stloc.2
+			IL_00c5: ldloc.s 4
+			IL_00c7: ldloc.2
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00cd: stloc.s 4
+			IL_00cf: ldloc.s 4
+			IL_00d1: ldstr ":"
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00db: stloc.s 4
+			IL_00dd: ldarg.0
+			IL_00de: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
+			IL_00e3: stloc.2
+			IL_00e4: ldloc.s 4
+			IL_00e6: ldloc.2
+			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00ec: stloc.s 4
+			IL_00ee: ldloc.s 4
+			IL_00f0: ret
 		} // end of method objectOrder::__js_call__
 
 	} // end of class objectOrder
@@ -1935,85 +1905,70 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 162 (0xa2)
+			// Code size: 136 (0x88)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[1] object[],
-				[2] object,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[4] string,
-				[5] object
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[3] string,
+				[4] object
 			)
 
 			IL_0000: ldarg.0
 			IL_0001: ldstr ""
 			IL_0006: stfld object Modules.Function_SchedulerLiteralArguments/Scope::order
 			IL_000b: ldarg.0
-			IL_000c: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::f
-			IL_0011: ldc.i4.1
-			IL_0012: newarr [System.Runtime]System.Object
-			IL_0017: dup
-			IL_0018: ldc.i4.0
-			IL_0019: ldarg.0
-			IL_001a: stelem.ref
-			IL_001b: stloc.1
-			IL_001c: ldloc.1
-			IL_001d: ldstr "a"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0027: stloc.2
-			IL_0028: ldc.i4.1
-			IL_0029: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_002e: dup
-			IL_002f: ldloc.2
-			IL_0030: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0035: stloc.3
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::spread
-			IL_003c: stloc.2
-			IL_003d: ldloc.3
-			IL_003e: ldloc.2
-			IL_003f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-			IL_0044: ldarg.0
-			IL_0045: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::f
-			IL_004a: ldc.i4.1
-			IL_004b: newarr [System.Runtime]System.Object
-			IL_0050: dup
-			IL_0051: ldc.i4.0
-			IL_0052: ldarg.0
-			IL_0053: stelem.ref
-			IL_0054: stloc.1
-			IL_0055: ldloc.1
-			IL_0056: ldstr "b"
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0060: stloc.2
-			IL_0061: ldloc.3
-			IL_0062: ldloc.2
-			IL_0063: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0068: ldloc.3
-			IL_0069: stloc.0
-			IL_006a: ldloc.0
-			IL_006b: ldc.i4.1
-			IL_006c: newarr [System.Runtime]System.Object
-			IL_0071: dup
-			IL_0072: ldc.i4.0
-			IL_0073: ldstr ","
-			IL_0078: stelem.ref
-			IL_0079: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_007e: stloc.s 4
-			IL_0080: ldloc.s 4
-			IL_0082: ldstr ":"
-			IL_0087: call string [System.Runtime]System.String::Concat(string, string)
-			IL_008c: stloc.s 4
-			IL_008e: ldarg.0
-			IL_008f: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
-			IL_0094: stloc.2
-			IL_0095: ldloc.s 4
-			IL_0097: ldloc.2
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_009d: stloc.s 5
-			IL_009f: ldloc.s 5
-			IL_00a1: ret
+			IL_000c: castclass Modules.Function_SchedulerLiteralArguments/Scope
+			IL_0011: ldnull
+			IL_0012: ldstr "a"
+			IL_0017: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+			IL_001c: stloc.1
+			IL_001d: ldc.i4.1
+			IL_001e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0023: dup
+			IL_0024: ldloc.1
+			IL_0025: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_002a: stloc.2
+			IL_002b: ldarg.0
+			IL_002c: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::spread
+			IL_0031: stloc.1
+			IL_0032: ldloc.2
+			IL_0033: ldloc.1
+			IL_0034: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+			IL_0039: ldarg.0
+			IL_003a: castclass Modules.Function_SchedulerLiteralArguments/Scope
+			IL_003f: ldnull
+			IL_0040: ldstr "b"
+			IL_0045: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+			IL_004a: stloc.1
+			IL_004b: ldloc.2
+			IL_004c: ldloc.1
+			IL_004d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0052: ldloc.2
+			IL_0053: stloc.0
+			IL_0054: ldloc.0
+			IL_0055: ldc.i4.1
+			IL_0056: newarr [System.Runtime]System.Object
+			IL_005b: dup
+			IL_005c: ldc.i4.0
+			IL_005d: ldstr ","
+			IL_0062: stelem.ref
+			IL_0063: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0068: stloc.3
+			IL_0069: ldloc.3
+			IL_006a: ldstr ":"
+			IL_006f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0074: stloc.3
+			IL_0075: ldarg.0
+			IL_0076: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
+			IL_007b: stloc.1
+			IL_007c: ldloc.3
+			IL_007d: ldloc.1
+			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0083: stloc.s 4
+			IL_0085: ldloc.s 4
+			IL_0087: ret
 		} // end of method spreadOrder::__js_call__
 
 	} // end of class spreadOrder
@@ -2196,17 +2151,16 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 177 (0xb1)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] class [System.Runtime]System.Exception,
 				[2] object,
 				[3] object,
-				[4] object[],
+				[4] object,
 				[5] object,
-				[6] object,
-				[7] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[6] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -2216,83 +2170,69 @@
 			{
 				IL_000b: nop
 				IL_000c: ldarg.0
-				IL_000d: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::throwValue
-				IL_0012: ldc.i4.1
-				IL_0013: newarr [System.Runtime]System.Object
-				IL_0018: dup
-				IL_0019: ldc.i4.0
-				IL_001a: ldarg.0
-				IL_001b: stelem.ref
-				IL_001c: stloc.s 4
-				IL_001e: ldloc.s 4
-				IL_0020: ldstr "a"
-				IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_002a: stloc.s 5
-				IL_002c: ldarg.0
-				IL_002d: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::f
-				IL_0032: ldc.i4.1
-				IL_0033: newarr [System.Runtime]System.Object
+				IL_000d: castclass Modules.Function_SchedulerLiteralArguments/Scope
+				IL_0012: ldnull
+				IL_0013: ldstr "a"
+				IL_0018: call object Modules.Function_SchedulerLiteralArguments/throwValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+				IL_001d: stloc.s 4
+				IL_001f: ldarg.0
+				IL_0020: castclass Modules.Function_SchedulerLiteralArguments/Scope
+				IL_0025: ldnull
+				IL_0026: ldstr "b"
+				IL_002b: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+				IL_0030: stloc.s 5
+				IL_0032: ldc.i4.2
+				IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 				IL_0038: dup
-				IL_0039: ldc.i4.0
-				IL_003a: ldarg.0
-				IL_003b: stelem.ref
-				IL_003c: stloc.s 4
-				IL_003e: ldloc.s 4
-				IL_0040: ldstr "b"
-				IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_004a: stloc.s 6
-				IL_004c: ldc.i4.2
-				IL_004d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-				IL_0052: dup
-				IL_0053: ldloc.s 5
-				IL_0055: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_005a: dup
-				IL_005b: ldloc.s 6
-				IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-				IL_0062: stloc.s 7
-				IL_0064: ldnull
-				IL_0065: stloc.0
-				IL_0066: ldloc.s 7
-				IL_0068: stloc.0
-				IL_0069: leave IL_00af
+				IL_0039: ldloc.s 4
+				IL_003b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0040: dup
+				IL_0041: ldloc.s 5
+				IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+				IL_0048: stloc.s 6
+				IL_004a: ldnull
+				IL_004b: stloc.0
+				IL_004c: ldloc.s 6
+				IL_004e: stloc.0
+				IL_004f: leave IL_0095
 
-				IL_006e: leave IL_00af
+				IL_0054: leave IL_0095
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0073: stloc.1
-				IL_0074: ldloc.1
-				IL_0075: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_007a: dup
-				IL_007b: brtrue IL_0090
+				IL_0059: stloc.1
+				IL_005a: ldloc.1
+				IL_005b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0060: dup
+				IL_0061: brtrue IL_0076
 
-				IL_0080: pop
-				IL_0081: ldloc.1
-				IL_0082: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0087: dup
-				IL_0088: brtrue IL_009b
+				IL_0066: pop
+				IL_0067: ldloc.1
+				IL_0068: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_006d: dup
+				IL_006e: brtrue IL_0081
 
-				IL_008d: pop
-				IL_008e: rethrow
+				IL_0073: pop
+				IL_0074: rethrow
 
-				IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0095: stloc.2
-				IL_0096: br IL_009c
+				IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_007b: stloc.2
+				IL_007c: br IL_0082
 
-				IL_009b: stloc.2
+				IL_0081: stloc.2
 
-				IL_009c: ldloc.2
-				IL_009d: stloc.3
-				IL_009e: ldarg.0
-				IL_009f: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
-				IL_00a4: stloc.0
-				IL_00a5: leave IL_00af
+				IL_0082: ldloc.2
+				IL_0083: stloc.3
+				IL_0084: ldarg.0
+				IL_0085: ldfld object Modules.Function_SchedulerLiteralArguments/Scope::order
+				IL_008a: stloc.0
+				IL_008b: leave IL_0095
 
-				IL_00aa: leave IL_00af
+				IL_0090: leave IL_0095
 			} // end handler
 
-			IL_00af: ldloc.0
-			IL_00b0: ret
+			IL_0095: ldloc.0
+			IL_0096: ret
 		} // end of method exceptionOrder::__js_call__
 
 	} // end of class exceptionOrder
@@ -2542,8 +2482,8 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1476 (0x5c4)
-		.maxstack 8
+		// Code size: 1269 (0x4f5)
+		.maxstack 11
 		.locals init (
 			[0] class Modules.Function_SchedulerLiteralArguments/Scope,
 			[1] class Modules.Function_SchedulerLiteralArguments/args/FunctionObject,
@@ -2556,14 +2496,16 @@
 			[8] class Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject,
 			[9] class Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject,
 			[10] object,
-			[11] object,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[12] object[],
 			[13] class Modules.Function_SchedulerLiteralArguments/f/FunctionObject,
 			[14] class Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject,
 			[15] object,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[18] object
+			[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[19] string,
+			[20] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_SchedulerLiteralArguments/Scope::.ctor()
@@ -2819,266 +2761,199 @@
 		IL_022f: nop
 		IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0235: stloc.s 17
-		IL_0237: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_023c: stloc.s 12
-		IL_023e: ldloc.1
-		IL_023f: ldloc.s 12
-		IL_0241: ldc.r8 2
-		IL_024a: box [System.Runtime]System.Double
-		IL_024f: ldc.r8 4
-		IL_0258: box [System.Runtime]System.Double
-		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0262: stloc.s 15
-		IL_0264: ldloc.s 17
-		IL_0266: ldloc.s 15
-		IL_0268: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026d: pop
-		IL_026e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0273: stloc.s 17
-		IL_0275: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_027a: stloc.s 12
-		IL_027c: ldloc.2
-		IL_027d: ldloc.s 12
-		IL_027f: ldc.r8 2
-		IL_0288: box [System.Runtime]System.Double
-		IL_028d: ldc.r8 4
-		IL_0296: box [System.Runtime]System.Double
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02a0: stloc.s 15
-		IL_02a2: ldloc.s 15
-		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a9: volatile.
-		IL_02ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_02b0: brfalse IL_02c9
+		IL_0237: ldnull
+		IL_0238: ldc.r8 2
+		IL_0241: ldc.r8 4
+		IL_024a: call object Modules.Function_SchedulerLiteralArguments/args::__js_call__(object, float64, float64)
+		IL_024f: stloc.s 15
+		IL_0251: ldloc.s 17
+		IL_0253: ldloc.s 15
+		IL_0255: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_025a: pop
+		IL_025b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0260: stloc.s 17
+		IL_0262: ldnull
+		IL_0263: ldc.r8 2
+		IL_026c: ldc.r8 4
+		IL_0275: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/arrayValue::__js_call__(object, float64, float64)
+		IL_027a: stloc.s 18
+		IL_027c: ldloc.s 18
+		IL_027e: ldc.i4.1
+		IL_027f: newarr [System.Runtime]System.Object
+		IL_0284: dup
+		IL_0285: ldc.i4.0
+		IL_0286: ldstr ","
+		IL_028b: stelem.ref
+		IL_028c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_0291: stloc.s 19
+		IL_0293: ldloc.s 17
+		IL_0295: ldloc.s 19
+		IL_0297: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029c: pop
+		IL_029d: ldloc.0
+		IL_029e: castclass Modules.Function_SchedulerLiteralArguments/Scope
+		IL_02a3: ldnull
+		IL_02a4: ldc.r8 2
+		IL_02ad: ldc.r8 4
+		IL_02b6: call object Modules.Function_SchedulerLiteralArguments/objectValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
+		IL_02bb: stloc.s 10
+		IL_02bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c2: stloc.s 17
+		IL_02c4: volatile.
+		IL_02c6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_02cb: brfalse IL_02e1
 
-		IL_02b5: ldstr "join"
-		IL_02ba: ldstr ","
-		IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c4: br IL_02e2
+		IL_02d0: ldloc.s 10
+		IL_02d2: ldstr "x"
+		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02dc: br IL_02f7
 
-		IL_02c9: ldstr "join"
-		IL_02ce: ldstr ","
-		IL_02d3: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:77"
-		IL_02d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_02e1: ldloc.s 10
+		IL_02e3: ldstr "x"
+		IL_02e8: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:89"
+		IL_02ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02e2: stloc.s 15
-		IL_02e4: ldloc.s 17
-		IL_02e6: ldloc.s 15
-		IL_02e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ed: pop
-		IL_02ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02f3: stloc.s 12
-		IL_02f5: ldloc.3
-		IL_02f6: ldloc.s 12
-		IL_02f8: ldc.r8 2
-		IL_0301: box [System.Runtime]System.Double
-		IL_0306: ldc.r8 4
-		IL_030f: box [System.Runtime]System.Double
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0319: stloc.s 10
-		IL_031b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0320: stloc.s 17
-		IL_0322: volatile.
-		IL_0324: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0329: brfalse IL_033f
+		IL_02f7: stloc.s 15
+		IL_02f9: ldloc.s 15
+		IL_02fb: ldstr ","
+		IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0305: stloc.s 20
+		IL_0307: volatile.
+		IL_0309: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_030e: brfalse IL_0324
 
-		IL_032e: ldloc.s 10
-		IL_0330: ldstr "x"
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_033a: br IL_0355
+		IL_0313: ldloc.s 10
+		IL_0315: ldstr "y"
+		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_031f: br IL_033a
 
-		IL_033f: ldloc.s 10
-		IL_0341: ldstr "x"
-		IL_0346: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:90"
-		IL_034b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0324: ldloc.s 10
+		IL_0326: ldstr "y"
+		IL_032b: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:93"
+		IL_0330: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0355: stloc.s 15
-		IL_0357: ldloc.s 15
-		IL_0359: ldstr ","
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0363: stloc.s 18
-		IL_0365: volatile.
-		IL_0367: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_036c: brfalse IL_0382
+		IL_033a: stloc.s 15
+		IL_033c: ldloc.s 20
+		IL_033e: ldloc.s 15
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0345: stloc.s 20
+		IL_0347: ldloc.s 17
+		IL_0349: ldloc.s 20
+		IL_034b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0350: pop
+		IL_0351: ldloc.0
+		IL_0352: castclass Modules.Function_SchedulerLiteralArguments/Scope
+		IL_0357: ldnull
+		IL_0358: ldc.r8 2
+		IL_0361: ldc.r8 4
+		IL_036a: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/'nested'::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
+		IL_036f: stloc.s 11
+		IL_0371: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0376: stloc.s 17
+		IL_0378: ldloc.s 11
+		IL_037a: ldc.r8 0.0
+		IL_0383: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0388: ldc.r8 0.0
+		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0396: stloc.s 15
+		IL_0398: ldloc.s 15
+		IL_039a: ldstr ","
+		IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03a4: stloc.s 20
+		IL_03a6: ldloc.s 11
+		IL_03a8: ldc.r8 1
+		IL_03b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_03b6: volatile.
+		IL_03b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_03bd: brfalse IL_03d1
 
-		IL_0371: ldloc.s 10
-		IL_0373: ldstr "y"
-		IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_037d: br IL_0398
+		IL_03c2: ldstr "y"
+		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03cc: br IL_03e5
 
-		IL_0382: ldloc.s 10
-		IL_0384: ldstr "y"
-		IL_0389: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:94"
-		IL_038e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03d1: ldstr "y"
+		IL_03d6: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:115"
+		IL_03db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0398: stloc.s 15
-		IL_039a: ldloc.s 18
-		IL_039c: ldloc.s 15
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_03a3: stloc.s 18
-		IL_03a5: ldloc.s 17
-		IL_03a7: ldloc.s 18
-		IL_03a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03ae: pop
-		IL_03af: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03b4: stloc.s 12
-		IL_03b6: ldloc.s 4
-		IL_03b8: ldloc.s 12
-		IL_03ba: ldc.r8 2
-		IL_03c3: box [System.Runtime]System.Double
-		IL_03c8: ldc.r8 4
-		IL_03d1: box [System.Runtime]System.Double
-		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_03db: stloc.s 11
-		IL_03dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03e2: stloc.s 17
-		IL_03e4: ldloc.s 11
-		IL_03e6: ldc.r8 0.0
-		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_03f4: stloc.s 15
-		IL_03f6: ldloc.s 15
-		IL_03f8: ldc.r8 0.0
-		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0406: stloc.s 15
-		IL_0408: ldloc.s 15
-		IL_040a: ldstr ","
-		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0414: stloc.s 18
-		IL_0416: ldloc.s 11
-		IL_0418: ldc.r8 1
-		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0426: stloc.s 15
-		IL_0428: volatile.
-		IL_042a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_042f: brfalse IL_0445
-
-		IL_0434: ldloc.s 15
-		IL_0436: ldstr "y"
-		IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0440: br IL_045b
-
-		IL_0445: ldloc.s 15
-		IL_0447: ldstr "y"
-		IL_044c: ldstr "Function_SchedulerLiteralArguments:Modules.Function_SchedulerLiteralArguments:__js_module_init__:116"
-		IL_0451: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_045b: stloc.s 15
-		IL_045d: ldloc.s 18
-		IL_045f: ldloc.s 15
-		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0466: stloc.s 18
-		IL_0468: ldloc.s 17
-		IL_046a: ldloc.s 18
-		IL_046c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0471: pop
-		IL_0472: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0477: stloc.s 17
-		IL_0479: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_047e: stloc.s 12
-		IL_0480: ldloc.s 5
-		IL_0482: ldloc.s 12
-		IL_0484: ldc.i4.s 9
-		IL_0486: newarr [System.Runtime]System.Object
-		IL_048b: dup
-		IL_048c: ldc.i4.0
-		IL_048d: ldc.r8 1
-		IL_0496: box [System.Runtime]System.Double
-		IL_049b: stelem.ref
-		IL_049c: dup
-		IL_049d: ldc.i4.1
-		IL_049e: ldc.r8 2
-		IL_04a7: box [System.Runtime]System.Double
-		IL_04ac: stelem.ref
-		IL_04ad: dup
-		IL_04ae: ldc.i4.2
-		IL_04af: ldc.r8 3
-		IL_04b8: box [System.Runtime]System.Double
-		IL_04bd: stelem.ref
-		IL_04be: dup
-		IL_04bf: ldc.i4.3
-		IL_04c0: ldc.r8 4
-		IL_04c9: box [System.Runtime]System.Double
-		IL_04ce: stelem.ref
-		IL_04cf: dup
-		IL_04d0: ldc.i4.4
-		IL_04d1: ldc.r8 5
-		IL_04da: box [System.Runtime]System.Double
-		IL_04df: stelem.ref
-		IL_04e0: dup
-		IL_04e1: ldc.i4.5
-		IL_04e2: ldc.r8 6
-		IL_04eb: box [System.Runtime]System.Double
-		IL_04f0: stelem.ref
-		IL_04f1: dup
-		IL_04f2: ldc.i4.6
-		IL_04f3: ldc.r8 7
-		IL_04fc: box [System.Runtime]System.Double
-		IL_0501: stelem.ref
-		IL_0502: dup
-		IL_0503: ldc.i4.7
-		IL_0504: ldc.r8 8
-		IL_050d: box [System.Runtime]System.Double
-		IL_0512: stelem.ref
-		IL_0513: dup
-		IL_0514: ldc.i4.8
-		IL_0515: ldc.r8 9
-		IL_051e: box [System.Runtime]System.Double
-		IL_0523: stelem.ref
-		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0529: stloc.s 15
-		IL_052b: ldloc.s 15
-		IL_052d: ldc.r8 0.0
-		IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_053b: stloc.s 15
-		IL_053d: ldloc.s 17
-		IL_053f: ldloc.s 15
-		IL_0541: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0546: pop
-		IL_0547: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_054c: stloc.s 17
-		IL_054e: ldloc.s 6
-		IL_0550: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0555: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_055a: stloc.s 15
-		IL_055c: ldloc.s 17
-		IL_055e: ldloc.s 15
-		IL_0560: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0565: pop
-		IL_0566: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_056b: stloc.s 17
-		IL_056d: ldloc.s 7
-		IL_056f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0579: stloc.s 15
-		IL_057b: ldloc.s 17
-		IL_057d: ldloc.s 15
-		IL_057f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0584: pop
-		IL_0585: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_058a: stloc.s 17
-		IL_058c: ldloc.s 8
-		IL_058e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0598: stloc.s 15
-		IL_059a: ldloc.s 17
-		IL_059c: ldloc.s 15
-		IL_059e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05a3: pop
-		IL_05a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05a9: stloc.s 17
-		IL_05ab: ldloc.s 9
-		IL_05ad: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_05b7: stloc.s 15
-		IL_05b9: ldloc.s 17
-		IL_05bb: ldloc.s 15
-		IL_05bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05c2: pop
-		IL_05c3: ret
+		IL_03e5: stloc.s 15
+		IL_03e7: ldloc.s 20
+		IL_03e9: ldloc.s 15
+		IL_03eb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03f0: stloc.s 20
+		IL_03f2: ldloc.s 17
+		IL_03f4: ldloc.s 20
+		IL_03f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03fb: pop
+		IL_03fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0401: stloc.s 17
+		IL_0403: ldnull
+		IL_0404: ldc.r8 1
+		IL_040d: ldc.r8 2
+		IL_0416: ldc.r8 3
+		IL_041f: ldc.r8 4
+		IL_0428: ldc.r8 5
+		IL_0431: ldc.r8 6
+		IL_043a: ldc.r8 7
+		IL_0443: ldc.r8 8
+		IL_044c: ldc.r8 9
+		IL_0455: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/deepArray::__js_call__(object, float64, float64, float64, float64, float64, float64, float64, float64, float64)
+		IL_045a: stloc.s 18
+		IL_045c: ldloc.s 18
+		IL_045e: ldc.r8 0.0
+		IL_0467: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_046c: stloc.s 15
+		IL_046e: ldloc.s 17
+		IL_0470: ldloc.s 15
+		IL_0472: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0477: pop
+		IL_0478: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_047d: stloc.s 17
+		IL_047f: ldloc.0
+		IL_0480: castclass Modules.Function_SchedulerLiteralArguments/Scope
+		IL_0485: ldnull
+		IL_0486: call object Modules.Function_SchedulerLiteralArguments/arrayOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+		IL_048b: stloc.s 15
+		IL_048d: ldloc.s 17
+		IL_048f: ldloc.s 15
+		IL_0491: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0496: pop
+		IL_0497: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_049c: stloc.s 17
+		IL_049e: ldloc.0
+		IL_049f: castclass Modules.Function_SchedulerLiteralArguments/Scope
+		IL_04a4: ldnull
+		IL_04a5: call object Modules.Function_SchedulerLiteralArguments/objectOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+		IL_04aa: stloc.s 15
+		IL_04ac: ldloc.s 17
+		IL_04ae: ldloc.s 15
+		IL_04b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04b5: pop
+		IL_04b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04bb: stloc.s 17
+		IL_04bd: ldloc.0
+		IL_04be: castclass Modules.Function_SchedulerLiteralArguments/Scope
+		IL_04c3: ldnull
+		IL_04c4: call object Modules.Function_SchedulerLiteralArguments/spreadOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+		IL_04c9: stloc.s 15
+		IL_04cb: ldloc.s 17
+		IL_04cd: ldloc.s 15
+		IL_04cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04d4: pop
+		IL_04d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04da: stloc.s 17
+		IL_04dc: ldloc.0
+		IL_04dd: castclass Modules.Function_SchedulerLiteralArguments/Scope
+		IL_04e2: ldnull
+		IL_04e3: call object Modules.Function_SchedulerLiteralArguments/exceptionOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+		IL_04e8: stloc.s 15
+		IL_04ea: ldloc.s 17
+		IL_04ec: ldloc.s 15
+		IL_04ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04f3: pop
+		IL_04f4: ret
 	} // end of method Function_SchedulerLiteralArguments::__js_module_init__
 
 } // end of class Modules.Function_SchedulerLiteralArguments
@@ -3113,7 +2988,6 @@
 	.field assembly static int32 __jroc_dynamicLookup_25
 	.field assembly static int32 __jroc_dynamicLookup_26
 	.field assembly static int32 __jroc_dynamicLookup_27
-	.field assembly static int32 __jroc_dynamicLookup_28
 
 } // end of class Jroc.Generated.DynamicLookupSites
 

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StrictBareCalls_PreserveThisAndDirectFastPath.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StrictBareCalls_PreserveThisAndDirectFastPath.verified.txt
@@ -1,0 +1,860 @@
+﻿// IL code: Function_StrictBareCalls_PreserveThisAndDirectFastPath
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi abstract sealed beforefieldinit Function_StrictBareCalls_PreserveThisAndDirectFastPath
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit Scripts
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit Function_StrictBareCalls_PreserveThisAndDirectFastPath
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig static 
+				void Run (
+					string[] args
+				) cil managed 
+			{
+				.param [1]
+					.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+						01 00 00 00
+					)
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldftn void Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+				IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+				IL_000c: ldstr "Function_StrictBareCalls_PreserveThisAndDirectFastPath"
+				IL_0011: ldarg.0
+				IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+				IL_0017: ret
+			} // end of method Function_StrictBareCalls_PreserveThisAndDirectFastPath::Run
+
+		} // end of class Function_StrictBareCalls_PreserveThisAndDirectFastPath
+
+
+	} // end of class Scripts
+
+
+	// Methods
+	.method public hidebysig static 
+		void Run (
+			string[] args
+		) cil managed 
+	{
+		.param [1]
+			.custom instance void [System.Runtime]System.ParamArrayAttribute::.ctor() = (
+				01 00 00 00
+			)
+		// Header size: 1
+		// Code size: 24 (0x18)
+		.maxstack 8
+
+		IL_0000: ldnull
+		IL_0001: ldftn void Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_0007: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_000c: ldstr "Function_StrictBareCalls_PreserveThisAndDirectFastPath"
+		IL_0011: ldarg.0
+		IL_0012: call void [JavaScriptRuntime]Jroc.Runtime.CompiledScriptRunner::Run(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate, string, string[])
+		IL_0017: ret
+	} // end of method Function_StrictBareCalls_PreserveThisAndDirectFastPath::Run
+
+} // end of class Function_StrictBareCalls_PreserveThisAndDirectFastPath
+
+.class private auto ansi beforefieldinit Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit increment
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/increment::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/increment::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				float64 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 17 (0x11)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: ldc.r8 1
+			IL_000a: add
+			IL_000b: box [System.Runtime]System.Double
+			IL_0010: ret
+		} // end of method increment::__js_call__
+
+	} // end of class increment
+
+	.class nested public auto ansi abstract sealed beforefieldinit directThis
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 22 (0x16)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: call object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/directThis::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0015: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 22 (0x16)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: call object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/directThis::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0015: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 12 (0xc)
+			.maxstack 8
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+			IL_000b: ret
+		} // end of method directThis::__js_call__
+
+	} // end of class directThis
+
+	.class nested public auto ansi abstract sealed beforefieldinit nestedArrowThis
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit ArrowFunction_L12C13
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _lexicalThis
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 22 (0x16)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldc.i4.1
+					IL_0008: ldc.i4.1
+					IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+					IL_000e: ldarg.0
+					IL_000f: ldarg.1
+					IL_0010: stfld class [System.Runtime]System.Object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/ArrowFunction_L12C13/FunctionObject::_lexicalThis
+					IL_0015: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/ArrowFunction_L12C13/FunctionObject::_lexicalThis
+					IL_0006: ret
+				} // end of method FunctionObject::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 22 (0x16)
+					.maxstack 8
+
+					IL_0000: ldnull
+					IL_0001: ldc.i4.1
+					IL_0002: ldarg.1
+					IL_0003: ldarg.2
+					IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0009: ldarg.0
+					IL_000a: ldnull
+					IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+					IL_0010: call object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/ArrowFunction_L12C13::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+					IL_0015: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget,
+					valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 00 00 00 00 00 00
+				)
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+				IL_000b: ret
+			} // end of method ArrowFunction_L12C13::__js_call__
+
+		} // end of class ArrowFunction_L12C13
+
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 15 (0xf)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 22 (0x16)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldnull
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: call object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0015: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 22 (0x16)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldc.i4.1
+				IL_0002: ldarg.1
+				IL_0003: ldarg.2
+				IL_0004: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0009: ldarg.0
+				IL_000a: ldarg.3
+				IL_000b: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0010: call object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis::__js_call__(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0015: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 57 (0x39)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/Scope,
+				[1] object[],
+				[2] class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/ArrowFunction_L12C13/FunctionObject,
+				[3] object
+			)
+
+			IL_0000: newobj instance void Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_000b: stloc.1
+			IL_000c: ldarg.1
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+			IL_0012: newobj instance void Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/ArrowFunction_L12C13/FunctionObject::.ctor(class [System.Runtime]System.Object)
+			IL_0017: ldc.i4.0
+			IL_0018: conv.r8
+			IL_0019: ldstr ""
+			IL_001e: ldc.i4.0
+			IL_001f: ldc.i4.0
+			IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/ArrowFunction_L12C13/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/ArrowFunction_L12C13/FunctionObject>(!!0)
+			IL_002a: stloc.2
+			IL_002b: ldloc.2
+			IL_002c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0036: stloc.3
+			IL_0037: ldloc.3
+			IL_0038: ret
+		} // end of method nestedArrowThis::__js_call__
+
+	} // end of class nestedArrowThis
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 57 53 63 6f 70 65 20 69 6e 63 72 65 6d 65
+			6e 74 3d 7b 69 6e 63 72 65 6d 65 6e 74 7d 2c 20
+			64 69 72 65 63 74 54 68 69 73 3d 7b 64 69 72 65
+			63 74 54 68 69 73 7d 2c 20 6e 65 73 74 65 64 41
+			72 72 6f 77 54 68 69 73 3d 7b 6e 65 73 74 65 64
+			41 72 72 6f 77 54 68 69 73 7d 00 00
+		)
+		// Fields
+		.field public object increment
+		.field public object directThis
+		.field public object nestedArrowThis
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 239 (0xef)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/Scope,
+			[1] class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/increment/FunctionObject,
+			[2] class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/directThis/FunctionObject,
+			[3] class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/FunctionObject,
+			[4] object[],
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[6] object,
+			[7] bool,
+			[8] object
+		)
+
+		IL_0000: newobj instance void Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldloc.0
+		IL_000f: stelem.ref
+		IL_0010: stloc.s 4
+		IL_0012: newobj instance void Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/increment/FunctionObject::.ctor()
+		IL_0017: ldc.i4.1
+		IL_0018: conv.r8
+		IL_0019: ldstr "increment"
+		IL_001e: ldc.i4.0
+		IL_001f: ldc.i4.0
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/increment/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: stloc.1
+		IL_0026: ldc.i4.1
+		IL_0027: newarr [System.Runtime]System.Object
+		IL_002c: dup
+		IL_002d: ldc.i4.0
+		IL_002e: ldloc.0
+		IL_002f: stelem.ref
+		IL_0030: stloc.s 4
+		IL_0032: newobj instance void Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/directThis/FunctionObject::.ctor()
+		IL_0037: ldc.i4.0
+		IL_0038: conv.r8
+		IL_0039: ldstr "directThis"
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.i4.0
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/directThis/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.2
+		IL_0046: ldc.i4.1
+		IL_0047: newarr [System.Runtime]System.Object
+		IL_004c: dup
+		IL_004d: ldc.i4.0
+		IL_004e: ldloc.0
+		IL_004f: stelem.ref
+		IL_0050: stloc.s 4
+		IL_0052: newobj instance void Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/FunctionObject::.ctor()
+		IL_0057: ldc.i4.0
+		IL_0058: conv.r8
+		IL_0059: ldstr "nestedArrowThis"
+		IL_005e: ldc.i4.0
+		IL_005f: ldc.i4.0
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/nestedArrowThis/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0065: stloc.3
+		IL_0066: nop
+		IL_0067: nop
+		IL_0068: nop
+		IL_0069: nop
+		IL_006a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006f: stloc.s 5
+		IL_0071: ldnull
+		IL_0072: ldc.r8 41
+		IL_007b: call object Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath/increment::__js_call__(object, float64)
+		IL_0080: stloc.s 6
+		IL_0082: ldloc.s 5
+		IL_0084: ldloc.s 6
+		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008b: pop
+		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0091: stloc.s 5
+		IL_0093: ldloc.2
+		IL_0094: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_009e: stloc.s 6
+		IL_00a0: ldloc.s 6
+		IL_00a2: ldnull
+		IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00a8: stloc.s 7
+		IL_00aa: ldloc.s 7
+		IL_00ac: box [System.Runtime]System.Boolean
+		IL_00b1: stloc.s 8
+		IL_00b3: ldloc.s 5
+		IL_00b5: ldloc.s 8
+		IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00bc: pop
+		IL_00bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c2: stloc.s 5
+		IL_00c4: ldloc.3
+		IL_00c5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00cf: stloc.s 6
+		IL_00d1: ldloc.s 6
+		IL_00d3: ldnull
+		IL_00d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00d9: stloc.s 7
+		IL_00db: ldloc.s 7
+		IL_00dd: box [System.Runtime]System.Boolean
+		IL_00e2: stloc.s 8
+		IL_00e4: ldloc.s 5
+		IL_00e6: ldloc.s 8
+		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ed: pop
+		IL_00ee: ret
+	} // end of method Function_StrictBareCalls_PreserveThisAndDirectFastPath::__js_module_init__
+
+} // end of class Modules.Function_StrictBareCalls_PreserveThisAndDirectFastPath
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main (
+			string[] args
+		) cil managed 
+	{
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: ldarg.0
+		IL_0001: call void Function_StrictBareCalls_PreserveThisAndDirectFastPath::Run(string[])
+		IL_0006: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
@@ -2152,7 +2152,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 781 (0x30d)
+		// Code size: 687 (0x2af)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope,
@@ -2163,15 +2163,14 @@
 			[5] float64,
 			[6] object[],
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[8] object[],
-			[9] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/FunctionObject,
-			[10] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41/FunctionObject,
-			[11] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37/FunctionObject,
-			[12] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36/FunctionObject,
-			[13] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37/FunctionObject,
-			[14] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38/FunctionObject,
-			[15] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34/FunctionObject,
-			[16] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35/FunctionObject
+			[8] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/FunctionObject,
+			[9] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41/FunctionObject,
+			[10] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37/FunctionObject,
+			[11] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36/FunctionObject,
+			[12] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37/FunctionObject,
+			[13] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38/FunctionObject,
+			[14] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34/FunctionObject,
+			[15] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::.ctor()
@@ -2241,254 +2240,226 @@
 		IL_0089: nop
 		IL_008a: nop
 		IL_008b: nop
-		IL_008c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0091: stloc.s 6
-		IL_0093: ldloc.1
-		IL_0094: ldloc.s 6
-		IL_0096: ldstr "dromaeo-object-array"
-		IL_009b: ldstr "bde4f5f4"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00a5: pop
-		IL_00a6: ldc.i4.0
-		IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00ac: stloc.s 7
-		IL_00ae: ldloc.0
-		IL_00af: ldloc.s 7
-		IL_00b1: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-		IL_00b6: ldloc.0
-		IL_00b7: ldnull
-		IL_00b8: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-		IL_00bd: ldc.r8 500
-		IL_00c6: stloc.s 5
-		IL_00c8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00cd: stloc.s 6
-		IL_00cf: ldc.i4.1
-		IL_00d0: newarr [System.Runtime]System.Object
-		IL_00d5: dup
-		IL_00d6: ldc.i4.0
-		IL_00d7: ldloc.0
-		IL_00d8: stelem.ref
-		IL_00d9: stloc.s 8
-		IL_00db: ldloc.s 8
-		IL_00dd: ldc.i4.0
-		IL_00de: ldelem.ref
-		IL_00df: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_00e4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
-		IL_00e9: ldc.i4.0
-		IL_00ea: conv.r8
-		IL_00eb: ldstr ""
-		IL_00f0: ldc.i4.0
-		IL_00f1: ldc.i4.0
-		IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/FunctionObject>(!!0)
-		IL_00fc: stloc.s 9
-		IL_00fe: ldloc.s 4
-		IL_0100: ldloc.s 6
-		IL_0102: ldstr "Array Construction, []"
-		IL_0107: ldloc.s 9
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_010e: pop
-		IL_010f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0114: stloc.s 6
-		IL_0116: ldc.i4.1
-		IL_0117: newarr [System.Runtime]System.Object
-		IL_011c: dup
+		IL_008c: ldnull
+		IL_008d: ldstr "dromaeo-object-array"
+		IL_0092: ldstr "bde4f5f4"
+		IL_0097: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest::__js_call__(object, string, string)
+		IL_009c: pop
+		IL_009d: ldc.i4.0
+		IL_009e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00a3: stloc.s 7
+		IL_00a5: ldloc.0
+		IL_00a6: ldloc.s 7
+		IL_00a8: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+		IL_00ad: ldloc.0
+		IL_00ae: ldnull
+		IL_00af: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+		IL_00b4: ldc.r8 500
+		IL_00bd: stloc.s 5
+		IL_00bf: ldc.i4.1
+		IL_00c0: newarr [System.Runtime]System.Object
+		IL_00c5: dup
+		IL_00c6: ldc.i4.0
+		IL_00c7: ldloc.0
+		IL_00c8: stelem.ref
+		IL_00c9: stloc.s 6
+		IL_00cb: ldloc.s 6
+		IL_00cd: ldc.i4.0
+		IL_00ce: ldelem.ref
+		IL_00cf: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_00d4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
+		IL_00d9: ldc.i4.0
+		IL_00da: conv.r8
+		IL_00db: ldstr ""
+		IL_00e0: ldc.i4.0
+		IL_00e1: ldc.i4.0
+		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32/FunctionObject>(!!0)
+		IL_00ec: stloc.s 8
+		IL_00ee: ldnull
+		IL_00ef: ldstr "Array Construction, []"
+		IL_00f4: ldloc.s 8
+		IL_00f6: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+		IL_00fb: pop
+		IL_00fc: ldc.i4.1
+		IL_00fd: newarr [System.Runtime]System.Object
+		IL_0102: dup
+		IL_0103: ldc.i4.0
+		IL_0104: ldloc.0
+		IL_0105: stelem.ref
+		IL_0106: stloc.s 6
+		IL_0108: ldloc.s 6
+		IL_010a: ldc.i4.0
+		IL_010b: ldelem.ref
+		IL_010c: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0111: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
+		IL_0116: ldc.i4.0
+		IL_0117: conv.r8
+		IL_0118: ldstr ""
 		IL_011d: ldc.i4.0
-		IL_011e: ldloc.0
-		IL_011f: stelem.ref
-		IL_0120: stloc.s 8
-		IL_0122: ldloc.s 8
-		IL_0124: ldc.i4.0
-		IL_0125: ldelem.ref
-		IL_0126: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_012b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
-		IL_0130: ldc.i4.0
-		IL_0131: conv.r8
-		IL_0132: ldstr ""
-		IL_0137: ldc.i4.0
-		IL_0138: ldc.i4.0
-		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41/FunctionObject>(!!0)
-		IL_0143: stloc.s 10
-		IL_0145: ldloc.s 4
-		IL_0147: ldloc.s 6
-		IL_0149: ldstr "Array Construction, new Array()"
-		IL_014e: ldloc.s 10
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0155: pop
-		IL_0156: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_015b: stloc.s 6
-		IL_015d: ldc.i4.1
-		IL_015e: newarr [System.Runtime]System.Object
-		IL_0163: dup
-		IL_0164: ldc.i4.0
-		IL_0165: ldloc.0
-		IL_0166: stelem.ref
-		IL_0167: stloc.s 8
-		IL_0169: ldloc.s 8
-		IL_016b: ldc.i4.0
-		IL_016c: ldelem.ref
-		IL_016d: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0172: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
-		IL_0177: ldc.i4.0
-		IL_0178: conv.r8
-		IL_0179: ldstr ""
-		IL_017e: ldc.i4.0
-		IL_017f: ldc.i4.0
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37/FunctionObject>(!!0)
-		IL_018a: stloc.s 11
-		IL_018c: ldloc.s 4
-		IL_018e: ldloc.s 6
-		IL_0190: ldstr "Array Construction, unshift"
-		IL_0195: ldloc.s 11
-		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_019c: pop
-		IL_019d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01a2: stloc.s 6
-		IL_01a4: ldc.i4.1
-		IL_01a5: newarr [System.Runtime]System.Object
-		IL_01aa: dup
-		IL_01ab: ldc.i4.0
-		IL_01ac: ldloc.0
-		IL_01ad: stelem.ref
-		IL_01ae: stloc.s 8
-		IL_01b0: ldloc.s 8
-		IL_01b2: ldc.i4.0
-		IL_01b3: ldelem.ref
-		IL_01b4: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_01b9: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
-		IL_01be: ldc.i4.0
-		IL_01bf: conv.r8
-		IL_01c0: ldstr ""
-		IL_01c5: ldc.i4.0
-		IL_01c6: ldc.i4.0
-		IL_01c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36/FunctionObject>(!!0)
-		IL_01d1: stloc.s 12
-		IL_01d3: ldloc.s 4
-		IL_01d5: ldloc.s 6
-		IL_01d7: ldstr "Array Construction, splice"
-		IL_01dc: ldloc.s 12
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01e3: pop
-		IL_01e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01e9: stloc.s 6
-		IL_01eb: ldc.i4.1
-		IL_01ec: newarr [System.Runtime]System.Object
-		IL_01f1: dup
-		IL_01f2: ldc.i4.0
-		IL_01f3: ldloc.0
-		IL_01f4: stelem.ref
-		IL_01f5: stloc.s 8
-		IL_01f7: ldloc.s 8
-		IL_01f9: ldc.i4.0
-		IL_01fa: ldelem.ref
-		IL_01fb: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0200: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
-		IL_0205: ldc.i4.0
-		IL_0206: conv.r8
-		IL_0207: ldstr ""
-		IL_020c: ldc.i4.0
-		IL_020d: ldc.i4.0
-		IL_020e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0213: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37/FunctionObject>(!!0)
-		IL_0218: stloc.s 13
-		IL_021a: ldloc.s 4
-		IL_021c: ldloc.s 6
-		IL_021e: ldstr "Array Deconstruction, shift"
-		IL_0223: ldloc.s 13
-		IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_022a: pop
-		IL_022b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0230: stloc.s 6
-		IL_0232: ldc.i4.1
-		IL_0233: newarr [System.Runtime]System.Object
-		IL_0238: dup
-		IL_0239: ldc.i4.0
-		IL_023a: ldloc.0
-		IL_023b: stelem.ref
-		IL_023c: stloc.s 8
-		IL_023e: ldloc.s 8
-		IL_0240: ldc.i4.0
-		IL_0241: ldelem.ref
-		IL_0242: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0247: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
-		IL_024c: ldc.i4.0
-		IL_024d: conv.r8
-		IL_024e: ldstr ""
-		IL_0253: ldc.i4.0
-		IL_0254: ldc.i4.0
-		IL_0255: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38/FunctionObject>(!!0)
-		IL_025f: stloc.s 14
-		IL_0261: ldloc.s 4
-		IL_0263: ldloc.s 6
-		IL_0265: ldstr "Array Deconstruction, splice"
-		IL_026a: ldloc.s 14
-		IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0271: pop
-		IL_0272: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0277: stloc.s 6
-		IL_0279: ldc.i4.1
-		IL_027a: newarr [System.Runtime]System.Object
-		IL_027f: dup
-		IL_0280: ldc.i4.0
-		IL_0281: ldloc.0
-		IL_0282: stelem.ref
-		IL_0283: stloc.s 8
-		IL_0285: ldloc.s 8
-		IL_0287: ldc.i4.0
-		IL_0288: ldelem.ref
-		IL_0289: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_028e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
-		IL_0293: ldc.i4.0
-		IL_0294: conv.r8
-		IL_0295: ldstr ""
-		IL_029a: ldc.i4.0
-		IL_029b: ldc.i4.0
-		IL_029c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34/FunctionObject>(!!0)
-		IL_02a6: stloc.s 15
-		IL_02a8: ldloc.s 4
-		IL_02aa: ldloc.s 6
-		IL_02ac: ldstr "Array Construction, push"
-		IL_02b1: ldloc.s 15
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02b8: pop
-		IL_02b9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02be: stloc.s 6
-		IL_02c0: ldc.i4.1
-		IL_02c1: newarr [System.Runtime]System.Object
-		IL_02c6: dup
-		IL_02c7: ldc.i4.0
-		IL_02c8: ldloc.0
-		IL_02c9: stelem.ref
-		IL_02ca: stloc.s 8
-		IL_02cc: ldloc.s 8
-		IL_02ce: ldc.i4.0
-		IL_02cf: ldelem.ref
-		IL_02d0: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_02d5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
-		IL_02da: ldc.i4.0
-		IL_02db: conv.r8
-		IL_02dc: ldstr ""
-		IL_02e1: ldc.i4.0
-		IL_02e2: ldc.i4.0
-		IL_02e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35/FunctionObject>(!!0)
-		IL_02ed: stloc.s 16
-		IL_02ef: ldloc.s 4
-		IL_02f1: ldloc.s 6
-		IL_02f3: ldstr "Array Deconstruction, pop"
-		IL_02f8: ldloc.s 16
-		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02ff: pop
-		IL_0300: ldloc.2
-		IL_0301: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_030b: pop
-		IL_030c: ret
+		IL_011e: ldc.i4.0
+		IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41/FunctionObject>(!!0)
+		IL_0129: stloc.s 9
+		IL_012b: ldnull
+		IL_012c: ldstr "Array Construction, new Array()"
+		IL_0131: ldloc.s 9
+		IL_0133: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+		IL_0138: pop
+		IL_0139: ldc.i4.1
+		IL_013a: newarr [System.Runtime]System.Object
+		IL_013f: dup
+		IL_0140: ldc.i4.0
+		IL_0141: ldloc.0
+		IL_0142: stelem.ref
+		IL_0143: stloc.s 6
+		IL_0145: ldloc.s 6
+		IL_0147: ldc.i4.0
+		IL_0148: ldelem.ref
+		IL_0149: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_014e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
+		IL_0153: ldc.i4.0
+		IL_0154: conv.r8
+		IL_0155: ldstr ""
+		IL_015a: ldc.i4.0
+		IL_015b: ldc.i4.0
+		IL_015c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37/FunctionObject>(!!0)
+		IL_0166: stloc.s 10
+		IL_0168: ldnull
+		IL_0169: ldstr "Array Construction, unshift"
+		IL_016e: ldloc.s 10
+		IL_0170: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+		IL_0175: pop
+		IL_0176: ldc.i4.1
+		IL_0177: newarr [System.Runtime]System.Object
+		IL_017c: dup
+		IL_017d: ldc.i4.0
+		IL_017e: ldloc.0
+		IL_017f: stelem.ref
+		IL_0180: stloc.s 6
+		IL_0182: ldloc.s 6
+		IL_0184: ldc.i4.0
+		IL_0185: ldelem.ref
+		IL_0186: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_018b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
+		IL_0190: ldc.i4.0
+		IL_0191: conv.r8
+		IL_0192: ldstr ""
+		IL_0197: ldc.i4.0
+		IL_0198: ldc.i4.0
+		IL_0199: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_019e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36/FunctionObject>(!!0)
+		IL_01a3: stloc.s 11
+		IL_01a5: ldnull
+		IL_01a6: ldstr "Array Construction, splice"
+		IL_01ab: ldloc.s 11
+		IL_01ad: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+		IL_01b2: pop
+		IL_01b3: ldc.i4.1
+		IL_01b4: newarr [System.Runtime]System.Object
+		IL_01b9: dup
+		IL_01ba: ldc.i4.0
+		IL_01bb: ldloc.0
+		IL_01bc: stelem.ref
+		IL_01bd: stloc.s 6
+		IL_01bf: ldloc.s 6
+		IL_01c1: ldc.i4.0
+		IL_01c2: ldelem.ref
+		IL_01c3: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_01c8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
+		IL_01cd: ldc.i4.0
+		IL_01ce: conv.r8
+		IL_01cf: ldstr ""
+		IL_01d4: ldc.i4.0
+		IL_01d5: ldc.i4.0
+		IL_01d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37/FunctionObject>(!!0)
+		IL_01e0: stloc.s 12
+		IL_01e2: ldnull
+		IL_01e3: ldstr "Array Deconstruction, shift"
+		IL_01e8: ldloc.s 12
+		IL_01ea: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+		IL_01ef: pop
+		IL_01f0: ldc.i4.1
+		IL_01f1: newarr [System.Runtime]System.Object
+		IL_01f6: dup
+		IL_01f7: ldc.i4.0
+		IL_01f8: ldloc.0
+		IL_01f9: stelem.ref
+		IL_01fa: stloc.s 6
+		IL_01fc: ldloc.s 6
+		IL_01fe: ldc.i4.0
+		IL_01ff: ldelem.ref
+		IL_0200: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0205: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
+		IL_020a: ldc.i4.0
+		IL_020b: conv.r8
+		IL_020c: ldstr ""
+		IL_0211: ldc.i4.0
+		IL_0212: ldc.i4.0
+		IL_0213: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0218: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38/FunctionObject>(!!0)
+		IL_021d: stloc.s 13
+		IL_021f: ldnull
+		IL_0220: ldstr "Array Deconstruction, splice"
+		IL_0225: ldloc.s 13
+		IL_0227: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+		IL_022c: pop
+		IL_022d: ldc.i4.1
+		IL_022e: newarr [System.Runtime]System.Object
+		IL_0233: dup
+		IL_0234: ldc.i4.0
+		IL_0235: ldloc.0
+		IL_0236: stelem.ref
+		IL_0237: stloc.s 6
+		IL_0239: ldloc.s 6
+		IL_023b: ldc.i4.0
+		IL_023c: ldelem.ref
+		IL_023d: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0242: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
+		IL_0247: ldc.i4.0
+		IL_0248: conv.r8
+		IL_0249: ldstr ""
+		IL_024e: ldc.i4.0
+		IL_024f: ldc.i4.0
+		IL_0250: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0255: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34/FunctionObject>(!!0)
+		IL_025a: stloc.s 14
+		IL_025c: ldnull
+		IL_025d: ldstr "Array Construction, push"
+		IL_0262: ldloc.s 14
+		IL_0264: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+		IL_0269: pop
+		IL_026a: ldc.i4.1
+		IL_026b: newarr [System.Runtime]System.Object
+		IL_0270: dup
+		IL_0271: ldc.i4.0
+		IL_0272: ldloc.0
+		IL_0273: stelem.ref
+		IL_0274: stloc.s 6
+		IL_0276: ldloc.s 6
+		IL_0278: ldc.i4.0
+		IL_0279: ldelem.ref
+		IL_027a: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_027f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope)
+		IL_0284: ldc.i4.0
+		IL_0285: conv.r8
+		IL_0286: ldstr ""
+		IL_028b: ldc.i4.0
+		IL_028c: ldc.i4.0
+		IL_028d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35/FunctionObject>(!!0)
+		IL_0297: stloc.s 15
+		IL_0299: ldnull
+		IL_029a: ldstr "Array Deconstruction, pop"
+		IL_029f: ldloc.s 15
+		IL_02a1: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+		IL_02a6: pop
+		IL_02a7: ldnull
+		IL_02a8: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
+		IL_02ad: pop
+		IL_02ae: ret
 	} // end of method Compile_Performance_Dromaeo_Object_Array_Modern::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Array_Modern

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -1067,7 +1067,7 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 576 (0x240)
+			// Code size: 516 (0x204)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1076,7 +1076,7 @@
 				[3] float64,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[5] float64,
-				[6] object,
+				[6] string,
 				[7] object,
 				[8] object,
 				[9] float64,
@@ -1120,196 +1120,168 @@
 				IL_005f: ldloc.s 5
 				IL_0061: ldarg.2
 				IL_0062: clt
-				IL_0064: brfalse IL_0234
+				IL_0064: brfalse IL_01f8
 
-				IL_0069: ldarg.0
-				IL_006a: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-				IL_006f: ldc.i4.1
-				IL_0070: newarr [System.Runtime]System.Object
-				IL_0075: dup
-				IL_0076: ldc.i4.0
-				IL_0077: ldarg.0
-				IL_0078: stelem.ref
-				IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_007e: stloc.s 6
-				IL_0080: ldarg.0
-				IL_0081: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-				IL_0086: stloc.s 7
-				IL_0088: ldloc.s 6
-				IL_008a: ldloc.s 7
-				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0091: stloc.s 8
-				IL_0093: ldarg.0
-				IL_0094: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-				IL_0099: ldc.i4.1
-				IL_009a: newarr [System.Runtime]System.Object
-				IL_009f: dup
-				IL_00a0: ldc.i4.0
-				IL_00a1: ldarg.0
-				IL_00a2: stelem.ref
-				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_00a8: stloc.s 7
-				IL_00aa: ldloc.s 8
-				IL_00ac: ldloc.s 7
-				IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_00b3: stloc.s 8
-				IL_00b5: ldloc.s 8
-				IL_00b7: stloc.0
-				IL_00b8: ldc.r8 4
-				IL_00c1: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-				IL_00c6: mul
-				IL_00c7: box [System.Runtime]System.Double
-				IL_00cc: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-				IL_00d1: stloc.s 5
-				IL_00d3: ldloc.s 5
-				IL_00d5: stloc.2
-				IL_00d6: ldc.r8 0.0
-				IL_00df: stloc.3
-				// loop start (head: IL_00e0)
-					IL_00e0: ldloc.3
-					IL_00e1: stloc.s 5
-					IL_00e3: ldloc.s 5
-					IL_00e5: ldloc.2
-					IL_00e6: clt
-					IL_00e8: brfalse IL_0144
+				IL_0069: ldnull
+				IL_006a: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+				IL_006f: stloc.s 6
+				IL_0071: ldarg.0
+				IL_0072: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+				IL_0077: stloc.s 7
+				IL_0079: ldloc.s 6
+				IL_007b: ldloc.s 7
+				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0082: stloc.s 8
+				IL_0084: ldnull
+				IL_0085: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+				IL_008a: stloc.s 6
+				IL_008c: ldloc.s 8
+				IL_008e: ldloc.s 6
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0095: stloc.s 8
+				IL_0097: ldloc.s 8
+				IL_0099: stloc.0
+				IL_009a: ldc.r8 4
+				IL_00a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+				IL_00a8: mul
+				IL_00a9: box [System.Runtime]System.Double
+				IL_00ae: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+				IL_00b3: stloc.s 5
+				IL_00b5: ldloc.s 5
+				IL_00b7: stloc.2
+				IL_00b8: ldc.r8 0.0
+				IL_00c1: stloc.3
+				// loop start (head: IL_00c2)
+					IL_00c2: ldloc.3
+					IL_00c3: stloc.s 5
+					IL_00c5: ldloc.s 5
+					IL_00c7: ldloc.2
+					IL_00c8: clt
+					IL_00ca: brfalse IL_0108
 
-					IL_00ed: ldarg.0
-					IL_00ee: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-					IL_00f3: ldc.i4.1
-					IL_00f4: newarr [System.Runtime]System.Object
-					IL_00f9: dup
-					IL_00fa: ldc.i4.0
-					IL_00fb: ldarg.0
-					IL_00fc: stelem.ref
-					IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-					IL_0102: stloc.s 7
-					IL_0104: ldloc.s 7
-					IL_0106: ldloc.0
-					IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_010c: stloc.s 8
-					IL_010e: ldarg.0
-					IL_010f: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-					IL_0114: ldc.i4.1
-					IL_0115: newarr [System.Runtime]System.Object
-					IL_011a: dup
-					IL_011b: ldc.i4.0
-					IL_011c: ldarg.0
-					IL_011d: stelem.ref
-					IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-					IL_0123: stloc.s 7
-					IL_0125: ldloc.s 8
-					IL_0127: ldloc.s 7
-					IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_012e: stloc.s 8
-					IL_0130: ldloc.s 8
-					IL_0132: stloc.0
-					IL_0133: ldloc.3
-					IL_0134: ldc.r8 1
-					IL_013d: add
-					IL_013e: stloc.3
-					IL_013f: br IL_00e0
+					IL_00cf: ldnull
+					IL_00d0: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+					IL_00d5: stloc.s 6
+					IL_00d7: ldloc.s 6
+					IL_00d9: ldloc.0
+					IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_00df: stloc.s 8
+					IL_00e1: ldnull
+					IL_00e2: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+					IL_00e7: stloc.s 6
+					IL_00e9: ldloc.s 8
+					IL_00eb: ldloc.s 6
+					IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_00f2: stloc.s 8
+					IL_00f4: ldloc.s 8
+					IL_00f6: stloc.0
+					IL_00f7: ldloc.3
+					IL_00f8: ldc.r8 1
+					IL_0101: add
+					IL_0102: stloc.3
+					IL_0103: br IL_00c2
 				// end loop
 
-				IL_0144: ldc.r8 0.0
-				IL_014d: stloc.3
-				// loop start (head: IL_014e)
-					IL_014e: ldloc.3
-					IL_014f: stloc.s 5
-					IL_0151: ldloc.0
-					IL_0152: castclass [System.Runtime]System.String
-					IL_0157: callvirt instance int32 [System.Runtime]System.String::get_Length()
-					IL_015c: conv.r8
-					IL_015d: stloc.s 9
-					IL_015f: ldloc.s 5
-					IL_0161: ldloc.s 9
-					IL_0163: clt
-					IL_0165: brfalse IL_0210
+				IL_0108: ldc.r8 0.0
+				IL_0111: stloc.3
+				// loop start (head: IL_0112)
+					IL_0112: ldloc.3
+					IL_0113: stloc.s 5
+					IL_0115: ldloc.0
+					IL_0116: castclass [System.Runtime]System.String
+					IL_011b: callvirt instance int32 [System.Runtime]System.String::get_Length()
+					IL_0120: conv.r8
+					IL_0121: stloc.s 9
+					IL_0123: ldloc.s 5
+					IL_0125: ldloc.s 9
+					IL_0127: clt
+					IL_0129: brfalse IL_01d4
 
-					IL_016a: ldloc.0
-					IL_016b: ldloc.3
-					IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-					IL_0171: stloc.s 7
-					IL_0173: ldarg.0
+					IL_012e: ldloc.0
+					IL_012f: ldloc.3
+					IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_0135: stloc.s 7
+					IL_0137: ldarg.0
+					IL_0138: ldloc.s 7
+					IL_013a: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_013f: ldloc.0
+					IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0145: stloc.s 7
+					IL_0147: ldloc.3
+					IL_0148: box [System.Runtime]System.Double
+					IL_014d: stloc.s 10
+					IL_014f: ldloc.3
+					IL_0150: stloc.s 9
+					IL_0152: ldloc.s 9
+					IL_0154: ldc.r8 100
+					IL_015d: add
+					IL_015e: stloc.s 9
+					IL_0160: ldloc.s 9
+					IL_0162: box [System.Runtime]System.Double
+					IL_0167: stloc.s 11
+					IL_0169: ldc.i4.0
+					IL_016a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+					IL_016f: brfalse IL_01a5
+
 					IL_0174: ldloc.s 7
-					IL_0176: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_017b: ldloc.0
-					IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0181: stloc.s 7
-					IL_0183: ldloc.3
-					IL_0184: box [System.Runtime]System.Double
-					IL_0189: stloc.s 10
-					IL_018b: ldloc.3
-					IL_018c: stloc.s 9
-					IL_018e: ldloc.s 9
-					IL_0190: ldc.r8 100
-					IL_0199: add
-					IL_019a: stloc.s 9
-					IL_019c: ldloc.s 9
-					IL_019e: box [System.Runtime]System.Double
-					IL_01a3: stloc.s 11
-					IL_01a5: ldc.i4.0
-					IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-					IL_01ab: brfalse IL_01e1
+					IL_0176: isinst [System.Runtime]System.String
+					IL_017b: dup
+					IL_017c: brtrue IL_0194
 
-					IL_01b0: ldloc.s 7
-					IL_01b2: isinst [System.Runtime]System.String
-					IL_01b7: dup
-					IL_01b8: brtrue IL_01d0
+					IL_0181: pop
+					IL_0182: ldloc.s 7
+					IL_0184: ldstr "substring"
+					IL_0189: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+					IL_018e: dup
+					IL_018f: brfalse IL_01a4
 
-					IL_01bd: pop
-					IL_01be: ldloc.s 7
-					IL_01c0: ldstr "substring"
-					IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-					IL_01ca: dup
-					IL_01cb: brfalse IL_01e0
+					IL_0194: ldloc.s 10
+					IL_0196: ldloc.s 11
+					IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+					IL_019d: stloc.s 7
+					IL_019f: br IL_01b7
 
-					IL_01d0: ldloc.s 10
-					IL_01d2: ldloc.s 11
-					IL_01d4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-					IL_01d9: stloc.s 7
-					IL_01db: br IL_01f3
+					IL_01a4: pop
 
-					IL_01e0: pop
+					IL_01a5: ldloc.s 7
+					IL_01a7: ldstr "substring"
+					IL_01ac: ldloc.s 10
+					IL_01ae: ldloc.s 11
+					IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_01b5: stloc.s 7
 
-					IL_01e1: ldloc.s 7
-					IL_01e3: ldstr "substring"
-					IL_01e8: ldloc.s 10
-					IL_01ea: ldloc.s 11
-					IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_01f1: stloc.s 7
-
-					IL_01f3: ldarg.0
-					IL_01f4: ldloc.s 7
-					IL_01f6: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_01fb: ldloc.3
-					IL_01fc: ldc.r8 100
-					IL_0205: add
-					IL_0206: stloc.s 9
-					IL_0208: ldloc.s 9
-					IL_020a: stloc.3
-					IL_020b: br IL_014e
+					IL_01b7: ldarg.0
+					IL_01b8: ldloc.s 7
+					IL_01ba: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_01bf: ldloc.3
+					IL_01c0: ldc.r8 100
+					IL_01c9: add
+					IL_01ca: stloc.s 9
+					IL_01cc: ldloc.s 9
+					IL_01ce: stloc.3
+					IL_01cf: br IL_0112
 				// end loop
 
-				IL_0210: ldarg.0
-				IL_0211: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-				IL_0216: stloc.s 7
-				IL_0218: ldloc.s 7
-				IL_021a: ldloc.1
-				IL_021b: ldloc.0
-				IL_021c: ldc.i4.1
-				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-				IL_0222: pop
-				IL_0223: ldloc.1
-				IL_0224: ldc.r8 1
-				IL_022d: add
-				IL_022e: stloc.1
-				IL_022f: br IL_005c
+				IL_01d4: ldarg.0
+				IL_01d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+				IL_01da: stloc.s 7
+				IL_01dc: ldloc.s 7
+				IL_01de: ldloc.1
+				IL_01df: ldloc.0
+				IL_01e0: ldc.i4.1
+				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+				IL_01e6: pop
+				IL_01e7: ldloc.1
+				IL_01e8: ldc.r8 1
+				IL_01f1: add
+				IL_01f2: stloc.1
+				IL_01f3: br IL_005c
 			// end loop
 
-			IL_0234: ldarg.0
-			IL_0235: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_023a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_023f: ret
+			IL_01f8: ldarg.0
+			IL_01f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_01fe: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0203: ret
 		} // end of method generateTestStrings::__js_call__
 
 	} // end of class generateTestStrings
@@ -1452,12 +1424,11 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object[],
-				[2] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "(?:)"
@@ -1468,25 +1439,16 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_001d: ldc.i4.1
-			IL_001e: newarr [System.Runtime]System.Object
-			IL_0023: dup
-			IL_0024: ldc.i4.0
-			IL_0025: ldarg.0
-			IL_0026: stelem.ref
-			IL_0027: stloc.1
-			IL_0028: ldloc.1
-			IL_0029: ldc.r8 30
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_003c: stloc.2
-			IL_003d: ldarg.0
-			IL_003e: ldloc.2
-			IL_003f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0044: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 30
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_002c: stloc.1
+			IL_002d: ldarg.0
+			IL_002e: ldloc.1
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L48C5::__js_call__
 
 	} // end of class FunctionExpression_L48C5
@@ -1833,12 +1795,11 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object[],
-				[2] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "a"
@@ -1849,25 +1810,16 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_001d: ldc.i4.1
-			IL_001e: newarr [System.Runtime]System.Object
-			IL_0023: dup
-			IL_0024: ldc.i4.0
-			IL_0025: ldarg.0
-			IL_0026: stelem.ref
-			IL_0027: stloc.1
-			IL_0028: ldloc.1
-			IL_0029: ldc.r8 30
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_003c: stloc.2
-			IL_003d: ldarg.0
-			IL_003e: ldloc.2
-			IL_003f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0044: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 30
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_002c: stloc.1
+			IL_002d: ldarg.0
+			IL_002e: ldloc.1
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L61C5::__js_call__
 
 	} // end of class FunctionExpression_L61C5
@@ -2214,12 +2166,11 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object[],
-				[2] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr ".*"
@@ -2230,25 +2181,16 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_001d: ldc.i4.1
-			IL_001e: newarr [System.Runtime]System.Object
-			IL_0023: dup
-			IL_0024: ldc.i4.0
-			IL_0025: ldarg.0
-			IL_0026: stelem.ref
-			IL_0027: stloc.1
-			IL_0028: ldloc.1
-			IL_0029: ldc.r8 100
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_003c: stloc.2
-			IL_003d: ldarg.0
-			IL_003e: ldloc.2
-			IL_003f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0044: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_002c: stloc.1
+			IL_002d: ldarg.0
+			IL_002e: ldloc.1
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L71C5::__js_call__
 
 	} // end of class FunctionExpression_L71C5
@@ -2595,12 +2537,11 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object[],
-				[2] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "aaaaaaaaaa"
@@ -2611,25 +2552,16 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_001d: ldc.i4.1
-			IL_001e: newarr [System.Runtime]System.Object
-			IL_0023: dup
-			IL_0024: ldc.i4.0
-			IL_0025: ldarg.0
-			IL_0026: stelem.ref
-			IL_0027: stloc.1
-			IL_0028: ldloc.1
-			IL_0029: ldc.r8 100
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_003c: stloc.2
-			IL_003d: ldarg.0
-			IL_003e: ldloc.2
-			IL_003f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0044: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_002c: stloc.1
+			IL_002d: ldarg.0
+			IL_002e: ldloc.1
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L83C5::__js_call__
 
 	} // end of class FunctionExpression_L83C5
@@ -2976,33 +2908,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 100
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L93C5::__js_call__
 
 	} // end of class FunctionExpression_L93C5
@@ -3334,33 +3256,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 100
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L102C5::__js_call__
 
 	} // end of class FunctionExpression_L102C5
@@ -3695,33 +3607,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L111C5::__js_call__
 
 	} // end of class FunctionExpression_L111C5
@@ -4056,12 +3958,11 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object[],
-				[2] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "aaaaaaaaaa"
@@ -4072,25 +3973,16 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_001d: ldc.i4.1
-			IL_001e: newarr [System.Runtime]System.Object
-			IL_0023: dup
-			IL_0024: ldc.i4.0
-			IL_0025: ldarg.0
-			IL_0026: stelem.ref
-			IL_0027: stloc.1
-			IL_0028: ldloc.1
-			IL_0029: ldc.r8 100
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_003c: stloc.2
-			IL_003d: ldarg.0
-			IL_003e: ldloc.2
-			IL_003f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0044: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_002c: stloc.1
+			IL_002d: ldarg.0
+			IL_002e: ldloc.1
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L120C5::__js_call__
 
 	} // end of class FunctionExpression_L120C5
@@ -4437,33 +4329,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 100
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L130C5::__js_call__
 
 	} // end of class FunctionExpression_L130C5
@@ -4795,33 +4677,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L139C5::__js_call__
 
 	} // end of class FunctionExpression_L139C5
@@ -5156,33 +5028,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L148C5::__js_call__
 
 	} // end of class FunctionExpression_L148C5
@@ -5517,33 +5379,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L157C5::__js_call__
 
 	} // end of class FunctionExpression_L157C5
@@ -6037,12 +5889,11 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object[],
-				[2] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "a.*a"
@@ -6053,25 +5904,16 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_001d: ldc.i4.1
-			IL_001e: newarr [System.Runtime]System.Object
-			IL_0023: dup
-			IL_0024: ldc.i4.0
-			IL_0025: ldarg.0
-			IL_0026: stelem.ref
-			IL_0027: stloc.1
-			IL_0028: ldloc.1
-			IL_0029: ldc.r8 100
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_003c: stloc.2
-			IL_003d: ldarg.0
-			IL_003e: ldloc.2
-			IL_003f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0044: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_002c: stloc.1
+			IL_002d: ldarg.0
+			IL_002e: ldloc.1
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L170C5::__js_call__
 
 	} // end of class FunctionExpression_L170C5
@@ -6418,33 +6260,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 100
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L180C5::__js_call__
 
 	} // end of class FunctionExpression_L180C5
@@ -6776,33 +6608,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L189C5::__js_call__
 
 	} // end of class FunctionExpression_L189C5
@@ -7137,33 +6959,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L198C5::__js_call__
 
 	} // end of class FunctionExpression_L198C5
@@ -7498,12 +7310,11 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object[],
-				[2] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "aaaaaaaaaa"
@@ -7514,25 +7325,16 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_001d: ldc.i4.1
-			IL_001e: newarr [System.Runtime]System.Object
-			IL_0023: dup
-			IL_0024: ldc.i4.0
-			IL_0025: ldarg.0
-			IL_0026: stelem.ref
-			IL_0027: stloc.1
-			IL_0028: ldloc.1
-			IL_0029: ldc.r8 100
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_003c: stloc.2
-			IL_003d: ldarg.0
-			IL_003e: ldloc.2
-			IL_003f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0044: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_002c: stloc.1
+			IL_002d: ldarg.0
+			IL_002e: ldloc.1
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L207C5::__js_call__
 
 	} // end of class FunctionExpression_L207C5
@@ -7879,33 +7681,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 100
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L217C5::__js_call__
 
 	} // end of class FunctionExpression_L217C5
@@ -8237,33 +8029,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L226C5::__js_call__
 
 	} // end of class FunctionExpression_L226C5
@@ -8598,33 +8380,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L235C5::__js_call__
 
 	} // end of class FunctionExpression_L235C5
@@ -8959,33 +8731,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L244C5::__js_call__
 
 	} // end of class FunctionExpression_L244C5
@@ -9479,12 +9241,11 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object[],
-				[2] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "aa(b)aa"
@@ -9495,25 +9256,16 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_001d: ldc.i4.1
-			IL_001e: newarr [System.Runtime]System.Object
-			IL_0023: dup
-			IL_0024: ldc.i4.0
-			IL_0025: ldarg.0
-			IL_0026: stelem.ref
-			IL_0027: stloc.1
-			IL_0028: ldloc.1
-			IL_0029: ldc.r8 100
-			IL_0032: box [System.Runtime]System.Double
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_003c: stloc.2
-			IL_003d: ldarg.0
-			IL_003e: ldloc.2
-			IL_003f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0044: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_002c: stloc.1
+			IL_002d: ldarg.0
+			IL_002e: ldloc.1
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L257C5::__js_call__
 
 	} // end of class FunctionExpression_L257C5
@@ -9860,33 +9612,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L267C5::__js_call__
 
 	} // end of class FunctionExpression_L267C5
@@ -10221,33 +9963,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L276C5::__js_call__
 
 	} // end of class FunctionExpression_L276C5
@@ -10582,33 +10314,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L285C5::__js_call__
 
 	} // end of class FunctionExpression_L285C5
@@ -11120,33 +10842,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L296C5::__js_call__
 
 	} // end of class FunctionExpression_L296C5
@@ -11680,33 +11392,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 100
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L309C5::__js_call__
 
 	} // end of class FunctionExpression_L309C5
@@ -12055,33 +11757,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 100
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L318C5::__js_call__
 
 	} // end of class FunctionExpression_L318C5
@@ -12413,33 +12105,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L327C5::__js_call__
 
 	} // end of class FunctionExpression_L327C5
@@ -12776,33 +12458,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L336C5::__js_call__
 
 	} // end of class FunctionExpression_L336C5
@@ -13139,33 +12811,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 100
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L345C5::__js_call__
 
 	} // end of class FunctionExpression_L345C5
@@ -13514,33 +13176,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 100
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L354C5::__js_call__
 
 	} // end of class FunctionExpression_L354C5
@@ -13872,33 +13524,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L363C5::__js_call__
 
 	} // end of class FunctionExpression_L363C5
@@ -14235,33 +13877,23 @@
 				74 61 54 6f 6b 65 6e 54 00 00 02
 			)
 			// Header size: 12
-			// Code size: 52 (0x34)
+			// Code size: 31 (0x1f)
 			.maxstack 8
 			.locals init (
-				[0] object[],
-				[1] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ldc.r8 50
-			IL_001b: box [System.Runtime]System.Double
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0025: stloc.1
-			IL_0026: ldarg.0
-			IL_0027: ldloc.1
-			IL_0028: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_002d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0032: ldnull
-			IL_0033: ret
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+			IL_0015: stloc.0
+			IL_0016: ldarg.0
+			IL_0017: ldloc.0
+			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_001d: ldnull
+			IL_001e: ret
 		} // end of method FunctionExpression_L372C5::__js_call__
 
 	} // end of class FunctionExpression_L372C5
@@ -14514,7 +14146,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 4957 (0x135d)
+		// Code size: 4287 (0x10bf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope,
@@ -14529,9 +14161,9 @@
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[10] float64,
 			[11] object,
-			[12] object,
+			[12] string,
 			[13] object,
-			[14] object[],
+			[14] object,
 			[15] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject,
 			[16] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject,
 			[17] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject,
@@ -14709,1958 +14341,1748 @@
 		IL_00e4: nop
 		IL_00e5: nop
 		IL_00e6: nop
-		IL_00e7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ec: stloc.s 6
-		IL_00ee: ldloc.1
-		IL_00ef: ldloc.s 6
-		IL_00f1: ldstr "dromaeo-object-regexp"
-		IL_00f6: ldstr "812dde38"
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0100: pop
-		IL_0101: ldc.i4.0
-		IL_0102: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0107: stloc.s 9
-		IL_0109: ldloc.0
-		IL_010a: ldloc.s 9
-		IL_010c: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0111: ldloc.0
-		IL_0112: ldnull
-		IL_0113: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0118: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-		IL_011d: ldloc.0
-		IL_011e: ldnull
-		IL_011f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-		IL_0124: ldloc.0
-		IL_0125: ldnull
-		IL_0126: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_012b: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-		IL_0130: ldc.i4.0
-		IL_0131: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0136: stloc.s 9
-		IL_0138: ldloc.0
-		IL_0139: ldloc.s 9
-		IL_013b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-		IL_0140: ldc.r8 65536
-		IL_0149: stloc.s 5
-		IL_014b: nop
-		IL_014c: ldc.r8 0.0
-		IL_0155: stloc.s 5
-		// loop start (head: IL_0157)
-			IL_0157: ldloc.s 5
-			IL_0159: stloc.s 10
-			IL_015b: ldloc.s 10
-			IL_015d: ldc.r8 16384
-			IL_0166: clt
-			IL_0168: brfalse IL_01ff
+		IL_00e7: ldnull
+		IL_00e8: ldstr "dromaeo-object-regexp"
+		IL_00ed: ldstr "812dde38"
+		IL_00f2: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, string, string)
+		IL_00f7: pop
+		IL_00f8: ldc.i4.0
+		IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00fe: stloc.s 9
+		IL_0100: ldloc.0
+		IL_0101: ldloc.s 9
+		IL_0103: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0108: ldloc.0
+		IL_0109: ldnull
+		IL_010a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_010f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+		IL_0114: ldloc.0
+		IL_0115: ldnull
+		IL_0116: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+		IL_011b: ldloc.0
+		IL_011c: ldnull
+		IL_011d: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+		IL_0122: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+		IL_0127: ldc.i4.0
+		IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_012d: stloc.s 9
+		IL_012f: ldloc.0
+		IL_0130: ldloc.s 9
+		IL_0132: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+		IL_0137: ldc.r8 65536
+		IL_0140: stloc.s 5
+		IL_0142: nop
+		IL_0143: ldc.r8 0.0
+		IL_014c: stloc.s 5
+		// loop start (head: IL_014e)
+			IL_014e: ldloc.s 5
+			IL_0150: stloc.s 10
+			IL_0152: ldloc.s 10
+			IL_0154: ldc.r8 16384
+			IL_015d: clt
+			IL_015f: brfalse IL_01ec
 
-			IL_016d: ldloc.0
-			IL_016e: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0178: stloc.s 11
-			IL_017a: ldloc.0
-			IL_017b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
-			IL_0180: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_018a: stloc.s 12
-			IL_018c: ldc.i4.1
-			IL_018d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0192: brfalse IL_01dd
+			IL_0164: ldloc.0
+			IL_0165: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016f: stloc.s 11
+			IL_0171: ldnull
+			IL_0172: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+			IL_0177: stloc.s 12
+			IL_0179: ldc.i4.1
+			IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_017f: brfalse IL_01ca
 
-			IL_0197: ldloc.s 11
-			IL_0199: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_019e: dup
-			IL_019f: brfalse IL_01dc
+			IL_0184: ldloc.s 11
+			IL_0186: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_018b: dup
+			IL_018c: brfalse IL_01c9
 
-			IL_01a4: pop
-			IL_01a5: ldloc.s 11
-			IL_01a7: ldstr "push"
-			IL_01ac: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-			IL_01b1: brtrue IL_01dd
+			IL_0191: pop
+			IL_0192: ldloc.s 11
+			IL_0194: ldstr "push"
+			IL_0199: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_019e: brtrue IL_01ca
 
-			IL_01b6: ldloc.s 11
-			IL_01b8: ldc.i4.1
-			IL_01b9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_01be: brfalse IL_01dd
+			IL_01a3: ldloc.s 11
+			IL_01a5: ldc.i4.1
+			IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01ab: brfalse IL_01ca
 
-			IL_01c3: ldloc.s 11
-			IL_01c5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01ca: ldloc.s 12
-			IL_01cc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_01d1: box [System.Runtime]System.Double
-			IL_01d6: pop
-			IL_01d7: br IL_01ec
+			IL_01b0: ldloc.s 11
+			IL_01b2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01b7: ldloc.s 12
+			IL_01b9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_01be: box [System.Runtime]System.Double
+			IL_01c3: pop
+			IL_01c4: br IL_01d9
 
-			IL_01dc: pop
+			IL_01c9: pop
 
-			IL_01dd: ldloc.s 11
-			IL_01df: ldstr "push"
-			IL_01e4: ldloc.s 12
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01eb: pop
+			IL_01ca: ldloc.s 11
+			IL_01cc: ldstr "push"
+			IL_01d1: ldloc.s 12
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01d8: pop
 
-			IL_01ec: ldloc.s 5
-			IL_01ee: ldc.r8 1
-			IL_01f7: add
-			IL_01f8: stloc.s 5
-			IL_01fa: br IL_0157
+			IL_01d9: ldloc.s 5
+			IL_01db: ldc.r8 1
+			IL_01e4: add
+			IL_01e5: stloc.s 5
+			IL_01e7: br IL_014e
 		// end loop
 
-		IL_01ff: ldloc.0
-		IL_0200: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020a: volatile.
-		IL_020c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-		IL_0211: brfalse IL_022a
+		IL_01ec: ldloc.0
+		IL_01ed: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f7: volatile.
+		IL_01f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_01fe: brfalse IL_0217
 
-		IL_0216: ldstr "join"
-		IL_021b: ldstr ""
-		IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0225: br IL_0243
+		IL_0203: ldstr "join"
+		IL_0208: ldstr ""
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0212: br IL_0230
 
-		IL_022a: ldstr "join"
-		IL_022f: ldstr ""
-		IL_0234: ldstr "Compile_Performance_Dromaeo_Object_Regexp:Modules.Compile_Performance_Dromaeo_Object_Regexp:__js_module_init__:70"
-		IL_0239: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0217: ldstr "join"
+		IL_021c: ldstr ""
+		IL_0221: ldstr "Compile_Performance_Dromaeo_Object_Regexp:Modules.Compile_Performance_Dromaeo_Object_Regexp:__js_module_init__:69"
+		IL_0226: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0243: stloc.s 12
-		IL_0245: ldloc.0
-		IL_0246: ldloc.s 12
-		IL_0248: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_024d: ldloc.0
-		IL_024e: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0253: stloc.s 12
+		IL_0230: stloc.s 11
+		IL_0232: ldloc.0
+		IL_0233: ldloc.s 11
+		IL_0235: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_023a: ldloc.0
+		IL_023b: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0240: stloc.s 11
+		IL_0242: ldloc.0
+		IL_0243: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0248: stloc.s 13
+		IL_024a: ldloc.s 11
+		IL_024c: ldloc.s 13
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0253: stloc.s 14
 		IL_0255: ldloc.0
-		IL_0256: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_025b: stloc.s 11
-		IL_025d: ldloc.s 12
-		IL_025f: ldloc.s 11
-		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0266: stloc.s 13
-		IL_0268: ldloc.0
-		IL_0269: ldloc.s 13
-		IL_026b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0270: ldloc.0
-		IL_0271: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0276: stloc.s 11
+		IL_0256: ldloc.s 14
+		IL_0258: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_025d: ldloc.0
+		IL_025e: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0263: stloc.s 13
+		IL_0265: ldloc.0
+		IL_0266: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_026b: stloc.s 11
+		IL_026d: ldloc.s 13
+		IL_026f: ldloc.s 11
+		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0276: stloc.s 14
 		IL_0278: ldloc.0
-		IL_0279: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_027e: stloc.s 12
-		IL_0280: ldloc.s 11
-		IL_0282: ldloc.s 12
-		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0289: stloc.s 13
-		IL_028b: ldloc.0
-		IL_028c: ldloc.s 13
-		IL_028e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0293: nop
-		IL_0294: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0299: stloc.s 6
-		IL_029b: ldc.i4.1
-		IL_029c: newarr [System.Runtime]System.Object
-		IL_02a1: dup
+		IL_0279: ldloc.s 14
+		IL_027b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0280: nop
+		IL_0281: ldc.i4.1
+		IL_0282: newarr [System.Runtime]System.Object
+		IL_0287: dup
+		IL_0288: ldc.i4.0
+		IL_0289: ldloc.0
+		IL_028a: stelem.ref
+		IL_028b: stloc.s 6
+		IL_028d: ldloc.s 6
+		IL_028f: ldc.i4.0
+		IL_0290: ldelem.ref
+		IL_0291: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0296: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_029b: ldc.i4.0
+		IL_029c: conv.r8
+		IL_029d: ldstr ""
 		IL_02a2: ldc.i4.0
-		IL_02a3: ldloc.0
-		IL_02a4: stelem.ref
-		IL_02a5: stloc.s 14
-		IL_02a7: ldloc.s 14
-		IL_02a9: ldc.i4.0
-		IL_02aa: ldelem.ref
-		IL_02ab: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02b0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_02b5: ldc.i4.0
-		IL_02b6: conv.r8
-		IL_02b7: ldstr ""
-		IL_02bc: ldc.i4.0
-		IL_02bd: ldc.i4.0
-		IL_02be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02c3: stloc.s 15
-		IL_02c5: ldloc.3
-		IL_02c6: ldloc.s 6
-		IL_02c8: ldloc.s 15
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02cf: pop
-		IL_02d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02d5: stloc.s 6
-		IL_02d7: ldc.i4.1
-		IL_02d8: newarr [System.Runtime]System.Object
-		IL_02dd: dup
-		IL_02de: ldc.i4.0
-		IL_02df: ldloc.0
-		IL_02e0: stelem.ref
-		IL_02e1: stloc.s 14
-		IL_02e3: ldloc.s 14
-		IL_02e5: ldc.i4.0
-		IL_02e6: ldelem.ref
-		IL_02e7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02ec: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_02f1: ldc.i4.0
-		IL_02f2: conv.r8
-		IL_02f3: ldstr ""
-		IL_02f8: ldc.i4.0
-		IL_02f9: ldc.i4.0
-		IL_02fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02ff: stloc.s 16
-		IL_0301: ldloc.s 4
-		IL_0303: ldloc.s 6
-		IL_0305: ldstr "Compiled Object Empty Split"
-		IL_030a: ldloc.s 16
-		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0311: pop
-		IL_0312: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0317: stloc.s 6
-		IL_0319: ldc.i4.1
-		IL_031a: newarr [System.Runtime]System.Object
-		IL_031f: dup
-		IL_0320: ldc.i4.0
-		IL_0321: ldloc.0
-		IL_0322: stelem.ref
-		IL_0323: stloc.s 14
-		IL_0325: ldloc.s 14
-		IL_0327: ldc.i4.0
-		IL_0328: ldelem.ref
-		IL_0329: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_032e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0333: ldc.i4.0
-		IL_0334: conv.r8
-		IL_0335: ldstr ""
-		IL_033a: ldc.i4.0
-		IL_033b: ldc.i4.0
-		IL_033c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0341: stloc.s 17
-		IL_0343: ldloc.3
-		IL_0344: ldloc.s 6
-		IL_0346: ldloc.s 17
-		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_034d: pop
-		IL_034e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0353: stloc.s 6
-		IL_0355: ldc.i4.1
-		IL_0356: newarr [System.Runtime]System.Object
-		IL_035b: dup
-		IL_035c: ldc.i4.0
-		IL_035d: ldloc.0
-		IL_035e: stelem.ref
-		IL_035f: stloc.s 14
-		IL_0361: ldloc.s 14
-		IL_0363: ldc.i4.0
-		IL_0364: ldelem.ref
-		IL_0365: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_036a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_036f: ldc.i4.0
-		IL_0370: conv.r8
-		IL_0371: ldstr ""
-		IL_0376: ldc.i4.0
-		IL_0377: ldc.i4.0
-		IL_0378: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_037d: stloc.s 18
-		IL_037f: ldloc.s 4
-		IL_0381: ldloc.s 6
-		IL_0383: ldstr "Compiled Object Char Split"
-		IL_0388: ldloc.s 18
-		IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_038f: pop
-		IL_0390: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0395: stloc.s 6
-		IL_0397: ldc.i4.1
-		IL_0398: newarr [System.Runtime]System.Object
-		IL_039d: dup
-		IL_039e: ldc.i4.0
-		IL_039f: ldloc.0
-		IL_03a0: stelem.ref
-		IL_03a1: stloc.s 14
-		IL_03a3: ldloc.s 14
-		IL_03a5: ldc.i4.0
-		IL_03a6: ldelem.ref
-		IL_03a7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03ac: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_03b1: ldc.i4.0
-		IL_03b2: conv.r8
-		IL_03b3: ldstr ""
-		IL_03b8: ldc.i4.0
-		IL_03b9: ldc.i4.0
-		IL_03ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03bf: stloc.s 19
-		IL_03c1: ldloc.3
-		IL_03c2: ldloc.s 6
-		IL_03c4: ldloc.s 19
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03cb: pop
-		IL_03cc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03d1: stloc.s 6
-		IL_03d3: ldc.i4.1
-		IL_03d4: newarr [System.Runtime]System.Object
-		IL_03d9: dup
-		IL_03da: ldc.i4.0
-		IL_03db: ldloc.0
-		IL_03dc: stelem.ref
-		IL_03dd: stloc.s 14
-		IL_03df: ldloc.s 14
-		IL_03e1: ldc.i4.0
-		IL_03e2: ldelem.ref
-		IL_03e3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03e8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_03ed: ldc.i4.0
-		IL_03ee: conv.r8
-		IL_03ef: ldstr ""
-		IL_03f4: ldc.i4.0
-		IL_03f5: ldc.i4.0
-		IL_03f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03fb: stloc.s 20
-		IL_03fd: ldloc.s 4
-		IL_03ff: ldloc.s 6
-		IL_0401: ldstr "Compiled Object Variable Split"
-		IL_0406: ldloc.s 20
-		IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_040d: pop
-		IL_040e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0413: stloc.s 6
-		IL_0415: ldc.i4.1
-		IL_0416: newarr [System.Runtime]System.Object
-		IL_041b: dup
-		IL_041c: ldc.i4.0
-		IL_041d: ldloc.0
-		IL_041e: stelem.ref
-		IL_041f: stloc.s 14
-		IL_0421: ldloc.s 14
-		IL_0423: ldc.i4.0
-		IL_0424: ldelem.ref
-		IL_0425: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_042a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_042f: ldc.i4.0
-		IL_0430: conv.r8
-		IL_0431: ldstr ""
-		IL_0436: ldc.i4.0
-		IL_0437: ldc.i4.0
-		IL_0438: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_043d: stloc.s 21
-		IL_043f: ldloc.3
-		IL_0440: ldloc.s 6
-		IL_0442: ldloc.s 21
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0449: pop
-		IL_044a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_044f: stloc.s 6
-		IL_0451: ldc.i4.1
-		IL_0452: newarr [System.Runtime]System.Object
-		IL_0457: dup
-		IL_0458: ldc.i4.0
-		IL_0459: ldloc.0
-		IL_045a: stelem.ref
-		IL_045b: stloc.s 14
-		IL_045d: ldloc.s 14
-		IL_045f: ldc.i4.0
-		IL_0460: ldelem.ref
-		IL_0461: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0466: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_046b: ldc.i4.0
-		IL_046c: conv.r8
-		IL_046d: ldstr ""
-		IL_0472: ldc.i4.0
-		IL_0473: ldc.i4.0
-		IL_0474: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0479: stloc.s 22
-		IL_047b: ldloc.s 4
-		IL_047d: ldloc.s 6
-		IL_047f: ldstr "Compiled Match"
-		IL_0484: ldloc.s 22
-		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_048b: pop
-		IL_048c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0491: stloc.s 6
-		IL_0493: ldc.i4.1
-		IL_0494: newarr [System.Runtime]System.Object
-		IL_0499: dup
-		IL_049a: ldc.i4.0
-		IL_049b: ldloc.0
-		IL_049c: stelem.ref
-		IL_049d: stloc.s 14
-		IL_049f: ldloc.s 14
-		IL_04a1: ldc.i4.0
-		IL_04a2: ldelem.ref
-		IL_04a3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04a8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_04ad: ldc.i4.0
-		IL_04ae: conv.r8
-		IL_04af: ldstr ""
-		IL_04b4: ldc.i4.0
-		IL_04b5: ldc.i4.0
-		IL_04b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04bb: stloc.s 23
-		IL_04bd: ldloc.3
-		IL_04be: ldloc.s 6
-		IL_04c0: ldloc.s 23
-		IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_04c7: pop
-		IL_04c8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04cd: stloc.s 6
-		IL_04cf: ldc.i4.1
-		IL_04d0: newarr [System.Runtime]System.Object
-		IL_04d5: dup
-		IL_04d6: ldc.i4.0
-		IL_04d7: ldloc.0
-		IL_04d8: stelem.ref
-		IL_04d9: stloc.s 14
-		IL_04db: ldloc.s 14
-		IL_04dd: ldc.i4.0
-		IL_04de: ldelem.ref
-		IL_04df: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04e4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_04e9: ldc.i4.0
-		IL_04ea: conv.r8
-		IL_04eb: ldstr ""
-		IL_04f0: ldc.i4.0
-		IL_04f1: ldc.i4.0
-		IL_04f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04f7: stloc.s 24
-		IL_04f9: ldloc.s 4
-		IL_04fb: ldloc.s 6
-		IL_04fd: ldstr "Compiled Test"
-		IL_0502: ldloc.s 24
-		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0509: pop
-		IL_050a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_050f: stloc.s 6
-		IL_0511: ldc.i4.1
-		IL_0512: newarr [System.Runtime]System.Object
-		IL_0517: dup
-		IL_0518: ldc.i4.0
-		IL_0519: ldloc.0
-		IL_051a: stelem.ref
-		IL_051b: stloc.s 14
-		IL_051d: ldloc.s 14
-		IL_051f: ldc.i4.0
-		IL_0520: ldelem.ref
-		IL_0521: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0526: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_052b: ldc.i4.0
-		IL_052c: conv.r8
-		IL_052d: ldstr ""
-		IL_0532: ldc.i4.0
-		IL_0533: ldc.i4.0
-		IL_0534: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0539: stloc.s 25
-		IL_053b: ldloc.3
-		IL_053c: ldloc.s 6
-		IL_053e: ldloc.s 25
-		IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0545: pop
-		IL_0546: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_054b: stloc.s 6
-		IL_054d: ldc.i4.1
-		IL_054e: newarr [System.Runtime]System.Object
-		IL_0553: dup
-		IL_0554: ldc.i4.0
-		IL_0555: ldloc.0
-		IL_0556: stelem.ref
-		IL_0557: stloc.s 14
-		IL_0559: ldloc.s 14
-		IL_055b: ldc.i4.0
-		IL_055c: ldelem.ref
-		IL_055d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0562: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0567: ldc.i4.0
-		IL_0568: conv.r8
-		IL_0569: ldstr ""
-		IL_056e: ldc.i4.0
-		IL_056f: ldc.i4.0
-		IL_0570: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0575: stloc.s 26
-		IL_0577: ldloc.s 4
-		IL_0579: ldloc.s 6
-		IL_057b: ldstr "Compiled Empty Replace"
-		IL_0580: ldloc.s 26
-		IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0587: pop
-		IL_0588: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_058d: stloc.s 6
-		IL_058f: ldc.i4.1
-		IL_0590: newarr [System.Runtime]System.Object
-		IL_0595: dup
-		IL_0596: ldc.i4.0
-		IL_0597: ldloc.0
-		IL_0598: stelem.ref
-		IL_0599: stloc.s 14
-		IL_059b: ldloc.s 14
-		IL_059d: ldc.i4.0
-		IL_059e: ldelem.ref
-		IL_059f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05a4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_05a9: ldc.i4.0
-		IL_05aa: conv.r8
-		IL_05ab: ldstr ""
-		IL_05b0: ldc.i4.0
-		IL_05b1: ldc.i4.0
-		IL_05b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05b7: stloc.s 27
-		IL_05b9: ldloc.3
-		IL_05ba: ldloc.s 6
-		IL_05bc: ldloc.s 27
-		IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_05c3: pop
-		IL_05c4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05c9: stloc.s 6
-		IL_05cb: ldc.i4.1
-		IL_05cc: newarr [System.Runtime]System.Object
-		IL_05d1: dup
-		IL_05d2: ldc.i4.0
-		IL_05d3: ldloc.0
-		IL_05d4: stelem.ref
-		IL_05d5: stloc.s 14
-		IL_05d7: ldloc.s 14
-		IL_05d9: ldc.i4.0
-		IL_05da: ldelem.ref
-		IL_05db: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05e0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_05e5: ldc.i4.0
-		IL_05e6: conv.r8
-		IL_05e7: ldstr ""
-		IL_05ec: ldc.i4.0
-		IL_05ed: ldc.i4.0
-		IL_05ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05f3: stloc.s 28
-		IL_05f5: ldloc.s 4
-		IL_05f7: ldloc.s 6
-		IL_05f9: ldstr "Compiled 12 Char Replace"
-		IL_05fe: ldloc.s 28
-		IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0605: pop
-		IL_0606: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_060b: stloc.s 6
-		IL_060d: ldc.i4.1
-		IL_060e: newarr [System.Runtime]System.Object
-		IL_0613: dup
-		IL_0614: ldc.i4.0
-		IL_0615: ldloc.0
-		IL_0616: stelem.ref
-		IL_0617: stloc.s 14
-		IL_0619: ldloc.s 14
-		IL_061b: ldc.i4.0
-		IL_061c: ldelem.ref
-		IL_061d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0622: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0627: ldc.i4.0
-		IL_0628: conv.r8
-		IL_0629: ldstr ""
+		IL_02a3: ldc.i4.0
+		IL_02a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02a9: stloc.s 15
+		IL_02ab: ldnull
+		IL_02ac: ldloc.s 15
+		IL_02ae: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_02b3: pop
+		IL_02b4: ldc.i4.1
+		IL_02b5: newarr [System.Runtime]System.Object
+		IL_02ba: dup
+		IL_02bb: ldc.i4.0
+		IL_02bc: ldloc.0
+		IL_02bd: stelem.ref
+		IL_02be: stloc.s 6
+		IL_02c0: ldloc.s 6
+		IL_02c2: ldc.i4.0
+		IL_02c3: ldelem.ref
+		IL_02c4: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_02c9: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_02ce: ldc.i4.0
+		IL_02cf: conv.r8
+		IL_02d0: ldstr ""
+		IL_02d5: ldc.i4.0
+		IL_02d6: ldc.i4.0
+		IL_02d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02dc: stloc.s 16
+		IL_02de: ldnull
+		IL_02df: ldstr "Compiled Object Empty Split"
+		IL_02e4: ldloc.s 16
+		IL_02e6: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_02eb: pop
+		IL_02ec: ldc.i4.1
+		IL_02ed: newarr [System.Runtime]System.Object
+		IL_02f2: dup
+		IL_02f3: ldc.i4.0
+		IL_02f4: ldloc.0
+		IL_02f5: stelem.ref
+		IL_02f6: stloc.s 6
+		IL_02f8: ldloc.s 6
+		IL_02fa: ldc.i4.0
+		IL_02fb: ldelem.ref
+		IL_02fc: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0301: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0306: ldc.i4.0
+		IL_0307: conv.r8
+		IL_0308: ldstr ""
+		IL_030d: ldc.i4.0
+		IL_030e: ldc.i4.0
+		IL_030f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0314: stloc.s 17
+		IL_0316: ldnull
+		IL_0317: ldloc.s 17
+		IL_0319: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_031e: pop
+		IL_031f: ldc.i4.1
+		IL_0320: newarr [System.Runtime]System.Object
+		IL_0325: dup
+		IL_0326: ldc.i4.0
+		IL_0327: ldloc.0
+		IL_0328: stelem.ref
+		IL_0329: stloc.s 6
+		IL_032b: ldloc.s 6
+		IL_032d: ldc.i4.0
+		IL_032e: ldelem.ref
+		IL_032f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0334: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0339: ldc.i4.0
+		IL_033a: conv.r8
+		IL_033b: ldstr ""
+		IL_0340: ldc.i4.0
+		IL_0341: ldc.i4.0
+		IL_0342: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0347: stloc.s 18
+		IL_0349: ldnull
+		IL_034a: ldstr "Compiled Object Char Split"
+		IL_034f: ldloc.s 18
+		IL_0351: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0356: pop
+		IL_0357: ldc.i4.1
+		IL_0358: newarr [System.Runtime]System.Object
+		IL_035d: dup
+		IL_035e: ldc.i4.0
+		IL_035f: ldloc.0
+		IL_0360: stelem.ref
+		IL_0361: stloc.s 6
+		IL_0363: ldloc.s 6
+		IL_0365: ldc.i4.0
+		IL_0366: ldelem.ref
+		IL_0367: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_036c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0371: ldc.i4.0
+		IL_0372: conv.r8
+		IL_0373: ldstr ""
+		IL_0378: ldc.i4.0
+		IL_0379: ldc.i4.0
+		IL_037a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_037f: stloc.s 19
+		IL_0381: ldnull
+		IL_0382: ldloc.s 19
+		IL_0384: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0389: pop
+		IL_038a: ldc.i4.1
+		IL_038b: newarr [System.Runtime]System.Object
+		IL_0390: dup
+		IL_0391: ldc.i4.0
+		IL_0392: ldloc.0
+		IL_0393: stelem.ref
+		IL_0394: stloc.s 6
+		IL_0396: ldloc.s 6
+		IL_0398: ldc.i4.0
+		IL_0399: ldelem.ref
+		IL_039a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_039f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_03a4: ldc.i4.0
+		IL_03a5: conv.r8
+		IL_03a6: ldstr ""
+		IL_03ab: ldc.i4.0
+		IL_03ac: ldc.i4.0
+		IL_03ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03b2: stloc.s 20
+		IL_03b4: ldnull
+		IL_03b5: ldstr "Compiled Object Variable Split"
+		IL_03ba: ldloc.s 20
+		IL_03bc: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_03c1: pop
+		IL_03c2: ldc.i4.1
+		IL_03c3: newarr [System.Runtime]System.Object
+		IL_03c8: dup
+		IL_03c9: ldc.i4.0
+		IL_03ca: ldloc.0
+		IL_03cb: stelem.ref
+		IL_03cc: stloc.s 6
+		IL_03ce: ldloc.s 6
+		IL_03d0: ldc.i4.0
+		IL_03d1: ldelem.ref
+		IL_03d2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_03d7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_03dc: ldc.i4.0
+		IL_03dd: conv.r8
+		IL_03de: ldstr ""
+		IL_03e3: ldc.i4.0
+		IL_03e4: ldc.i4.0
+		IL_03e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03ea: stloc.s 21
+		IL_03ec: ldnull
+		IL_03ed: ldloc.s 21
+		IL_03ef: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_03f4: pop
+		IL_03f5: ldc.i4.1
+		IL_03f6: newarr [System.Runtime]System.Object
+		IL_03fb: dup
+		IL_03fc: ldc.i4.0
+		IL_03fd: ldloc.0
+		IL_03fe: stelem.ref
+		IL_03ff: stloc.s 6
+		IL_0401: ldloc.s 6
+		IL_0403: ldc.i4.0
+		IL_0404: ldelem.ref
+		IL_0405: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_040a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_040f: ldc.i4.0
+		IL_0410: conv.r8
+		IL_0411: ldstr ""
+		IL_0416: ldc.i4.0
+		IL_0417: ldc.i4.0
+		IL_0418: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_041d: stloc.s 22
+		IL_041f: ldnull
+		IL_0420: ldstr "Compiled Match"
+		IL_0425: ldloc.s 22
+		IL_0427: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_042c: pop
+		IL_042d: ldc.i4.1
+		IL_042e: newarr [System.Runtime]System.Object
+		IL_0433: dup
+		IL_0434: ldc.i4.0
+		IL_0435: ldloc.0
+		IL_0436: stelem.ref
+		IL_0437: stloc.s 6
+		IL_0439: ldloc.s 6
+		IL_043b: ldc.i4.0
+		IL_043c: ldelem.ref
+		IL_043d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0442: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0447: ldc.i4.0
+		IL_0448: conv.r8
+		IL_0449: ldstr ""
+		IL_044e: ldc.i4.0
+		IL_044f: ldc.i4.0
+		IL_0450: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0455: stloc.s 23
+		IL_0457: ldnull
+		IL_0458: ldloc.s 23
+		IL_045a: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_045f: pop
+		IL_0460: ldc.i4.1
+		IL_0461: newarr [System.Runtime]System.Object
+		IL_0466: dup
+		IL_0467: ldc.i4.0
+		IL_0468: ldloc.0
+		IL_0469: stelem.ref
+		IL_046a: stloc.s 6
+		IL_046c: ldloc.s 6
+		IL_046e: ldc.i4.0
+		IL_046f: ldelem.ref
+		IL_0470: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0475: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_047a: ldc.i4.0
+		IL_047b: conv.r8
+		IL_047c: ldstr ""
+		IL_0481: ldc.i4.0
+		IL_0482: ldc.i4.0
+		IL_0483: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0488: stloc.s 24
+		IL_048a: ldnull
+		IL_048b: ldstr "Compiled Test"
+		IL_0490: ldloc.s 24
+		IL_0492: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0497: pop
+		IL_0498: ldc.i4.1
+		IL_0499: newarr [System.Runtime]System.Object
+		IL_049e: dup
+		IL_049f: ldc.i4.0
+		IL_04a0: ldloc.0
+		IL_04a1: stelem.ref
+		IL_04a2: stloc.s 6
+		IL_04a4: ldloc.s 6
+		IL_04a6: ldc.i4.0
+		IL_04a7: ldelem.ref
+		IL_04a8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_04ad: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_04b2: ldc.i4.0
+		IL_04b3: conv.r8
+		IL_04b4: ldstr ""
+		IL_04b9: ldc.i4.0
+		IL_04ba: ldc.i4.0
+		IL_04bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04c0: stloc.s 25
+		IL_04c2: ldnull
+		IL_04c3: ldloc.s 25
+		IL_04c5: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_04ca: pop
+		IL_04cb: ldc.i4.1
+		IL_04cc: newarr [System.Runtime]System.Object
+		IL_04d1: dup
+		IL_04d2: ldc.i4.0
+		IL_04d3: ldloc.0
+		IL_04d4: stelem.ref
+		IL_04d5: stloc.s 6
+		IL_04d7: ldloc.s 6
+		IL_04d9: ldc.i4.0
+		IL_04da: ldelem.ref
+		IL_04db: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_04e0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_04e5: ldc.i4.0
+		IL_04e6: conv.r8
+		IL_04e7: ldstr ""
+		IL_04ec: ldc.i4.0
+		IL_04ed: ldc.i4.0
+		IL_04ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04f3: stloc.s 26
+		IL_04f5: ldnull
+		IL_04f6: ldstr "Compiled Empty Replace"
+		IL_04fb: ldloc.s 26
+		IL_04fd: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0502: pop
+		IL_0503: ldc.i4.1
+		IL_0504: newarr [System.Runtime]System.Object
+		IL_0509: dup
+		IL_050a: ldc.i4.0
+		IL_050b: ldloc.0
+		IL_050c: stelem.ref
+		IL_050d: stloc.s 6
+		IL_050f: ldloc.s 6
+		IL_0511: ldc.i4.0
+		IL_0512: ldelem.ref
+		IL_0513: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0518: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_051d: ldc.i4.0
+		IL_051e: conv.r8
+		IL_051f: ldstr ""
+		IL_0524: ldc.i4.0
+		IL_0525: ldc.i4.0
+		IL_0526: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_052b: stloc.s 27
+		IL_052d: ldnull
+		IL_052e: ldloc.s 27
+		IL_0530: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0535: pop
+		IL_0536: ldc.i4.1
+		IL_0537: newarr [System.Runtime]System.Object
+		IL_053c: dup
+		IL_053d: ldc.i4.0
+		IL_053e: ldloc.0
+		IL_053f: stelem.ref
+		IL_0540: stloc.s 6
+		IL_0542: ldloc.s 6
+		IL_0544: ldc.i4.0
+		IL_0545: ldelem.ref
+		IL_0546: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_054b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0550: ldc.i4.0
+		IL_0551: conv.r8
+		IL_0552: ldstr ""
+		IL_0557: ldc.i4.0
+		IL_0558: ldc.i4.0
+		IL_0559: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_055e: stloc.s 28
+		IL_0560: ldnull
+		IL_0561: ldstr "Compiled 12 Char Replace"
+		IL_0566: ldloc.s 28
+		IL_0568: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_056d: pop
+		IL_056e: ldc.i4.1
+		IL_056f: newarr [System.Runtime]System.Object
+		IL_0574: dup
+		IL_0575: ldc.i4.0
+		IL_0576: ldloc.0
+		IL_0577: stelem.ref
+		IL_0578: stloc.s 6
+		IL_057a: ldloc.s 6
+		IL_057c: ldc.i4.0
+		IL_057d: ldelem.ref
+		IL_057e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0583: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0588: ldc.i4.0
+		IL_0589: conv.r8
+		IL_058a: ldstr ""
+		IL_058f: ldc.i4.0
+		IL_0590: ldc.i4.0
+		IL_0591: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0596: stloc.s 29
+		IL_0598: ldnull
+		IL_0599: ldloc.s 29
+		IL_059b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_05a0: pop
+		IL_05a1: ldc.i4.1
+		IL_05a2: newarr [System.Runtime]System.Object
+		IL_05a7: dup
+		IL_05a8: ldc.i4.0
+		IL_05a9: ldloc.0
+		IL_05aa: stelem.ref
+		IL_05ab: stloc.s 6
+		IL_05ad: ldloc.s 6
+		IL_05af: ldc.i4.0
+		IL_05b0: ldelem.ref
+		IL_05b1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_05b6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05bb: ldc.i4.0
+		IL_05bc: conv.r8
+		IL_05bd: ldstr ""
+		IL_05c2: ldc.i4.0
+		IL_05c3: ldc.i4.0
+		IL_05c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05c9: stloc.s 30
+		IL_05cb: ldnull
+		IL_05cc: ldstr "Compiled Object Match"
+		IL_05d1: ldloc.s 30
+		IL_05d3: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_05d8: pop
+		IL_05d9: ldc.i4.1
+		IL_05da: newarr [System.Runtime]System.Object
+		IL_05df: dup
+		IL_05e0: ldc.i4.0
+		IL_05e1: ldloc.0
+		IL_05e2: stelem.ref
+		IL_05e3: stloc.s 6
+		IL_05e5: ldloc.s 6
+		IL_05e7: ldc.i4.0
+		IL_05e8: ldelem.ref
+		IL_05e9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_05ee: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05f3: ldc.i4.0
+		IL_05f4: conv.r8
+		IL_05f5: ldstr ""
+		IL_05fa: ldc.i4.0
+		IL_05fb: ldc.i4.0
+		IL_05fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0601: stloc.s 31
+		IL_0603: ldnull
+		IL_0604: ldloc.s 31
+		IL_0606: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_060b: pop
+		IL_060c: ldc.i4.1
+		IL_060d: newarr [System.Runtime]System.Object
+		IL_0612: dup
+		IL_0613: ldc.i4.0
+		IL_0614: ldloc.0
+		IL_0615: stelem.ref
+		IL_0616: stloc.s 6
+		IL_0618: ldloc.s 6
+		IL_061a: ldc.i4.0
+		IL_061b: ldelem.ref
+		IL_061c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0621: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0626: ldc.i4.0
+		IL_0627: conv.r8
+		IL_0628: ldstr ""
+		IL_062d: ldc.i4.0
 		IL_062e: ldc.i4.0
-		IL_062f: ldc.i4.0
-		IL_0630: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0635: stloc.s 29
-		IL_0637: ldloc.3
-		IL_0638: ldloc.s 6
-		IL_063a: ldloc.s 29
-		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0641: pop
-		IL_0642: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0647: stloc.s 6
-		IL_0649: ldc.i4.1
-		IL_064a: newarr [System.Runtime]System.Object
-		IL_064f: dup
-		IL_0650: ldc.i4.0
-		IL_0651: ldloc.0
-		IL_0652: stelem.ref
-		IL_0653: stloc.s 14
-		IL_0655: ldloc.s 14
-		IL_0657: ldc.i4.0
-		IL_0658: ldelem.ref
-		IL_0659: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_065e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0663: ldc.i4.0
-		IL_0664: conv.r8
-		IL_0665: ldstr ""
-		IL_066a: ldc.i4.0
-		IL_066b: ldc.i4.0
-		IL_066c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0671: stloc.s 30
-		IL_0673: ldloc.s 4
-		IL_0675: ldloc.s 6
-		IL_0677: ldstr "Compiled Object Match"
-		IL_067c: ldloc.s 30
-		IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0683: pop
-		IL_0684: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0689: stloc.s 6
-		IL_068b: ldc.i4.1
-		IL_068c: newarr [System.Runtime]System.Object
-		IL_0691: dup
-		IL_0692: ldc.i4.0
-		IL_0693: ldloc.0
-		IL_0694: stelem.ref
-		IL_0695: stloc.s 14
-		IL_0697: ldloc.s 14
+		IL_062f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0634: stloc.s 32
+		IL_0636: ldnull
+		IL_0637: ldstr "Compiled Object Test"
+		IL_063c: ldloc.s 32
+		IL_063e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0643: pop
+		IL_0644: ldc.i4.1
+		IL_0645: newarr [System.Runtime]System.Object
+		IL_064a: dup
+		IL_064b: ldc.i4.0
+		IL_064c: ldloc.0
+		IL_064d: stelem.ref
+		IL_064e: stloc.s 6
+		IL_0650: ldloc.s 6
+		IL_0652: ldc.i4.0
+		IL_0653: ldelem.ref
+		IL_0654: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0659: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_065e: ldc.i4.0
+		IL_065f: conv.r8
+		IL_0660: ldstr ""
+		IL_0665: ldc.i4.0
+		IL_0666: ldc.i4.0
+		IL_0667: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_066c: stloc.s 33
+		IL_066e: ldnull
+		IL_066f: ldloc.s 33
+		IL_0671: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0676: pop
+		IL_0677: ldc.i4.1
+		IL_0678: newarr [System.Runtime]System.Object
+		IL_067d: dup
+		IL_067e: ldc.i4.0
+		IL_067f: ldloc.0
+		IL_0680: stelem.ref
+		IL_0681: stloc.s 6
+		IL_0683: ldloc.s 6
+		IL_0685: ldc.i4.0
+		IL_0686: ldelem.ref
+		IL_0687: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_068c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0691: ldc.i4.0
+		IL_0692: conv.r8
+		IL_0693: ldstr ""
+		IL_0698: ldc.i4.0
 		IL_0699: ldc.i4.0
-		IL_069a: ldelem.ref
-		IL_069b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06a0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_06a5: ldc.i4.0
-		IL_06a6: conv.r8
-		IL_06a7: ldstr ""
-		IL_06ac: ldc.i4.0
-		IL_06ad: ldc.i4.0
-		IL_06ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06b3: stloc.s 31
-		IL_06b5: ldloc.3
-		IL_06b6: ldloc.s 6
-		IL_06b8: ldloc.s 31
-		IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_06bf: pop
-		IL_06c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06c5: stloc.s 6
-		IL_06c7: ldc.i4.1
-		IL_06c8: newarr [System.Runtime]System.Object
-		IL_06cd: dup
-		IL_06ce: ldc.i4.0
-		IL_06cf: ldloc.0
-		IL_06d0: stelem.ref
-		IL_06d1: stloc.s 14
-		IL_06d3: ldloc.s 14
-		IL_06d5: ldc.i4.0
-		IL_06d6: ldelem.ref
-		IL_06d7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06dc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_06e1: ldc.i4.0
-		IL_06e2: conv.r8
-		IL_06e3: ldstr ""
-		IL_06e8: ldc.i4.0
+		IL_069a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_069f: stloc.s 34
+		IL_06a1: ldnull
+		IL_06a2: ldstr "Compiled Object Empty Replace"
+		IL_06a7: ldloc.s 34
+		IL_06a9: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_06ae: pop
+		IL_06af: ldc.i4.1
+		IL_06b0: newarr [System.Runtime]System.Object
+		IL_06b5: dup
+		IL_06b6: ldc.i4.0
+		IL_06b7: ldloc.0
+		IL_06b8: stelem.ref
+		IL_06b9: stloc.s 6
+		IL_06bb: ldloc.s 6
+		IL_06bd: ldc.i4.0
+		IL_06be: ldelem.ref
+		IL_06bf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_06c4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06c9: ldc.i4.0
+		IL_06ca: conv.r8
+		IL_06cb: ldstr ""
+		IL_06d0: ldc.i4.0
+		IL_06d1: ldc.i4.0
+		IL_06d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06d7: stloc.s 35
+		IL_06d9: ldnull
+		IL_06da: ldloc.s 35
+		IL_06dc: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_06e1: pop
+		IL_06e2: ldc.i4.1
+		IL_06e3: newarr [System.Runtime]System.Object
+		IL_06e8: dup
 		IL_06e9: ldc.i4.0
-		IL_06ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06ef: stloc.s 32
-		IL_06f1: ldloc.s 4
-		IL_06f3: ldloc.s 6
-		IL_06f5: ldstr "Compiled Object Test"
-		IL_06fa: ldloc.s 32
-		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0701: pop
-		IL_0702: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0707: stloc.s 6
-		IL_0709: ldc.i4.1
-		IL_070a: newarr [System.Runtime]System.Object
-		IL_070f: dup
-		IL_0710: ldc.i4.0
-		IL_0711: ldloc.0
-		IL_0712: stelem.ref
-		IL_0713: stloc.s 14
-		IL_0715: ldloc.s 14
-		IL_0717: ldc.i4.0
-		IL_0718: ldelem.ref
-		IL_0719: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_071e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0723: ldc.i4.0
-		IL_0724: conv.r8
-		IL_0725: ldstr ""
-		IL_072a: ldc.i4.0
-		IL_072b: ldc.i4.0
-		IL_072c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0731: stloc.s 33
-		IL_0733: ldloc.3
-		IL_0734: ldloc.s 6
-		IL_0736: ldloc.s 33
-		IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_073d: pop
-		IL_073e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0743: stloc.s 6
-		IL_0745: ldc.i4.1
-		IL_0746: newarr [System.Runtime]System.Object
-		IL_074b: dup
-		IL_074c: ldc.i4.0
-		IL_074d: ldloc.0
-		IL_074e: stelem.ref
-		IL_074f: stloc.s 14
-		IL_0751: ldloc.s 14
-		IL_0753: ldc.i4.0
-		IL_0754: ldelem.ref
-		IL_0755: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_075a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_075f: ldc.i4.0
-		IL_0760: conv.r8
-		IL_0761: ldstr ""
-		IL_0766: ldc.i4.0
+		IL_06ea: ldloc.0
+		IL_06eb: stelem.ref
+		IL_06ec: stloc.s 6
+		IL_06ee: ldloc.s 6
+		IL_06f0: ldc.i4.0
+		IL_06f1: ldelem.ref
+		IL_06f2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_06f7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06fc: ldc.i4.0
+		IL_06fd: conv.r8
+		IL_06fe: ldstr ""
+		IL_0703: ldc.i4.0
+		IL_0704: ldc.i4.0
+		IL_0705: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_070a: stloc.s 36
+		IL_070c: ldnull
+		IL_070d: ldstr "Compiled Object 12 Char Replace"
+		IL_0712: ldloc.s 36
+		IL_0714: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0719: pop
+		IL_071a: ldc.i4.1
+		IL_071b: newarr [System.Runtime]System.Object
+		IL_0720: dup
+		IL_0721: ldc.i4.0
+		IL_0722: ldloc.0
+		IL_0723: stelem.ref
+		IL_0724: stloc.s 6
+		IL_0726: ldloc.s 6
+		IL_0728: ldc.i4.0
+		IL_0729: ldelem.ref
+		IL_072a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_072f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0734: ldc.i4.0
+		IL_0735: conv.r8
+		IL_0736: ldstr ""
+		IL_073b: ldc.i4.0
+		IL_073c: ldc.i4.0
+		IL_073d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0742: stloc.s 37
+		IL_0744: ldnull
+		IL_0745: ldloc.s 37
+		IL_0747: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_074c: pop
+		IL_074d: ldc.i4.1
+		IL_074e: newarr [System.Runtime]System.Object
+		IL_0753: dup
+		IL_0754: ldc.i4.0
+		IL_0755: ldloc.0
+		IL_0756: stelem.ref
+		IL_0757: stloc.s 6
+		IL_0759: ldloc.s 6
+		IL_075b: ldc.i4.0
+		IL_075c: ldelem.ref
+		IL_075d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0762: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0767: ldc.i4.0
-		IL_0768: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_076d: stloc.s 34
-		IL_076f: ldloc.s 4
-		IL_0771: ldloc.s 6
-		IL_0773: ldstr "Compiled Object Empty Replace"
-		IL_0778: ldloc.s 34
-		IL_077a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_077f: pop
-		IL_0780: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0785: stloc.s 6
-		IL_0787: ldc.i4.1
-		IL_0788: newarr [System.Runtime]System.Object
-		IL_078d: dup
-		IL_078e: ldc.i4.0
-		IL_078f: ldloc.0
-		IL_0790: stelem.ref
-		IL_0791: stloc.s 14
-		IL_0793: ldloc.s 14
-		IL_0795: ldc.i4.0
-		IL_0796: ldelem.ref
-		IL_0797: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_079c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_07a1: ldc.i4.0
-		IL_07a2: conv.r8
-		IL_07a3: ldstr ""
-		IL_07a8: ldc.i4.0
-		IL_07a9: ldc.i4.0
-		IL_07aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07af: stloc.s 35
-		IL_07b1: ldloc.3
-		IL_07b2: ldloc.s 6
-		IL_07b4: ldloc.s 35
-		IL_07b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_07bb: pop
-		IL_07bc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_07c1: stloc.s 6
-		IL_07c3: ldc.i4.1
-		IL_07c4: newarr [System.Runtime]System.Object
-		IL_07c9: dup
-		IL_07ca: ldc.i4.0
-		IL_07cb: ldloc.0
-		IL_07cc: stelem.ref
-		IL_07cd: stloc.s 14
-		IL_07cf: ldloc.s 14
-		IL_07d1: ldc.i4.0
-		IL_07d2: ldelem.ref
-		IL_07d3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_07d8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_07dd: ldc.i4.0
-		IL_07de: conv.r8
-		IL_07df: ldstr ""
-		IL_07e4: ldc.i4.0
-		IL_07e5: ldc.i4.0
-		IL_07e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07eb: stloc.s 36
-		IL_07ed: ldloc.s 4
-		IL_07ef: ldloc.s 6
-		IL_07f1: ldstr "Compiled Object 12 Char Replace"
-		IL_07f6: ldloc.s 36
-		IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_07fd: pop
-		IL_07fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0803: stloc.s 6
-		IL_0805: ldc.i4.1
-		IL_0806: newarr [System.Runtime]System.Object
-		IL_080b: dup
-		IL_080c: ldc.i4.0
-		IL_080d: ldloc.0
-		IL_080e: stelem.ref
-		IL_080f: stloc.s 14
-		IL_0811: ldloc.s 14
-		IL_0813: ldc.i4.0
-		IL_0814: ldelem.ref
-		IL_0815: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_081a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_081f: ldc.i4.0
-		IL_0820: conv.r8
-		IL_0821: ldstr ""
-		IL_0826: ldc.i4.0
-		IL_0827: ldc.i4.0
-		IL_0828: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_082d: stloc.s 37
-		IL_082f: ldloc.3
-		IL_0830: ldloc.s 6
-		IL_0832: ldloc.s 37
-		IL_0834: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0839: pop
-		IL_083a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_083f: stloc.s 6
-		IL_0841: ldc.i4.1
-		IL_0842: newarr [System.Runtime]System.Object
-		IL_0847: dup
-		IL_0848: ldc.i4.0
-		IL_0849: ldloc.0
-		IL_084a: stelem.ref
-		IL_084b: stloc.s 14
-		IL_084d: ldloc.s 14
-		IL_084f: ldc.i4.0
-		IL_0850: ldelem.ref
-		IL_0851: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0856: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_085b: ldc.i4.0
-		IL_085c: conv.r8
-		IL_085d: ldstr ""
+		IL_0768: conv.r8
+		IL_0769: ldstr ""
+		IL_076e: ldc.i4.0
+		IL_076f: ldc.i4.0
+		IL_0770: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0775: stloc.s 38
+		IL_0777: ldnull
+		IL_0778: ldstr "Compiled Object 12 Char Replace Function"
+		IL_077d: ldloc.s 38
+		IL_077f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0784: pop
+		IL_0785: ldc.i4.1
+		IL_0786: newarr [System.Runtime]System.Object
+		IL_078b: dup
+		IL_078c: ldc.i4.0
+		IL_078d: ldloc.0
+		IL_078e: stelem.ref
+		IL_078f: stloc.s 6
+		IL_0791: ldloc.s 6
+		IL_0793: ldc.i4.0
+		IL_0794: ldelem.ref
+		IL_0795: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_079a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_079f: ldc.i4.0
+		IL_07a0: conv.r8
+		IL_07a1: ldstr ""
+		IL_07a6: ldc.i4.0
+		IL_07a7: ldc.i4.0
+		IL_07a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07ad: stloc.s 39
+		IL_07af: ldnull
+		IL_07b0: ldloc.s 39
+		IL_07b2: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_07b7: pop
+		IL_07b8: ldc.i4.1
+		IL_07b9: newarr [System.Runtime]System.Object
+		IL_07be: dup
+		IL_07bf: ldc.i4.0
+		IL_07c0: ldloc.0
+		IL_07c1: stelem.ref
+		IL_07c2: stloc.s 6
+		IL_07c4: ldloc.s 6
+		IL_07c6: ldc.i4.0
+		IL_07c7: ldelem.ref
+		IL_07c8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_07cd: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_07d2: ldc.i4.0
+		IL_07d3: conv.r8
+		IL_07d4: ldstr ""
+		IL_07d9: ldc.i4.0
+		IL_07da: ldc.i4.0
+		IL_07db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07e0: stloc.s 40
+		IL_07e2: ldnull
+		IL_07e3: ldstr "Compiled Variable Match"
+		IL_07e8: ldloc.s 40
+		IL_07ea: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_07ef: pop
+		IL_07f0: ldc.i4.1
+		IL_07f1: newarr [System.Runtime]System.Object
+		IL_07f6: dup
+		IL_07f7: ldc.i4.0
+		IL_07f8: ldloc.0
+		IL_07f9: stelem.ref
+		IL_07fa: stloc.s 6
+		IL_07fc: ldloc.s 6
+		IL_07fe: ldc.i4.0
+		IL_07ff: ldelem.ref
+		IL_0800: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0805: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_080a: ldc.i4.0
+		IL_080b: conv.r8
+		IL_080c: ldstr ""
+		IL_0811: ldc.i4.0
+		IL_0812: ldc.i4.0
+		IL_0813: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0818: stloc.s 41
+		IL_081a: ldnull
+		IL_081b: ldloc.s 41
+		IL_081d: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0822: pop
+		IL_0823: ldc.i4.1
+		IL_0824: newarr [System.Runtime]System.Object
+		IL_0829: dup
+		IL_082a: ldc.i4.0
+		IL_082b: ldloc.0
+		IL_082c: stelem.ref
+		IL_082d: stloc.s 6
+		IL_082f: ldloc.s 6
+		IL_0831: ldc.i4.0
+		IL_0832: ldelem.ref
+		IL_0833: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0838: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_083d: ldc.i4.0
+		IL_083e: conv.r8
+		IL_083f: ldstr ""
+		IL_0844: ldc.i4.0
+		IL_0845: ldc.i4.0
+		IL_0846: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_084b: stloc.s 42
+		IL_084d: ldnull
+		IL_084e: ldstr "Compiled Variable Test"
+		IL_0853: ldloc.s 42
+		IL_0855: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_085a: pop
+		IL_085b: ldc.i4.1
+		IL_085c: newarr [System.Runtime]System.Object
+		IL_0861: dup
 		IL_0862: ldc.i4.0
-		IL_0863: ldc.i4.0
-		IL_0864: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0869: stloc.s 38
-		IL_086b: ldloc.s 4
-		IL_086d: ldloc.s 6
-		IL_086f: ldstr "Compiled Object 12 Char Replace Function"
-		IL_0874: ldloc.s 38
-		IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_087b: pop
-		IL_087c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0881: stloc.s 6
-		IL_0883: ldc.i4.1
-		IL_0884: newarr [System.Runtime]System.Object
-		IL_0889: dup
-		IL_088a: ldc.i4.0
-		IL_088b: ldloc.0
-		IL_088c: stelem.ref
-		IL_088d: stloc.s 14
-		IL_088f: ldloc.s 14
-		IL_0891: ldc.i4.0
-		IL_0892: ldelem.ref
-		IL_0893: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0898: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_089d: ldc.i4.0
-		IL_089e: conv.r8
-		IL_089f: ldstr ""
-		IL_08a4: ldc.i4.0
-		IL_08a5: ldc.i4.0
-		IL_08a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08ab: stloc.s 39
-		IL_08ad: ldloc.3
-		IL_08ae: ldloc.s 6
-		IL_08b0: ldloc.s 39
-		IL_08b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_08b7: pop
-		IL_08b8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08bd: stloc.s 6
-		IL_08bf: ldc.i4.1
-		IL_08c0: newarr [System.Runtime]System.Object
-		IL_08c5: dup
-		IL_08c6: ldc.i4.0
-		IL_08c7: ldloc.0
-		IL_08c8: stelem.ref
-		IL_08c9: stloc.s 14
-		IL_08cb: ldloc.s 14
+		IL_0863: ldloc.0
+		IL_0864: stelem.ref
+		IL_0865: stloc.s 6
+		IL_0867: ldloc.s 6
+		IL_0869: ldc.i4.0
+		IL_086a: ldelem.ref
+		IL_086b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0870: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0875: ldc.i4.0
+		IL_0876: conv.r8
+		IL_0877: ldstr ""
+		IL_087c: ldc.i4.0
+		IL_087d: ldc.i4.0
+		IL_087e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0883: stloc.s 43
+		IL_0885: ldnull
+		IL_0886: ldloc.s 43
+		IL_0888: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_088d: pop
+		IL_088e: ldc.i4.1
+		IL_088f: newarr [System.Runtime]System.Object
+		IL_0894: dup
+		IL_0895: ldc.i4.0
+		IL_0896: ldloc.0
+		IL_0897: stelem.ref
+		IL_0898: stloc.s 6
+		IL_089a: ldloc.s 6
+		IL_089c: ldc.i4.0
+		IL_089d: ldelem.ref
+		IL_089e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_08a3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_08a8: ldc.i4.0
+		IL_08a9: conv.r8
+		IL_08aa: ldstr ""
+		IL_08af: ldc.i4.0
+		IL_08b0: ldc.i4.0
+		IL_08b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08b6: stloc.s 44
+		IL_08b8: ldnull
+		IL_08b9: ldstr "Compiled Variable Empty Replace"
+		IL_08be: ldloc.s 44
+		IL_08c0: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_08c5: pop
+		IL_08c6: ldc.i4.1
+		IL_08c7: newarr [System.Runtime]System.Object
+		IL_08cc: dup
 		IL_08cd: ldc.i4.0
-		IL_08ce: ldelem.ref
-		IL_08cf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_08d4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_08d9: ldc.i4.0
-		IL_08da: conv.r8
-		IL_08db: ldstr ""
+		IL_08ce: ldloc.0
+		IL_08cf: stelem.ref
+		IL_08d0: stloc.s 6
+		IL_08d2: ldloc.s 6
+		IL_08d4: ldc.i4.0
+		IL_08d5: ldelem.ref
+		IL_08d6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_08db: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_08e0: ldc.i4.0
-		IL_08e1: ldc.i4.0
-		IL_08e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08e7: stloc.s 40
-		IL_08e9: ldloc.s 4
-		IL_08eb: ldloc.s 6
-		IL_08ed: ldstr "Compiled Variable Match"
-		IL_08f2: ldloc.s 40
-		IL_08f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_08f9: pop
-		IL_08fa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08ff: stloc.s 6
-		IL_0901: ldc.i4.1
-		IL_0902: newarr [System.Runtime]System.Object
-		IL_0907: dup
-		IL_0908: ldc.i4.0
-		IL_0909: ldloc.0
-		IL_090a: stelem.ref
-		IL_090b: stloc.s 14
-		IL_090d: ldloc.s 14
-		IL_090f: ldc.i4.0
-		IL_0910: ldelem.ref
-		IL_0911: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0916: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_08e1: conv.r8
+		IL_08e2: ldstr ""
+		IL_08e7: ldc.i4.0
+		IL_08e8: ldc.i4.0
+		IL_08e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08ee: stloc.s 45
+		IL_08f0: ldnull
+		IL_08f1: ldloc.s 45
+		IL_08f3: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_08f8: pop
+		IL_08f9: ldc.i4.1
+		IL_08fa: newarr [System.Runtime]System.Object
+		IL_08ff: dup
+		IL_0900: ldc.i4.0
+		IL_0901: ldloc.0
+		IL_0902: stelem.ref
+		IL_0903: stloc.s 6
+		IL_0905: ldloc.s 6
+		IL_0907: ldc.i4.0
+		IL_0908: ldelem.ref
+		IL_0909: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_090e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0913: ldc.i4.0
+		IL_0914: conv.r8
+		IL_0915: ldstr ""
+		IL_091a: ldc.i4.0
 		IL_091b: ldc.i4.0
-		IL_091c: conv.r8
-		IL_091d: ldstr ""
-		IL_0922: ldc.i4.0
-		IL_0923: ldc.i4.0
-		IL_0924: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0929: stloc.s 41
-		IL_092b: ldloc.3
-		IL_092c: ldloc.s 6
-		IL_092e: ldloc.s 41
-		IL_0930: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0935: pop
-		IL_0936: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_091c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0921: stloc.s 46
+		IL_0923: ldnull
+		IL_0924: ldstr "Compiled Variable 12 Char Replace"
+		IL_0929: ldloc.s 46
+		IL_092b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0930: pop
+		IL_0931: ldc.i4.1
+		IL_0932: newarr [System.Runtime]System.Object
+		IL_0937: dup
+		IL_0938: ldc.i4.0
+		IL_0939: ldloc.0
+		IL_093a: stelem.ref
 		IL_093b: stloc.s 6
-		IL_093d: ldc.i4.1
-		IL_093e: newarr [System.Runtime]System.Object
-		IL_0943: dup
-		IL_0944: ldc.i4.0
-		IL_0945: ldloc.0
-		IL_0946: stelem.ref
-		IL_0947: stloc.s 14
-		IL_0949: ldloc.s 14
+		IL_093d: ldloc.s 6
+		IL_093f: ldc.i4.0
+		IL_0940: ldelem.ref
+		IL_0941: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0946: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_094b: ldc.i4.0
-		IL_094c: ldelem.ref
-		IL_094d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0952: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0957: ldc.i4.0
-		IL_0958: conv.r8
-		IL_0959: ldstr ""
-		IL_095e: ldc.i4.0
-		IL_095f: ldc.i4.0
-		IL_0960: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0965: stloc.s 42
-		IL_0967: ldloc.s 4
-		IL_0969: ldloc.s 6
-		IL_096b: ldstr "Compiled Variable Test"
-		IL_0970: ldloc.s 42
-		IL_0972: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0977: pop
-		IL_0978: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_097d: stloc.s 6
-		IL_097f: ldc.i4.1
-		IL_0980: newarr [System.Runtime]System.Object
-		IL_0985: dup
+		IL_094c: conv.r8
+		IL_094d: ldstr ""
+		IL_0952: ldc.i4.0
+		IL_0953: ldc.i4.0
+		IL_0954: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0959: stloc.s 47
+		IL_095b: ldnull
+		IL_095c: ldloc.s 47
+		IL_095e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0963: pop
+		IL_0964: ldc.i4.1
+		IL_0965: newarr [System.Runtime]System.Object
+		IL_096a: dup
+		IL_096b: ldc.i4.0
+		IL_096c: ldloc.0
+		IL_096d: stelem.ref
+		IL_096e: stloc.s 6
+		IL_0970: ldloc.s 6
+		IL_0972: ldc.i4.0
+		IL_0973: ldelem.ref
+		IL_0974: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0979: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_097e: ldc.i4.0
+		IL_097f: conv.r8
+		IL_0980: ldstr ""
+		IL_0985: ldc.i4.0
 		IL_0986: ldc.i4.0
-		IL_0987: ldloc.0
-		IL_0988: stelem.ref
-		IL_0989: stloc.s 14
-		IL_098b: ldloc.s 14
-		IL_098d: ldc.i4.0
-		IL_098e: ldelem.ref
-		IL_098f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0994: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0999: ldc.i4.0
-		IL_099a: conv.r8
-		IL_099b: ldstr ""
-		IL_09a0: ldc.i4.0
-		IL_09a1: ldc.i4.0
-		IL_09a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_09a7: stloc.s 43
-		IL_09a9: ldloc.3
-		IL_09aa: ldloc.s 6
-		IL_09ac: ldloc.s 43
-		IL_09ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_09b3: pop
-		IL_09b4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_09b9: stloc.s 6
-		IL_09bb: ldc.i4.1
-		IL_09bc: newarr [System.Runtime]System.Object
-		IL_09c1: dup
-		IL_09c2: ldc.i4.0
-		IL_09c3: ldloc.0
-		IL_09c4: stelem.ref
-		IL_09c5: stloc.s 14
-		IL_09c7: ldloc.s 14
-		IL_09c9: ldc.i4.0
-		IL_09ca: ldelem.ref
-		IL_09cb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_09d0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_09d5: ldc.i4.0
-		IL_09d6: conv.r8
-		IL_09d7: ldstr ""
-		IL_09dc: ldc.i4.0
+		IL_0987: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_098c: stloc.s 48
+		IL_098e: ldnull
+		IL_098f: ldstr "Compiled Variable Object Match"
+		IL_0994: ldloc.s 48
+		IL_0996: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_099b: pop
+		IL_099c: ldc.i4.1
+		IL_099d: newarr [System.Runtime]System.Object
+		IL_09a2: dup
+		IL_09a3: ldc.i4.0
+		IL_09a4: ldloc.0
+		IL_09a5: stelem.ref
+		IL_09a6: stloc.s 6
+		IL_09a8: ldloc.s 6
+		IL_09aa: ldc.i4.0
+		IL_09ab: ldelem.ref
+		IL_09ac: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_09b1: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_09b6: ldc.i4.0
+		IL_09b7: conv.r8
+		IL_09b8: ldstr ""
+		IL_09bd: ldc.i4.0
+		IL_09be: ldc.i4.0
+		IL_09bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_09c4: stloc.s 49
+		IL_09c6: ldnull
+		IL_09c7: ldloc.s 49
+		IL_09c9: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_09ce: pop
+		IL_09cf: ldc.i4.1
+		IL_09d0: newarr [System.Runtime]System.Object
+		IL_09d5: dup
+		IL_09d6: ldc.i4.0
+		IL_09d7: ldloc.0
+		IL_09d8: stelem.ref
+		IL_09d9: stloc.s 6
+		IL_09db: ldloc.s 6
 		IL_09dd: ldc.i4.0
-		IL_09de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_09e3: stloc.s 44
-		IL_09e5: ldloc.s 4
-		IL_09e7: ldloc.s 6
-		IL_09e9: ldstr "Compiled Variable Empty Replace"
-		IL_09ee: ldloc.s 44
-		IL_09f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_09f5: pop
-		IL_09f6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_09fb: stloc.s 6
-		IL_09fd: ldc.i4.1
-		IL_09fe: newarr [System.Runtime]System.Object
-		IL_0a03: dup
-		IL_0a04: ldc.i4.0
-		IL_0a05: ldloc.0
-		IL_0a06: stelem.ref
-		IL_0a07: stloc.s 14
-		IL_0a09: ldloc.s 14
-		IL_0a0b: ldc.i4.0
-		IL_0a0c: ldelem.ref
-		IL_0a0d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a12: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0a17: ldc.i4.0
-		IL_0a18: conv.r8
-		IL_0a19: ldstr ""
-		IL_0a1e: ldc.i4.0
-		IL_0a1f: ldc.i4.0
-		IL_0a20: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0a25: stloc.s 45
-		IL_0a27: ldloc.3
-		IL_0a28: ldloc.s 6
-		IL_0a2a: ldloc.s 45
-		IL_0a2c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0a31: pop
-		IL_0a32: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0a37: stloc.s 6
-		IL_0a39: ldc.i4.1
-		IL_0a3a: newarr [System.Runtime]System.Object
-		IL_0a3f: dup
-		IL_0a40: ldc.i4.0
-		IL_0a41: ldloc.0
-		IL_0a42: stelem.ref
-		IL_0a43: stloc.s 14
-		IL_0a45: ldloc.s 14
-		IL_0a47: ldc.i4.0
-		IL_0a48: ldelem.ref
-		IL_0a49: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a4e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0a53: ldc.i4.0
-		IL_0a54: conv.r8
-		IL_0a55: ldstr ""
-		IL_0a5a: ldc.i4.0
+		IL_09de: ldelem.ref
+		IL_09df: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_09e4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_09e9: ldc.i4.0
+		IL_09ea: conv.r8
+		IL_09eb: ldstr ""
+		IL_09f0: ldc.i4.0
+		IL_09f1: ldc.i4.0
+		IL_09f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_09f7: stloc.s 50
+		IL_09f9: ldnull
+		IL_09fa: ldstr "Compiled Variable Object Test"
+		IL_09ff: ldloc.s 50
+		IL_0a01: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0a06: pop
+		IL_0a07: ldc.i4.1
+		IL_0a08: newarr [System.Runtime]System.Object
+		IL_0a0d: dup
+		IL_0a0e: ldc.i4.0
+		IL_0a0f: ldloc.0
+		IL_0a10: stelem.ref
+		IL_0a11: stloc.s 6
+		IL_0a13: ldloc.s 6
+		IL_0a15: ldc.i4.0
+		IL_0a16: ldelem.ref
+		IL_0a17: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a1c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a21: ldc.i4.0
+		IL_0a22: conv.r8
+		IL_0a23: ldstr ""
+		IL_0a28: ldc.i4.0
+		IL_0a29: ldc.i4.0
+		IL_0a2a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a2f: stloc.s 51
+		IL_0a31: ldnull
+		IL_0a32: ldloc.s 51
+		IL_0a34: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0a39: pop
+		IL_0a3a: ldc.i4.1
+		IL_0a3b: newarr [System.Runtime]System.Object
+		IL_0a40: dup
+		IL_0a41: ldc.i4.0
+		IL_0a42: ldloc.0
+		IL_0a43: stelem.ref
+		IL_0a44: stloc.s 6
+		IL_0a46: ldloc.s 6
+		IL_0a48: ldc.i4.0
+		IL_0a49: ldelem.ref
+		IL_0a4a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a4f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a54: ldc.i4.0
+		IL_0a55: conv.r8
+		IL_0a56: ldstr ""
 		IL_0a5b: ldc.i4.0
-		IL_0a5c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0a61: stloc.s 46
-		IL_0a63: ldloc.s 4
-		IL_0a65: ldloc.s 6
-		IL_0a67: ldstr "Compiled Variable 12 Char Replace"
-		IL_0a6c: ldloc.s 46
-		IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0a73: pop
-		IL_0a74: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0a79: stloc.s 6
-		IL_0a7b: ldc.i4.1
-		IL_0a7c: newarr [System.Runtime]System.Object
-		IL_0a81: dup
-		IL_0a82: ldc.i4.0
-		IL_0a83: ldloc.0
-		IL_0a84: stelem.ref
-		IL_0a85: stloc.s 14
-		IL_0a87: ldloc.s 14
-		IL_0a89: ldc.i4.0
-		IL_0a8a: ldelem.ref
-		IL_0a8b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a90: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0a95: ldc.i4.0
-		IL_0a96: conv.r8
-		IL_0a97: ldstr ""
-		IL_0a9c: ldc.i4.0
-		IL_0a9d: ldc.i4.0
-		IL_0a9e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0aa3: stloc.s 47
-		IL_0aa5: ldloc.3
-		IL_0aa6: ldloc.s 6
-		IL_0aa8: ldloc.s 47
-		IL_0aaa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0aaf: pop
-		IL_0ab0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0ab5: stloc.s 6
-		IL_0ab7: ldc.i4.1
-		IL_0ab8: newarr [System.Runtime]System.Object
-		IL_0abd: dup
-		IL_0abe: ldc.i4.0
-		IL_0abf: ldloc.0
-		IL_0ac0: stelem.ref
-		IL_0ac1: stloc.s 14
-		IL_0ac3: ldloc.s 14
-		IL_0ac5: ldc.i4.0
-		IL_0ac6: ldelem.ref
-		IL_0ac7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0acc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0ad1: ldc.i4.0
-		IL_0ad2: conv.r8
-		IL_0ad3: ldstr ""
-		IL_0ad8: ldc.i4.0
-		IL_0ad9: ldc.i4.0
-		IL_0ada: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0adf: stloc.s 48
-		IL_0ae1: ldloc.s 4
-		IL_0ae3: ldloc.s 6
-		IL_0ae5: ldstr "Compiled Variable Object Match"
-		IL_0aea: ldloc.s 48
-		IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0af1: pop
-		IL_0af2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0af7: stloc.s 6
-		IL_0af9: ldc.i4.1
-		IL_0afa: newarr [System.Runtime]System.Object
-		IL_0aff: dup
-		IL_0b00: ldc.i4.0
-		IL_0b01: ldloc.0
-		IL_0b02: stelem.ref
-		IL_0b03: stloc.s 14
-		IL_0b05: ldloc.s 14
-		IL_0b07: ldc.i4.0
-		IL_0b08: ldelem.ref
-		IL_0b09: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b0e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0b13: ldc.i4.0
-		IL_0b14: conv.r8
-		IL_0b15: ldstr ""
-		IL_0b1a: ldc.i4.0
-		IL_0b1b: ldc.i4.0
-		IL_0b1c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b21: stloc.s 49
-		IL_0b23: ldloc.3
-		IL_0b24: ldloc.s 6
-		IL_0b26: ldloc.s 49
-		IL_0b28: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0b2d: pop
-		IL_0b2e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0b33: stloc.s 6
-		IL_0b35: ldc.i4.1
-		IL_0b36: newarr [System.Runtime]System.Object
-		IL_0b3b: dup
-		IL_0b3c: ldc.i4.0
-		IL_0b3d: ldloc.0
-		IL_0b3e: stelem.ref
-		IL_0b3f: stloc.s 14
-		IL_0b41: ldloc.s 14
-		IL_0b43: ldc.i4.0
-		IL_0b44: ldelem.ref
-		IL_0b45: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b4a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a5c: ldc.i4.0
+		IL_0a5d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a62: stloc.s 52
+		IL_0a64: ldnull
+		IL_0a65: ldstr "Compiled Variable Object Empty Replace"
+		IL_0a6a: ldloc.s 52
+		IL_0a6c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0a71: pop
+		IL_0a72: ldc.i4.1
+		IL_0a73: newarr [System.Runtime]System.Object
+		IL_0a78: dup
+		IL_0a79: ldc.i4.0
+		IL_0a7a: ldloc.0
+		IL_0a7b: stelem.ref
+		IL_0a7c: stloc.s 6
+		IL_0a7e: ldloc.s 6
+		IL_0a80: ldc.i4.0
+		IL_0a81: ldelem.ref
+		IL_0a82: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a87: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a8c: ldc.i4.0
+		IL_0a8d: conv.r8
+		IL_0a8e: ldstr ""
+		IL_0a93: ldc.i4.0
+		IL_0a94: ldc.i4.0
+		IL_0a95: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a9a: stloc.s 53
+		IL_0a9c: ldnull
+		IL_0a9d: ldloc.s 53
+		IL_0a9f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0aa4: pop
+		IL_0aa5: ldc.i4.1
+		IL_0aa6: newarr [System.Runtime]System.Object
+		IL_0aab: dup
+		IL_0aac: ldc.i4.0
+		IL_0aad: ldloc.0
+		IL_0aae: stelem.ref
+		IL_0aaf: stloc.s 6
+		IL_0ab1: ldloc.s 6
+		IL_0ab3: ldc.i4.0
+		IL_0ab4: ldelem.ref
+		IL_0ab5: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0aba: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0abf: ldc.i4.0
+		IL_0ac0: conv.r8
+		IL_0ac1: ldstr ""
+		IL_0ac6: ldc.i4.0
+		IL_0ac7: ldc.i4.0
+		IL_0ac8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0acd: stloc.s 54
+		IL_0acf: ldnull
+		IL_0ad0: ldstr "Compiled Variable Object 12 Char Replace"
+		IL_0ad5: ldloc.s 54
+		IL_0ad7: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0adc: pop
+		IL_0add: ldc.i4.1
+		IL_0ade: newarr [System.Runtime]System.Object
+		IL_0ae3: dup
+		IL_0ae4: ldc.i4.0
+		IL_0ae5: ldloc.0
+		IL_0ae6: stelem.ref
+		IL_0ae7: stloc.s 6
+		IL_0ae9: ldloc.s 6
+		IL_0aeb: ldc.i4.0
+		IL_0aec: ldelem.ref
+		IL_0aed: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0af2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0af7: ldc.i4.0
+		IL_0af8: conv.r8
+		IL_0af9: ldstr ""
+		IL_0afe: ldc.i4.0
+		IL_0aff: ldc.i4.0
+		IL_0b00: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b05: stloc.s 55
+		IL_0b07: ldnull
+		IL_0b08: ldloc.s 55
+		IL_0b0a: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0b0f: pop
+		IL_0b10: ldc.i4.1
+		IL_0b11: newarr [System.Runtime]System.Object
+		IL_0b16: dup
+		IL_0b17: ldc.i4.0
+		IL_0b18: ldloc.0
+		IL_0b19: stelem.ref
+		IL_0b1a: stloc.s 6
+		IL_0b1c: ldloc.s 6
+		IL_0b1e: ldc.i4.0
+		IL_0b1f: ldelem.ref
+		IL_0b20: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b25: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b2a: ldc.i4.0
+		IL_0b2b: conv.r8
+		IL_0b2c: ldstr ""
+		IL_0b31: ldc.i4.0
+		IL_0b32: ldc.i4.0
+		IL_0b33: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b38: stloc.s 56
+		IL_0b3a: ldnull
+		IL_0b3b: ldstr "Compiled Variable Object 12 Char Replace Function"
+		IL_0b40: ldloc.s 56
+		IL_0b42: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0b47: pop
+		IL_0b48: ldc.i4.1
+		IL_0b49: newarr [System.Runtime]System.Object
+		IL_0b4e: dup
 		IL_0b4f: ldc.i4.0
-		IL_0b50: conv.r8
-		IL_0b51: ldstr ""
+		IL_0b50: ldloc.0
+		IL_0b51: stelem.ref
+		IL_0b52: stloc.s 6
+		IL_0b54: ldloc.s 6
 		IL_0b56: ldc.i4.0
-		IL_0b57: ldc.i4.0
-		IL_0b58: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b5d: stloc.s 50
-		IL_0b5f: ldloc.s 4
-		IL_0b61: ldloc.s 6
-		IL_0b63: ldstr "Compiled Variable Object Test"
-		IL_0b68: ldloc.s 50
-		IL_0b6a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0b6f: pop
-		IL_0b70: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0b75: stloc.s 6
-		IL_0b77: ldc.i4.1
-		IL_0b78: newarr [System.Runtime]System.Object
-		IL_0b7d: dup
-		IL_0b7e: ldc.i4.0
-		IL_0b7f: ldloc.0
-		IL_0b80: stelem.ref
-		IL_0b81: stloc.s 14
-		IL_0b83: ldloc.s 14
-		IL_0b85: ldc.i4.0
-		IL_0b86: ldelem.ref
-		IL_0b87: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b8c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0b91: ldc.i4.0
-		IL_0b92: conv.r8
-		IL_0b93: ldstr ""
-		IL_0b98: ldc.i4.0
-		IL_0b99: ldc.i4.0
-		IL_0b9a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b9f: stloc.s 51
-		IL_0ba1: ldloc.3
-		IL_0ba2: ldloc.s 6
-		IL_0ba4: ldloc.s 51
-		IL_0ba6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0bab: pop
-		IL_0bac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0bb1: stloc.s 6
+		IL_0b57: ldelem.ref
+		IL_0b58: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b5d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b62: ldc.i4.0
+		IL_0b63: conv.r8
+		IL_0b64: ldstr ""
+		IL_0b69: ldc.i4.0
+		IL_0b6a: ldc.i4.0
+		IL_0b6b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b70: stloc.s 57
+		IL_0b72: ldnull
+		IL_0b73: ldloc.s 57
+		IL_0b75: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0b7a: pop
+		IL_0b7b: ldc.i4.1
+		IL_0b7c: newarr [System.Runtime]System.Object
+		IL_0b81: dup
+		IL_0b82: ldc.i4.0
+		IL_0b83: ldloc.0
+		IL_0b84: stelem.ref
+		IL_0b85: stloc.s 6
+		IL_0b87: ldloc.s 6
+		IL_0b89: ldc.i4.0
+		IL_0b8a: ldelem.ref
+		IL_0b8b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b90: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b95: ldc.i4.0
+		IL_0b96: conv.r8
+		IL_0b97: ldstr ""
+		IL_0b9c: ldc.i4.0
+		IL_0b9d: ldc.i4.0
+		IL_0b9e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0ba3: stloc.s 58
+		IL_0ba5: ldnull
+		IL_0ba6: ldstr "Compiled Capture Match"
+		IL_0bab: ldloc.s 58
+		IL_0bad: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0bb2: pop
 		IL_0bb3: ldc.i4.1
 		IL_0bb4: newarr [System.Runtime]System.Object
 		IL_0bb9: dup
 		IL_0bba: ldc.i4.0
 		IL_0bbb: ldloc.0
 		IL_0bbc: stelem.ref
-		IL_0bbd: stloc.s 14
-		IL_0bbf: ldloc.s 14
+		IL_0bbd: stloc.s 6
+		IL_0bbf: ldloc.s 6
 		IL_0bc1: ldc.i4.0
 		IL_0bc2: ldelem.ref
 		IL_0bc3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0bc8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0bc8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0bcd: ldc.i4.0
 		IL_0bce: conv.r8
 		IL_0bcf: ldstr ""
 		IL_0bd4: ldc.i4.0
 		IL_0bd5: ldc.i4.0
-		IL_0bd6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0bdb: stloc.s 52
-		IL_0bdd: ldloc.s 4
-		IL_0bdf: ldloc.s 6
-		IL_0be1: ldstr "Compiled Variable Object Empty Replace"
-		IL_0be6: ldloc.s 52
-		IL_0be8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0bed: pop
-		IL_0bee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0bf3: stloc.s 6
-		IL_0bf5: ldc.i4.1
-		IL_0bf6: newarr [System.Runtime]System.Object
-		IL_0bfb: dup
-		IL_0bfc: ldc.i4.0
-		IL_0bfd: ldloc.0
-		IL_0bfe: stelem.ref
-		IL_0bff: stloc.s 14
-		IL_0c01: ldloc.s 14
-		IL_0c03: ldc.i4.0
-		IL_0c04: ldelem.ref
-		IL_0c05: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c0a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0c0f: ldc.i4.0
-		IL_0c10: conv.r8
-		IL_0c11: ldstr ""
-		IL_0c16: ldc.i4.0
-		IL_0c17: ldc.i4.0
-		IL_0c18: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0c1d: stloc.s 53
-		IL_0c1f: ldloc.3
-		IL_0c20: ldloc.s 6
-		IL_0c22: ldloc.s 53
-		IL_0c24: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0c29: pop
-		IL_0c2a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0c2f: stloc.s 6
-		IL_0c31: ldc.i4.1
-		IL_0c32: newarr [System.Runtime]System.Object
-		IL_0c37: dup
+		IL_0bd6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0bdb: stloc.s 59
+		IL_0bdd: ldnull
+		IL_0bde: ldloc.s 59
+		IL_0be0: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0be5: pop
+		IL_0be6: ldc.i4.1
+		IL_0be7: newarr [System.Runtime]System.Object
+		IL_0bec: dup
+		IL_0bed: ldc.i4.0
+		IL_0bee: ldloc.0
+		IL_0bef: stelem.ref
+		IL_0bf0: stloc.s 6
+		IL_0bf2: ldloc.s 6
+		IL_0bf4: ldc.i4.0
+		IL_0bf5: ldelem.ref
+		IL_0bf6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0bfb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c00: ldc.i4.0
+		IL_0c01: conv.r8
+		IL_0c02: ldstr ""
+		IL_0c07: ldc.i4.0
+		IL_0c08: ldc.i4.0
+		IL_0c09: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c0e: stloc.s 60
+		IL_0c10: ldnull
+		IL_0c11: ldstr "Compiled Capture Replace"
+		IL_0c16: ldloc.s 60
+		IL_0c18: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0c1d: pop
+		IL_0c1e: ldc.i4.1
+		IL_0c1f: newarr [System.Runtime]System.Object
+		IL_0c24: dup
+		IL_0c25: ldc.i4.0
+		IL_0c26: ldloc.0
+		IL_0c27: stelem.ref
+		IL_0c28: stloc.s 6
+		IL_0c2a: ldloc.s 6
+		IL_0c2c: ldc.i4.0
+		IL_0c2d: ldelem.ref
+		IL_0c2e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c33: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0c38: ldc.i4.0
-		IL_0c39: ldloc.0
-		IL_0c3a: stelem.ref
-		IL_0c3b: stloc.s 14
-		IL_0c3d: ldloc.s 14
+		IL_0c39: conv.r8
+		IL_0c3a: ldstr ""
 		IL_0c3f: ldc.i4.0
-		IL_0c40: ldelem.ref
-		IL_0c41: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c46: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0c4b: ldc.i4.0
-		IL_0c4c: conv.r8
-		IL_0c4d: ldstr ""
-		IL_0c52: ldc.i4.0
-		IL_0c53: ldc.i4.0
-		IL_0c54: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0c59: stloc.s 54
-		IL_0c5b: ldloc.s 4
+		IL_0c40: ldc.i4.0
+		IL_0c41: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c46: stloc.s 61
+		IL_0c48: ldnull
+		IL_0c49: ldloc.s 61
+		IL_0c4b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0c50: pop
+		IL_0c51: ldc.i4.1
+		IL_0c52: newarr [System.Runtime]System.Object
+		IL_0c57: dup
+		IL_0c58: ldc.i4.0
+		IL_0c59: ldloc.0
+		IL_0c5a: stelem.ref
+		IL_0c5b: stloc.s 6
 		IL_0c5d: ldloc.s 6
-		IL_0c5f: ldstr "Compiled Variable Object 12 Char Replace"
-		IL_0c64: ldloc.s 54
-		IL_0c66: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0c6b: pop
-		IL_0c6c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0c71: stloc.s 6
-		IL_0c73: ldc.i4.1
-		IL_0c74: newarr [System.Runtime]System.Object
-		IL_0c79: dup
-		IL_0c7a: ldc.i4.0
-		IL_0c7b: ldloc.0
-		IL_0c7c: stelem.ref
-		IL_0c7d: stloc.s 14
-		IL_0c7f: ldloc.s 14
-		IL_0c81: ldc.i4.0
-		IL_0c82: ldelem.ref
-		IL_0c83: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c88: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0c8d: ldc.i4.0
-		IL_0c8e: conv.r8
-		IL_0c8f: ldstr ""
-		IL_0c94: ldc.i4.0
-		IL_0c95: ldc.i4.0
-		IL_0c96: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0c9b: stloc.s 55
-		IL_0c9d: ldloc.3
-		IL_0c9e: ldloc.s 6
-		IL_0ca0: ldloc.s 55
-		IL_0ca2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0ca7: pop
-		IL_0ca8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0cad: stloc.s 6
-		IL_0caf: ldc.i4.1
-		IL_0cb0: newarr [System.Runtime]System.Object
-		IL_0cb5: dup
-		IL_0cb6: ldc.i4.0
-		IL_0cb7: ldloc.0
-		IL_0cb8: stelem.ref
-		IL_0cb9: stloc.s 14
-		IL_0cbb: ldloc.s 14
-		IL_0cbd: ldc.i4.0
-		IL_0cbe: ldelem.ref
-		IL_0cbf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0cc4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0cc9: ldc.i4.0
-		IL_0cca: conv.r8
-		IL_0ccb: ldstr ""
-		IL_0cd0: ldc.i4.0
-		IL_0cd1: ldc.i4.0
-		IL_0cd2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0cd7: stloc.s 56
-		IL_0cd9: ldloc.s 4
-		IL_0cdb: ldloc.s 6
-		IL_0cdd: ldstr "Compiled Variable Object 12 Char Replace Function"
-		IL_0ce2: ldloc.s 56
-		IL_0ce4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0ce9: pop
-		IL_0cea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0cef: stloc.s 6
-		IL_0cf1: ldc.i4.1
-		IL_0cf2: newarr [System.Runtime]System.Object
-		IL_0cf7: dup
-		IL_0cf8: ldc.i4.0
-		IL_0cf9: ldloc.0
-		IL_0cfa: stelem.ref
-		IL_0cfb: stloc.s 14
-		IL_0cfd: ldloc.s 14
-		IL_0cff: ldc.i4.0
-		IL_0d00: ldelem.ref
-		IL_0d01: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d06: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0d0b: ldc.i4.0
-		IL_0d0c: conv.r8
-		IL_0d0d: ldstr ""
-		IL_0d12: ldc.i4.0
-		IL_0d13: ldc.i4.0
-		IL_0d14: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0d19: stloc.s 57
-		IL_0d1b: ldloc.3
-		IL_0d1c: ldloc.s 6
-		IL_0d1e: ldloc.s 57
-		IL_0d20: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0d25: pop
-		IL_0d26: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0d2b: stloc.s 6
-		IL_0d2d: ldc.i4.1
-		IL_0d2e: newarr [System.Runtime]System.Object
-		IL_0d33: dup
-		IL_0d34: ldc.i4.0
-		IL_0d35: ldloc.0
-		IL_0d36: stelem.ref
-		IL_0d37: stloc.s 14
-		IL_0d39: ldloc.s 14
-		IL_0d3b: ldc.i4.0
-		IL_0d3c: ldelem.ref
-		IL_0d3d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d42: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0d47: ldc.i4.0
-		IL_0d48: conv.r8
-		IL_0d49: ldstr ""
-		IL_0d4e: ldc.i4.0
-		IL_0d4f: ldc.i4.0
-		IL_0d50: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0d55: stloc.s 58
-		IL_0d57: ldloc.s 4
-		IL_0d59: ldloc.s 6
-		IL_0d5b: ldstr "Compiled Capture Match"
-		IL_0d60: ldloc.s 58
-		IL_0d62: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0d67: pop
-		IL_0d68: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0d6d: stloc.s 6
-		IL_0d6f: ldc.i4.1
-		IL_0d70: newarr [System.Runtime]System.Object
-		IL_0d75: dup
-		IL_0d76: ldc.i4.0
-		IL_0d77: ldloc.0
-		IL_0d78: stelem.ref
-		IL_0d79: stloc.s 14
-		IL_0d7b: ldloc.s 14
-		IL_0d7d: ldc.i4.0
-		IL_0d7e: ldelem.ref
-		IL_0d7f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d84: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0d89: ldc.i4.0
-		IL_0d8a: conv.r8
-		IL_0d8b: ldstr ""
-		IL_0d90: ldc.i4.0
-		IL_0d91: ldc.i4.0
-		IL_0d92: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0d97: stloc.s 59
-		IL_0d99: ldloc.3
-		IL_0d9a: ldloc.s 6
-		IL_0d9c: ldloc.s 59
-		IL_0d9e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0da3: pop
-		IL_0da4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0da9: stloc.s 6
-		IL_0dab: ldc.i4.1
-		IL_0dac: newarr [System.Runtime]System.Object
-		IL_0db1: dup
-		IL_0db2: ldc.i4.0
-		IL_0db3: ldloc.0
-		IL_0db4: stelem.ref
-		IL_0db5: stloc.s 14
-		IL_0db7: ldloc.s 14
-		IL_0db9: ldc.i4.0
-		IL_0dba: ldelem.ref
-		IL_0dbb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0dc0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0dc5: ldc.i4.0
-		IL_0dc6: conv.r8
-		IL_0dc7: ldstr ""
-		IL_0dcc: ldc.i4.0
-		IL_0dcd: ldc.i4.0
-		IL_0dce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0dd3: stloc.s 60
-		IL_0dd5: ldloc.s 4
-		IL_0dd7: ldloc.s 6
-		IL_0dd9: ldstr "Compiled Capture Replace"
-		IL_0dde: ldloc.s 60
-		IL_0de0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0de5: pop
-		IL_0de6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0deb: stloc.s 6
-		IL_0ded: ldc.i4.1
-		IL_0dee: newarr [System.Runtime]System.Object
-		IL_0df3: dup
-		IL_0df4: ldc.i4.0
-		IL_0df5: ldloc.0
-		IL_0df6: stelem.ref
-		IL_0df7: stloc.s 14
-		IL_0df9: ldloc.s 14
-		IL_0dfb: ldc.i4.0
-		IL_0dfc: ldelem.ref
-		IL_0dfd: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e02: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0e07: ldc.i4.0
-		IL_0e08: conv.r8
-		IL_0e09: ldstr ""
-		IL_0e0e: ldc.i4.0
-		IL_0e0f: ldc.i4.0
-		IL_0e10: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0e15: stloc.s 61
-		IL_0e17: ldloc.3
-		IL_0e18: ldloc.s 6
-		IL_0e1a: ldloc.s 61
-		IL_0e1c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0e21: pop
-		IL_0e22: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0e27: stloc.s 6
-		IL_0e29: ldc.i4.1
-		IL_0e2a: newarr [System.Runtime]System.Object
-		IL_0e2f: dup
-		IL_0e30: ldc.i4.0
-		IL_0e31: ldloc.0
-		IL_0e32: stelem.ref
-		IL_0e33: stloc.s 14
-		IL_0e35: ldloc.s 14
-		IL_0e37: ldc.i4.0
-		IL_0e38: ldelem.ref
-		IL_0e39: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e3e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c5f: ldc.i4.0
+		IL_0c60: ldelem.ref
+		IL_0c61: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c66: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c6b: ldc.i4.0
+		IL_0c6c: conv.r8
+		IL_0c6d: ldstr ""
+		IL_0c72: ldc.i4.0
+		IL_0c73: ldc.i4.0
+		IL_0c74: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c79: stloc.s 62
+		IL_0c7b: ldnull
+		IL_0c7c: ldstr "Compiled Capture Replace with Capture"
+		IL_0c81: ldloc.s 62
+		IL_0c83: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0c88: pop
+		IL_0c89: ldc.i4.1
+		IL_0c8a: newarr [System.Runtime]System.Object
+		IL_0c8f: dup
+		IL_0c90: ldc.i4.0
+		IL_0c91: ldloc.0
+		IL_0c92: stelem.ref
+		IL_0c93: stloc.s 6
+		IL_0c95: ldloc.s 6
+		IL_0c97: ldc.i4.0
+		IL_0c98: ldelem.ref
+		IL_0c99: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c9e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ca3: ldc.i4.0
+		IL_0ca4: conv.r8
+		IL_0ca5: ldstr ""
+		IL_0caa: ldc.i4.0
+		IL_0cab: ldc.i4.0
+		IL_0cac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0cb1: stloc.s 63
+		IL_0cb3: ldnull
+		IL_0cb4: ldloc.s 63
+		IL_0cb6: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0cbb: pop
+		IL_0cbc: ldc.i4.1
+		IL_0cbd: newarr [System.Runtime]System.Object
+		IL_0cc2: dup
+		IL_0cc3: ldc.i4.0
+		IL_0cc4: ldloc.0
+		IL_0cc5: stelem.ref
+		IL_0cc6: stloc.s 6
+		IL_0cc8: ldloc.s 6
+		IL_0cca: ldc.i4.0
+		IL_0ccb: ldelem.ref
+		IL_0ccc: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0cd1: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0cd6: ldc.i4.0
+		IL_0cd7: conv.r8
+		IL_0cd8: ldstr ""
+		IL_0cdd: ldc.i4.0
+		IL_0cde: ldc.i4.0
+		IL_0cdf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0ce4: stloc.s 64
+		IL_0ce6: ldnull
+		IL_0ce7: ldstr "Compiled Capture Replace with Capture Function"
+		IL_0cec: ldloc.s 64
+		IL_0cee: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0cf3: pop
+		IL_0cf4: ldc.i4.1
+		IL_0cf5: newarr [System.Runtime]System.Object
+		IL_0cfa: dup
+		IL_0cfb: ldc.i4.0
+		IL_0cfc: ldloc.0
+		IL_0cfd: stelem.ref
+		IL_0cfe: stloc.s 6
+		IL_0d00: ldloc.s 6
+		IL_0d02: ldc.i4.0
+		IL_0d03: ldelem.ref
+		IL_0d04: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d09: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d0e: ldc.i4.0
+		IL_0d0f: conv.r8
+		IL_0d10: ldstr ""
+		IL_0d15: ldc.i4.0
+		IL_0d16: ldc.i4.0
+		IL_0d17: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d1c: stloc.s 65
+		IL_0d1e: ldnull
+		IL_0d1f: ldloc.s 65
+		IL_0d21: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0d26: pop
+		IL_0d27: ldc.i4.1
+		IL_0d28: newarr [System.Runtime]System.Object
+		IL_0d2d: dup
+		IL_0d2e: ldc.i4.0
+		IL_0d2f: ldloc.0
+		IL_0d30: stelem.ref
+		IL_0d31: stloc.s 6
+		IL_0d33: ldloc.s 6
+		IL_0d35: ldc.i4.0
+		IL_0d36: ldelem.ref
+		IL_0d37: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d3c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d41: ldc.i4.0
+		IL_0d42: conv.r8
+		IL_0d43: ldstr ""
+		IL_0d48: ldc.i4.0
+		IL_0d49: ldc.i4.0
+		IL_0d4a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d4f: stloc.s 66
+		IL_0d51: ldnull
+		IL_0d52: ldstr "Compiled Capture Replace with Upperase Capture Function"
+		IL_0d57: ldloc.s 66
+		IL_0d59: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0d5e: pop
+		IL_0d5f: ldc.i4.1
+		IL_0d60: newarr [System.Runtime]System.Object
+		IL_0d65: dup
+		IL_0d66: ldc.i4.0
+		IL_0d67: ldloc.0
+		IL_0d68: stelem.ref
+		IL_0d69: stloc.s 6
+		IL_0d6b: ldloc.s 6
+		IL_0d6d: ldc.i4.0
+		IL_0d6e: ldelem.ref
+		IL_0d6f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d74: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d79: ldc.i4.0
+		IL_0d7a: conv.r8
+		IL_0d7b: ldstr ""
+		IL_0d80: ldc.i4.0
+		IL_0d81: ldc.i4.0
+		IL_0d82: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d87: stloc.s 67
+		IL_0d89: ldnull
+		IL_0d8a: ldloc.s 67
+		IL_0d8c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0d91: pop
+		IL_0d92: ldc.i4.1
+		IL_0d93: newarr [System.Runtime]System.Object
+		IL_0d98: dup
+		IL_0d99: ldc.i4.0
+		IL_0d9a: ldloc.0
+		IL_0d9b: stelem.ref
+		IL_0d9c: stloc.s 6
+		IL_0d9e: ldloc.s 6
+		IL_0da0: ldc.i4.0
+		IL_0da1: ldelem.ref
+		IL_0da2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0da7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0dac: ldc.i4.0
+		IL_0dad: conv.r8
+		IL_0dae: ldstr ""
+		IL_0db3: ldc.i4.0
+		IL_0db4: ldc.i4.0
+		IL_0db5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0dba: stloc.s 68
+		IL_0dbc: ldnull
+		IL_0dbd: ldstr "Uncompiled Match"
+		IL_0dc2: ldloc.s 68
+		IL_0dc4: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0dc9: pop
+		IL_0dca: ldc.i4.1
+		IL_0dcb: newarr [System.Runtime]System.Object
+		IL_0dd0: dup
+		IL_0dd1: ldc.i4.0
+		IL_0dd2: ldloc.0
+		IL_0dd3: stelem.ref
+		IL_0dd4: stloc.s 6
+		IL_0dd6: ldloc.s 6
+		IL_0dd8: ldc.i4.0
+		IL_0dd9: ldelem.ref
+		IL_0dda: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0ddf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0de4: ldc.i4.0
+		IL_0de5: conv.r8
+		IL_0de6: ldstr ""
+		IL_0deb: ldc.i4.0
+		IL_0dec: ldc.i4.0
+		IL_0ded: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0df2: stloc.s 69
+		IL_0df4: ldnull
+		IL_0df5: ldloc.s 69
+		IL_0df7: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0dfc: pop
+		IL_0dfd: ldc.i4.1
+		IL_0dfe: newarr [System.Runtime]System.Object
+		IL_0e03: dup
+		IL_0e04: ldc.i4.0
+		IL_0e05: ldloc.0
+		IL_0e06: stelem.ref
+		IL_0e07: stloc.s 6
+		IL_0e09: ldloc.s 6
+		IL_0e0b: ldc.i4.0
+		IL_0e0c: ldelem.ref
+		IL_0e0d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e12: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e17: ldc.i4.0
+		IL_0e18: conv.r8
+		IL_0e19: ldstr ""
+		IL_0e1e: ldc.i4.0
+		IL_0e1f: ldc.i4.0
+		IL_0e20: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e25: stloc.s 70
+		IL_0e27: ldnull
+		IL_0e28: ldstr "Uncompiled Test"
+		IL_0e2d: ldloc.s 70
+		IL_0e2f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0e34: pop
+		IL_0e35: ldc.i4.1
+		IL_0e36: newarr [System.Runtime]System.Object
+		IL_0e3b: dup
+		IL_0e3c: ldc.i4.0
+		IL_0e3d: ldloc.0
+		IL_0e3e: stelem.ref
+		IL_0e3f: stloc.s 6
+		IL_0e41: ldloc.s 6
 		IL_0e43: ldc.i4.0
-		IL_0e44: conv.r8
-		IL_0e45: ldstr ""
-		IL_0e4a: ldc.i4.0
-		IL_0e4b: ldc.i4.0
-		IL_0e4c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0e51: stloc.s 62
-		IL_0e53: ldloc.s 4
-		IL_0e55: ldloc.s 6
-		IL_0e57: ldstr "Compiled Capture Replace with Capture"
-		IL_0e5c: ldloc.s 62
-		IL_0e5e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0e63: pop
-		IL_0e64: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0e69: stloc.s 6
-		IL_0e6b: ldc.i4.1
-		IL_0e6c: newarr [System.Runtime]System.Object
-		IL_0e71: dup
-		IL_0e72: ldc.i4.0
-		IL_0e73: ldloc.0
-		IL_0e74: stelem.ref
-		IL_0e75: stloc.s 14
-		IL_0e77: ldloc.s 14
-		IL_0e79: ldc.i4.0
-		IL_0e7a: ldelem.ref
-		IL_0e7b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e80: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0e85: ldc.i4.0
-		IL_0e86: conv.r8
-		IL_0e87: ldstr ""
-		IL_0e8c: ldc.i4.0
-		IL_0e8d: ldc.i4.0
-		IL_0e8e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0e93: stloc.s 63
-		IL_0e95: ldloc.3
-		IL_0e96: ldloc.s 6
-		IL_0e98: ldloc.s 63
-		IL_0e9a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0e44: ldelem.ref
+		IL_0e45: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e4a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e4f: ldc.i4.0
+		IL_0e50: conv.r8
+		IL_0e51: ldstr ""
+		IL_0e56: ldc.i4.0
+		IL_0e57: ldc.i4.0
+		IL_0e58: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e5d: stloc.s 71
+		IL_0e5f: ldnull
+		IL_0e60: ldloc.s 71
+		IL_0e62: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0e67: pop
+		IL_0e68: ldc.i4.1
+		IL_0e69: newarr [System.Runtime]System.Object
+		IL_0e6e: dup
+		IL_0e6f: ldc.i4.0
+		IL_0e70: ldloc.0
+		IL_0e71: stelem.ref
+		IL_0e72: stloc.s 6
+		IL_0e74: ldloc.s 6
+		IL_0e76: ldc.i4.0
+		IL_0e77: ldelem.ref
+		IL_0e78: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e7d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e82: ldc.i4.0
+		IL_0e83: conv.r8
+		IL_0e84: ldstr ""
+		IL_0e89: ldc.i4.0
+		IL_0e8a: ldc.i4.0
+		IL_0e8b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e90: stloc.s 72
+		IL_0e92: ldnull
+		IL_0e93: ldstr "Uncompiled Empty Replace"
+		IL_0e98: ldloc.s 72
+		IL_0e9a: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
 		IL_0e9f: pop
-		IL_0ea0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0ea5: stloc.s 6
-		IL_0ea7: ldc.i4.1
-		IL_0ea8: newarr [System.Runtime]System.Object
-		IL_0ead: dup
+		IL_0ea0: ldc.i4.1
+		IL_0ea1: newarr [System.Runtime]System.Object
+		IL_0ea6: dup
+		IL_0ea7: ldc.i4.0
+		IL_0ea8: ldloc.0
+		IL_0ea9: stelem.ref
+		IL_0eaa: stloc.s 6
+		IL_0eac: ldloc.s 6
 		IL_0eae: ldc.i4.0
-		IL_0eaf: ldloc.0
-		IL_0eb0: stelem.ref
-		IL_0eb1: stloc.s 14
-		IL_0eb3: ldloc.s 14
-		IL_0eb5: ldc.i4.0
-		IL_0eb6: ldelem.ref
-		IL_0eb7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ebc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0eaf: ldelem.ref
+		IL_0eb0: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0eb5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0eba: ldc.i4.0
+		IL_0ebb: conv.r8
+		IL_0ebc: ldstr ""
 		IL_0ec1: ldc.i4.0
-		IL_0ec2: conv.r8
-		IL_0ec3: ldstr ""
-		IL_0ec8: ldc.i4.0
-		IL_0ec9: ldc.i4.0
-		IL_0eca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0ecf: stloc.s 64
-		IL_0ed1: ldloc.s 4
-		IL_0ed3: ldloc.s 6
-		IL_0ed5: ldstr "Compiled Capture Replace with Capture Function"
-		IL_0eda: ldloc.s 64
-		IL_0edc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0ee1: pop
-		IL_0ee2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0ee7: stloc.s 6
-		IL_0ee9: ldc.i4.1
-		IL_0eea: newarr [System.Runtime]System.Object
-		IL_0eef: dup
-		IL_0ef0: ldc.i4.0
-		IL_0ef1: ldloc.0
-		IL_0ef2: stelem.ref
-		IL_0ef3: stloc.s 14
-		IL_0ef5: ldloc.s 14
-		IL_0ef7: ldc.i4.0
-		IL_0ef8: ldelem.ref
-		IL_0ef9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0efe: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0f03: ldc.i4.0
-		IL_0f04: conv.r8
-		IL_0f05: ldstr ""
-		IL_0f0a: ldc.i4.0
-		IL_0f0b: ldc.i4.0
-		IL_0f0c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0f11: stloc.s 65
-		IL_0f13: ldloc.3
-		IL_0f14: ldloc.s 6
-		IL_0f16: ldloc.s 65
-		IL_0f18: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0f1d: pop
-		IL_0f1e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0f23: stloc.s 6
-		IL_0f25: ldc.i4.1
-		IL_0f26: newarr [System.Runtime]System.Object
-		IL_0f2b: dup
+		IL_0ec2: ldc.i4.0
+		IL_0ec3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0ec8: stloc.s 73
+		IL_0eca: ldnull
+		IL_0ecb: ldloc.s 73
+		IL_0ecd: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0ed2: pop
+		IL_0ed3: ldc.i4.1
+		IL_0ed4: newarr [System.Runtime]System.Object
+		IL_0ed9: dup
+		IL_0eda: ldc.i4.0
+		IL_0edb: ldloc.0
+		IL_0edc: stelem.ref
+		IL_0edd: stloc.s 6
+		IL_0edf: ldloc.s 6
+		IL_0ee1: ldc.i4.0
+		IL_0ee2: ldelem.ref
+		IL_0ee3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0ee8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0eed: ldc.i4.0
+		IL_0eee: conv.r8
+		IL_0eef: ldstr ""
+		IL_0ef4: ldc.i4.0
+		IL_0ef5: ldc.i4.0
+		IL_0ef6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0efb: stloc.s 74
+		IL_0efd: ldnull
+		IL_0efe: ldstr "Uncompiled 12 Char Replace"
+		IL_0f03: ldloc.s 74
+		IL_0f05: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0f0a: pop
+		IL_0f0b: ldc.i4.1
+		IL_0f0c: newarr [System.Runtime]System.Object
+		IL_0f11: dup
+		IL_0f12: ldc.i4.0
+		IL_0f13: ldloc.0
+		IL_0f14: stelem.ref
+		IL_0f15: stloc.s 6
+		IL_0f17: ldloc.s 6
+		IL_0f19: ldc.i4.0
+		IL_0f1a: ldelem.ref
+		IL_0f1b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f20: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f25: ldc.i4.0
+		IL_0f26: conv.r8
+		IL_0f27: ldstr ""
 		IL_0f2c: ldc.i4.0
-		IL_0f2d: ldloc.0
-		IL_0f2e: stelem.ref
-		IL_0f2f: stloc.s 14
-		IL_0f31: ldloc.s 14
-		IL_0f33: ldc.i4.0
-		IL_0f34: ldelem.ref
-		IL_0f35: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f3a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0f3f: ldc.i4.0
-		IL_0f40: conv.r8
-		IL_0f41: ldstr ""
-		IL_0f46: ldc.i4.0
-		IL_0f47: ldc.i4.0
-		IL_0f48: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0f4d: stloc.s 66
-		IL_0f4f: ldloc.s 4
-		IL_0f51: ldloc.s 6
-		IL_0f53: ldstr "Compiled Capture Replace with Upperase Capture Function"
-		IL_0f58: ldloc.s 66
-		IL_0f5a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0f5f: pop
-		IL_0f60: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0f65: stloc.s 6
-		IL_0f67: ldc.i4.1
-		IL_0f68: newarr [System.Runtime]System.Object
-		IL_0f6d: dup
-		IL_0f6e: ldc.i4.0
-		IL_0f6f: ldloc.0
-		IL_0f70: stelem.ref
-		IL_0f71: stloc.s 14
-		IL_0f73: ldloc.s 14
-		IL_0f75: ldc.i4.0
-		IL_0f76: ldelem.ref
-		IL_0f77: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f7c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0f81: ldc.i4.0
-		IL_0f82: conv.r8
-		IL_0f83: ldstr ""
-		IL_0f88: ldc.i4.0
-		IL_0f89: ldc.i4.0
-		IL_0f8a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0f8f: stloc.s 67
-		IL_0f91: ldloc.3
-		IL_0f92: ldloc.s 6
-		IL_0f94: ldloc.s 67
-		IL_0f96: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0f9b: pop
-		IL_0f9c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0fa1: stloc.s 6
-		IL_0fa3: ldc.i4.1
-		IL_0fa4: newarr [System.Runtime]System.Object
-		IL_0fa9: dup
-		IL_0faa: ldc.i4.0
-		IL_0fab: ldloc.0
-		IL_0fac: stelem.ref
-		IL_0fad: stloc.s 14
-		IL_0faf: ldloc.s 14
-		IL_0fb1: ldc.i4.0
-		IL_0fb2: ldelem.ref
-		IL_0fb3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0fb8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0fbd: ldc.i4.0
-		IL_0fbe: conv.r8
-		IL_0fbf: ldstr ""
-		IL_0fc4: ldc.i4.0
-		IL_0fc5: ldc.i4.0
-		IL_0fc6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0fcb: stloc.s 68
-		IL_0fcd: ldloc.s 4
-		IL_0fcf: ldloc.s 6
-		IL_0fd1: ldstr "Uncompiled Match"
-		IL_0fd6: ldloc.s 68
-		IL_0fd8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0fdd: pop
-		IL_0fde: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0fe3: stloc.s 6
-		IL_0fe5: ldc.i4.1
-		IL_0fe6: newarr [System.Runtime]System.Object
-		IL_0feb: dup
-		IL_0fec: ldc.i4.0
-		IL_0fed: ldloc.0
-		IL_0fee: stelem.ref
-		IL_0fef: stloc.s 14
-		IL_0ff1: ldloc.s 14
-		IL_0ff3: ldc.i4.0
-		IL_0ff4: ldelem.ref
-		IL_0ff5: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ffa: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0fff: ldc.i4.0
-		IL_1000: conv.r8
-		IL_1001: ldstr ""
-		IL_1006: ldc.i4.0
-		IL_1007: ldc.i4.0
-		IL_1008: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_100d: stloc.s 69
-		IL_100f: ldloc.3
-		IL_1010: ldloc.s 6
-		IL_1012: ldloc.s 69
-		IL_1014: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1019: pop
-		IL_101a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_101f: stloc.s 6
-		IL_1021: ldc.i4.1
-		IL_1022: newarr [System.Runtime]System.Object
-		IL_1027: dup
-		IL_1028: ldc.i4.0
-		IL_1029: ldloc.0
-		IL_102a: stelem.ref
-		IL_102b: stloc.s 14
-		IL_102d: ldloc.s 14
-		IL_102f: ldc.i4.0
-		IL_1030: ldelem.ref
-		IL_1031: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1036: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_103b: ldc.i4.0
-		IL_103c: conv.r8
-		IL_103d: ldstr ""
-		IL_1042: ldc.i4.0
-		IL_1043: ldc.i4.0
-		IL_1044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1049: stloc.s 70
-		IL_104b: ldloc.s 4
-		IL_104d: ldloc.s 6
-		IL_104f: ldstr "Uncompiled Test"
-		IL_1054: ldloc.s 70
-		IL_1056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_105b: pop
-		IL_105c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1061: stloc.s 6
-		IL_1063: ldc.i4.1
-		IL_1064: newarr [System.Runtime]System.Object
-		IL_1069: dup
-		IL_106a: ldc.i4.0
-		IL_106b: ldloc.0
-		IL_106c: stelem.ref
-		IL_106d: stloc.s 14
-		IL_106f: ldloc.s 14
-		IL_1071: ldc.i4.0
-		IL_1072: ldelem.ref
-		IL_1073: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1078: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_107d: ldc.i4.0
-		IL_107e: conv.r8
-		IL_107f: ldstr ""
-		IL_1084: ldc.i4.0
-		IL_1085: ldc.i4.0
-		IL_1086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_108b: stloc.s 71
-		IL_108d: ldloc.3
-		IL_108e: ldloc.s 6
-		IL_1090: ldloc.s 71
-		IL_1092: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1097: pop
-		IL_1098: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_109d: stloc.s 6
-		IL_109f: ldc.i4.1
-		IL_10a0: newarr [System.Runtime]System.Object
-		IL_10a5: dup
-		IL_10a6: ldc.i4.0
-		IL_10a7: ldloc.0
-		IL_10a8: stelem.ref
-		IL_10a9: stloc.s 14
-		IL_10ab: ldloc.s 14
-		IL_10ad: ldc.i4.0
-		IL_10ae: ldelem.ref
-		IL_10af: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_10b4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_10b9: ldc.i4.0
-		IL_10ba: conv.r8
-		IL_10bb: ldstr ""
-		IL_10c0: ldc.i4.0
-		IL_10c1: ldc.i4.0
-		IL_10c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_10c7: stloc.s 72
-		IL_10c9: ldloc.s 4
-		IL_10cb: ldloc.s 6
-		IL_10cd: ldstr "Uncompiled Empty Replace"
-		IL_10d2: ldloc.s 72
-		IL_10d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_10d9: pop
-		IL_10da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_10df: stloc.s 6
-		IL_10e1: ldc.i4.1
-		IL_10e2: newarr [System.Runtime]System.Object
-		IL_10e7: dup
-		IL_10e8: ldc.i4.0
-		IL_10e9: ldloc.0
-		IL_10ea: stelem.ref
-		IL_10eb: stloc.s 14
-		IL_10ed: ldloc.s 14
-		IL_10ef: ldc.i4.0
-		IL_10f0: ldelem.ref
-		IL_10f1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_10f6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_10fb: ldc.i4.0
-		IL_10fc: conv.r8
-		IL_10fd: ldstr ""
-		IL_1102: ldc.i4.0
-		IL_1103: ldc.i4.0
-		IL_1104: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1109: stloc.s 73
-		IL_110b: ldloc.3
-		IL_110c: ldloc.s 6
-		IL_110e: ldloc.s 73
-		IL_1110: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1115: pop
-		IL_1116: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_111b: stloc.s 6
-		IL_111d: ldc.i4.1
-		IL_111e: newarr [System.Runtime]System.Object
-		IL_1123: dup
-		IL_1124: ldc.i4.0
-		IL_1125: ldloc.0
-		IL_1126: stelem.ref
-		IL_1127: stloc.s 14
-		IL_1129: ldloc.s 14
-		IL_112b: ldc.i4.0
-		IL_112c: ldelem.ref
-		IL_112d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1132: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1137: ldc.i4.0
-		IL_1138: conv.r8
-		IL_1139: ldstr ""
-		IL_113e: ldc.i4.0
-		IL_113f: ldc.i4.0
-		IL_1140: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1145: stloc.s 74
-		IL_1147: ldloc.s 4
-		IL_1149: ldloc.s 6
-		IL_114b: ldstr "Uncompiled 12 Char Replace"
-		IL_1150: ldloc.s 74
-		IL_1152: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_1157: pop
-		IL_1158: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_115d: stloc.s 6
-		IL_115f: ldc.i4.1
-		IL_1160: newarr [System.Runtime]System.Object
-		IL_1165: dup
-		IL_1166: ldc.i4.0
-		IL_1167: ldloc.0
-		IL_1168: stelem.ref
-		IL_1169: stloc.s 14
-		IL_116b: ldloc.s 14
-		IL_116d: ldc.i4.0
-		IL_116e: ldelem.ref
-		IL_116f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1174: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1179: ldc.i4.0
-		IL_117a: conv.r8
-		IL_117b: ldstr ""
-		IL_1180: ldc.i4.0
-		IL_1181: ldc.i4.0
-		IL_1182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1187: stloc.s 75
-		IL_1189: ldloc.3
-		IL_118a: ldloc.s 6
-		IL_118c: ldloc.s 75
-		IL_118e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1193: pop
-		IL_1194: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1199: stloc.s 6
-		IL_119b: ldc.i4.1
-		IL_119c: newarr [System.Runtime]System.Object
-		IL_11a1: dup
-		IL_11a2: ldc.i4.0
-		IL_11a3: ldloc.0
-		IL_11a4: stelem.ref
-		IL_11a5: stloc.s 14
-		IL_11a7: ldloc.s 14
-		IL_11a9: ldc.i4.0
-		IL_11aa: ldelem.ref
-		IL_11ab: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_11b0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_11b5: ldc.i4.0
-		IL_11b6: conv.r8
-		IL_11b7: ldstr ""
-		IL_11bc: ldc.i4.0
-		IL_11bd: ldc.i4.0
-		IL_11be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_11c3: stloc.s 76
-		IL_11c5: ldloc.s 4
-		IL_11c7: ldloc.s 6
-		IL_11c9: ldstr "Uncompiled Object Match"
-		IL_11ce: ldloc.s 76
-		IL_11d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_11d5: pop
-		IL_11d6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_11db: stloc.s 6
-		IL_11dd: ldc.i4.1
-		IL_11de: newarr [System.Runtime]System.Object
-		IL_11e3: dup
-		IL_11e4: ldc.i4.0
-		IL_11e5: ldloc.0
-		IL_11e6: stelem.ref
-		IL_11e7: stloc.s 14
-		IL_11e9: ldloc.s 14
-		IL_11eb: ldc.i4.0
-		IL_11ec: ldelem.ref
-		IL_11ed: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_11f2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_11f7: ldc.i4.0
-		IL_11f8: conv.r8
-		IL_11f9: ldstr ""
-		IL_11fe: ldc.i4.0
-		IL_11ff: ldc.i4.0
-		IL_1200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1205: stloc.s 77
-		IL_1207: ldloc.3
-		IL_1208: ldloc.s 6
-		IL_120a: ldloc.s 77
-		IL_120c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1211: pop
-		IL_1212: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1217: stloc.s 6
-		IL_1219: ldc.i4.1
-		IL_121a: newarr [System.Runtime]System.Object
-		IL_121f: dup
-		IL_1220: ldc.i4.0
-		IL_1221: ldloc.0
-		IL_1222: stelem.ref
-		IL_1223: stloc.s 14
-		IL_1225: ldloc.s 14
-		IL_1227: ldc.i4.0
-		IL_1228: ldelem.ref
-		IL_1229: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_122e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1233: ldc.i4.0
-		IL_1234: conv.r8
-		IL_1235: ldstr ""
-		IL_123a: ldc.i4.0
-		IL_123b: ldc.i4.0
-		IL_123c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1241: stloc.s 78
-		IL_1243: ldloc.s 4
-		IL_1245: ldloc.s 6
-		IL_1247: ldstr "Uncompiled Object Test"
-		IL_124c: ldloc.s 78
-		IL_124e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_1253: pop
-		IL_1254: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1259: stloc.s 6
-		IL_125b: ldc.i4.1
-		IL_125c: newarr [System.Runtime]System.Object
-		IL_1261: dup
-		IL_1262: ldc.i4.0
-		IL_1263: ldloc.0
-		IL_1264: stelem.ref
-		IL_1265: stloc.s 14
-		IL_1267: ldloc.s 14
-		IL_1269: ldc.i4.0
-		IL_126a: ldelem.ref
-		IL_126b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1270: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1275: ldc.i4.0
-		IL_1276: conv.r8
-		IL_1277: ldstr ""
-		IL_127c: ldc.i4.0
-		IL_127d: ldc.i4.0
-		IL_127e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1283: stloc.s 79
-		IL_1285: ldloc.3
-		IL_1286: ldloc.s 6
-		IL_1288: ldloc.s 79
-		IL_128a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_128f: pop
-		IL_1290: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1295: stloc.s 6
-		IL_1297: ldc.i4.1
-		IL_1298: newarr [System.Runtime]System.Object
-		IL_129d: dup
-		IL_129e: ldc.i4.0
-		IL_129f: ldloc.0
-		IL_12a0: stelem.ref
-		IL_12a1: stloc.s 14
-		IL_12a3: ldloc.s 14
-		IL_12a5: ldc.i4.0
-		IL_12a6: ldelem.ref
-		IL_12a7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_12ac: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_12b1: ldc.i4.0
-		IL_12b2: conv.r8
-		IL_12b3: ldstr ""
-		IL_12b8: ldc.i4.0
-		IL_12b9: ldc.i4.0
-		IL_12ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_12bf: stloc.s 80
-		IL_12c1: ldloc.s 4
-		IL_12c3: ldloc.s 6
-		IL_12c5: ldstr "Uncompiled Object Empty Replace"
-		IL_12ca: ldloc.s 80
-		IL_12cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_12d1: pop
-		IL_12d2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_12d7: stloc.s 6
-		IL_12d9: ldc.i4.1
-		IL_12da: newarr [System.Runtime]System.Object
-		IL_12df: dup
-		IL_12e0: ldc.i4.0
-		IL_12e1: ldloc.0
-		IL_12e2: stelem.ref
-		IL_12e3: stloc.s 14
-		IL_12e5: ldloc.s 14
-		IL_12e7: ldc.i4.0
-		IL_12e8: ldelem.ref
-		IL_12e9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_12ee: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_12f3: ldc.i4.0
-		IL_12f4: conv.r8
-		IL_12f5: ldstr ""
-		IL_12fa: ldc.i4.0
-		IL_12fb: ldc.i4.0
-		IL_12fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1301: stloc.s 81
-		IL_1303: ldloc.3
-		IL_1304: ldloc.s 6
-		IL_1306: ldloc.s 81
-		IL_1308: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_130d: pop
-		IL_130e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1313: stloc.s 6
-		IL_1315: ldc.i4.1
-		IL_1316: newarr [System.Runtime]System.Object
-		IL_131b: dup
-		IL_131c: ldc.i4.0
-		IL_131d: ldloc.0
-		IL_131e: stelem.ref
-		IL_131f: stloc.s 14
-		IL_1321: ldloc.s 14
-		IL_1323: ldc.i4.0
-		IL_1324: ldelem.ref
-		IL_1325: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_132a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_132f: ldc.i4.0
-		IL_1330: conv.r8
-		IL_1331: ldstr ""
-		IL_1336: ldc.i4.0
-		IL_1337: ldc.i4.0
-		IL_1338: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_133d: stloc.s 82
-		IL_133f: ldloc.s 4
-		IL_1341: ldloc.s 6
-		IL_1343: ldstr "Uncompiled Object 12 Char Replace"
-		IL_1348: ldloc.s 82
-		IL_134a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_134f: pop
-		IL_1350: ldloc.2
-		IL_1351: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1356: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_135b: pop
-		IL_135c: ret
+		IL_0f2d: ldc.i4.0
+		IL_0f2e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0f33: stloc.s 75
+		IL_0f35: ldnull
+		IL_0f36: ldloc.s 75
+		IL_0f38: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0f3d: pop
+		IL_0f3e: ldc.i4.1
+		IL_0f3f: newarr [System.Runtime]System.Object
+		IL_0f44: dup
+		IL_0f45: ldc.i4.0
+		IL_0f46: ldloc.0
+		IL_0f47: stelem.ref
+		IL_0f48: stloc.s 6
+		IL_0f4a: ldloc.s 6
+		IL_0f4c: ldc.i4.0
+		IL_0f4d: ldelem.ref
+		IL_0f4e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f53: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f58: ldc.i4.0
+		IL_0f59: conv.r8
+		IL_0f5a: ldstr ""
+		IL_0f5f: ldc.i4.0
+		IL_0f60: ldc.i4.0
+		IL_0f61: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0f66: stloc.s 76
+		IL_0f68: ldnull
+		IL_0f69: ldstr "Uncompiled Object Match"
+		IL_0f6e: ldloc.s 76
+		IL_0f70: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0f75: pop
+		IL_0f76: ldc.i4.1
+		IL_0f77: newarr [System.Runtime]System.Object
+		IL_0f7c: dup
+		IL_0f7d: ldc.i4.0
+		IL_0f7e: ldloc.0
+		IL_0f7f: stelem.ref
+		IL_0f80: stloc.s 6
+		IL_0f82: ldloc.s 6
+		IL_0f84: ldc.i4.0
+		IL_0f85: ldelem.ref
+		IL_0f86: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f8b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f90: ldc.i4.0
+		IL_0f91: conv.r8
+		IL_0f92: ldstr ""
+		IL_0f97: ldc.i4.0
+		IL_0f98: ldc.i4.0
+		IL_0f99: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0f9e: stloc.s 77
+		IL_0fa0: ldnull
+		IL_0fa1: ldloc.s 77
+		IL_0fa3: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_0fa8: pop
+		IL_0fa9: ldc.i4.1
+		IL_0faa: newarr [System.Runtime]System.Object
+		IL_0faf: dup
+		IL_0fb0: ldc.i4.0
+		IL_0fb1: ldloc.0
+		IL_0fb2: stelem.ref
+		IL_0fb3: stloc.s 6
+		IL_0fb5: ldloc.s 6
+		IL_0fb7: ldc.i4.0
+		IL_0fb8: ldelem.ref
+		IL_0fb9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0fbe: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0fc3: ldc.i4.0
+		IL_0fc4: conv.r8
+		IL_0fc5: ldstr ""
+		IL_0fca: ldc.i4.0
+		IL_0fcb: ldc.i4.0
+		IL_0fcc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0fd1: stloc.s 78
+		IL_0fd3: ldnull
+		IL_0fd4: ldstr "Uncompiled Object Test"
+		IL_0fd9: ldloc.s 78
+		IL_0fdb: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_0fe0: pop
+		IL_0fe1: ldc.i4.1
+		IL_0fe2: newarr [System.Runtime]System.Object
+		IL_0fe7: dup
+		IL_0fe8: ldc.i4.0
+		IL_0fe9: ldloc.0
+		IL_0fea: stelem.ref
+		IL_0feb: stloc.s 6
+		IL_0fed: ldloc.s 6
+		IL_0fef: ldc.i4.0
+		IL_0ff0: ldelem.ref
+		IL_0ff1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0ff6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ffb: ldc.i4.0
+		IL_0ffc: conv.r8
+		IL_0ffd: ldstr ""
+		IL_1002: ldc.i4.0
+		IL_1003: ldc.i4.0
+		IL_1004: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1009: stloc.s 79
+		IL_100b: ldnull
+		IL_100c: ldloc.s 79
+		IL_100e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_1013: pop
+		IL_1014: ldc.i4.1
+		IL_1015: newarr [System.Runtime]System.Object
+		IL_101a: dup
+		IL_101b: ldc.i4.0
+		IL_101c: ldloc.0
+		IL_101d: stelem.ref
+		IL_101e: stloc.s 6
+		IL_1020: ldloc.s 6
+		IL_1022: ldc.i4.0
+		IL_1023: ldelem.ref
+		IL_1024: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1029: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_102e: ldc.i4.0
+		IL_102f: conv.r8
+		IL_1030: ldstr ""
+		IL_1035: ldc.i4.0
+		IL_1036: ldc.i4.0
+		IL_1037: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_103c: stloc.s 80
+		IL_103e: ldnull
+		IL_103f: ldstr "Uncompiled Object Empty Replace"
+		IL_1044: ldloc.s 80
+		IL_1046: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_104b: pop
+		IL_104c: ldc.i4.1
+		IL_104d: newarr [System.Runtime]System.Object
+		IL_1052: dup
+		IL_1053: ldc.i4.0
+		IL_1054: ldloc.0
+		IL_1055: stelem.ref
+		IL_1056: stloc.s 6
+		IL_1058: ldloc.s 6
+		IL_105a: ldc.i4.0
+		IL_105b: ldelem.ref
+		IL_105c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1061: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1066: ldc.i4.0
+		IL_1067: conv.r8
+		IL_1068: ldstr ""
+		IL_106d: ldc.i4.0
+		IL_106e: ldc.i4.0
+		IL_106f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1074: stloc.s 81
+		IL_1076: ldnull
+		IL_1077: ldloc.s 81
+		IL_1079: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+		IL_107e: pop
+		IL_107f: ldc.i4.1
+		IL_1080: newarr [System.Runtime]System.Object
+		IL_1085: dup
+		IL_1086: ldc.i4.0
+		IL_1087: ldloc.0
+		IL_1088: stelem.ref
+		IL_1089: stloc.s 6
+		IL_108b: ldloc.s 6
+		IL_108d: ldc.i4.0
+		IL_108e: ldelem.ref
+		IL_108f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1094: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1099: ldc.i4.0
+		IL_109a: conv.r8
+		IL_109b: ldstr ""
+		IL_10a0: ldc.i4.0
+		IL_10a1: ldc.i4.0
+		IL_10a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_10a7: stloc.s 82
+		IL_10a9: ldnull
+		IL_10aa: ldstr "Uncompiled Object 12 Char Replace"
+		IL_10af: ldloc.s 82
+		IL_10b1: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+		IL_10b6: pop
+		IL_10b7: ldnull
+		IL_10b8: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
+		IL_10bd: pop
+		IL_10be: ret
 	} // end of method Compile_Performance_Dromaeo_Object_Regexp::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Regexp

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_String.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_String.verified.txt
@@ -6528,7 +6528,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1943 (0x797)
+		// Code size: 1723 (0x6bb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_String/Scope,
@@ -6538,34 +6538,33 @@
 			[4] class Modules.Compile_Performance_Dromaeo_Object_String/test/FunctionObject,
 			[5] float64,
 			[6] object[],
-			[7] object[],
-			[8] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject,
-			[9] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject,
-			[10] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject,
-			[11] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[13] float64,
-			[14] string,
+			[7] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject,
+			[8] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject,
+			[9] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject,
+			[10] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[12] float64,
+			[13] string,
+			[14] object,
 			[15] object,
 			[16] object,
-			[17] object,
-			[18] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject,
-			[19] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject,
-			[20] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject,
-			[21] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject,
-			[22] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject,
-			[23] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject,
-			[24] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject,
-			[25] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject,
-			[26] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject,
-			[27] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject,
-			[28] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject,
-			[29] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject,
-			[30] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject,
-			[31] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject,
-			[32] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject,
-			[33] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject,
-			[34] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject
+			[17] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject,
+			[18] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject,
+			[19] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject,
+			[20] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject,
+			[21] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject,
+			[22] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject,
+			[23] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject,
+			[24] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject,
+			[25] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject,
+			[26] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject,
+			[27] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject,
+			[28] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject,
+			[29] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject,
+			[30] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject,
+			[31] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject,
+			[32] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject,
+			[33] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/Scope::.ctor()
@@ -6635,705 +6634,638 @@
 		IL_0089: nop
 		IL_008a: nop
 		IL_008b: nop
-		IL_008c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0091: stloc.s 6
-		IL_0093: ldloc.1
-		IL_0094: ldloc.s 6
-		IL_0096: ldstr "dromaeo-object-string"
-		IL_009b: ldstr "ef8605c3"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00a5: pop
-		IL_00a6: ldloc.0
-		IL_00a7: ldnull
-		IL_00a8: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-		IL_00ad: ldloc.0
-		IL_00ae: ldc.r8 5000
-		IL_00b7: box [System.Runtime]System.Double
-		IL_00bc: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
-		IL_00c1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00c6: stloc.s 6
-		IL_00c8: ldc.i4.1
-		IL_00c9: newarr [System.Runtime]System.Object
-		IL_00ce: dup
-		IL_00cf: ldc.i4.0
-		IL_00d0: ldloc.0
-		IL_00d1: stelem.ref
-		IL_00d2: stloc.s 7
-		IL_00d4: ldloc.s 7
-		IL_00d6: ldc.i4.0
-		IL_00d7: ldelem.ref
-		IL_00d8: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_00dd: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_00e2: ldc.i4.0
-		IL_00e3: conv.r8
-		IL_00e4: ldstr ""
-		IL_00e9: ldc.i4.0
-		IL_00ea: ldc.i4.0
-		IL_00eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00f0: stloc.s 8
-		IL_00f2: ldloc.s 4
-		IL_00f4: ldloc.s 6
-		IL_00f6: ldstr "Concat String"
-		IL_00fb: ldloc.s 8
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0102: pop
-		IL_0103: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0108: stloc.s 6
-		IL_010a: ldc.i4.1
-		IL_010b: newarr [System.Runtime]System.Object
-		IL_0110: dup
+		IL_008c: ldnull
+		IL_008d: ldstr "dromaeo-object-string"
+		IL_0092: ldstr "ef8605c3"
+		IL_0097: call object Modules.Compile_Performance_Dromaeo_Object_String/startTest::__js_call__(object, string, string)
+		IL_009c: pop
+		IL_009d: ldloc.0
+		IL_009e: ldnull
+		IL_009f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+		IL_00a4: ldloc.0
+		IL_00a5: ldc.r8 5000
+		IL_00ae: box [System.Runtime]System.Double
+		IL_00b3: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+		IL_00b8: ldc.i4.1
+		IL_00b9: newarr [System.Runtime]System.Object
+		IL_00be: dup
+		IL_00bf: ldc.i4.0
+		IL_00c0: ldloc.0
+		IL_00c1: stelem.ref
+		IL_00c2: stloc.s 6
+		IL_00c4: ldloc.s 6
+		IL_00c6: ldc.i4.0
+		IL_00c7: ldelem.ref
+		IL_00c8: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_00cd: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_00d2: ldc.i4.0
+		IL_00d3: conv.r8
+		IL_00d4: ldstr ""
+		IL_00d9: ldc.i4.0
+		IL_00da: ldc.i4.0
+		IL_00db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e0: stloc.s 7
+		IL_00e2: ldnull
+		IL_00e3: ldstr "Concat String"
+		IL_00e8: ldloc.s 7
+		IL_00ea: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_00ef: pop
+		IL_00f0: ldc.i4.1
+		IL_00f1: newarr [System.Runtime]System.Object
+		IL_00f6: dup
+		IL_00f7: ldc.i4.0
+		IL_00f8: ldloc.0
+		IL_00f9: stelem.ref
+		IL_00fa: stloc.s 6
+		IL_00fc: ldloc.s 6
+		IL_00fe: ldc.i4.0
+		IL_00ff: ldelem.ref
+		IL_0100: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0105: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_010a: ldc.i4.0
+		IL_010b: conv.r8
+		IL_010c: ldstr ""
 		IL_0111: ldc.i4.0
-		IL_0112: ldloc.0
-		IL_0113: stelem.ref
-		IL_0114: stloc.s 7
-		IL_0116: ldloc.s 7
-		IL_0118: ldc.i4.0
-		IL_0119: ldelem.ref
-		IL_011a: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_011f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0124: ldc.i4.0
-		IL_0125: conv.r8
-		IL_0126: ldstr ""
-		IL_012b: ldc.i4.0
-		IL_012c: ldc.i4.0
-		IL_012d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0132: stloc.s 9
-		IL_0134: ldloc.s 4
-		IL_0136: ldloc.s 6
-		IL_0138: ldstr "Concat String Object"
-		IL_013d: ldloc.s 9
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0144: pop
-		IL_0145: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_014a: stloc.s 6
-		IL_014c: ldc.i4.1
-		IL_014d: newarr [System.Runtime]System.Object
-		IL_0152: dup
-		IL_0153: ldc.i4.0
-		IL_0154: ldloc.0
-		IL_0155: stelem.ref
-		IL_0156: stloc.s 7
-		IL_0158: ldloc.s 7
-		IL_015a: ldc.i4.0
-		IL_015b: ldelem.ref
-		IL_015c: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0161: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0166: ldc.i4.0
-		IL_0167: conv.r8
-		IL_0168: ldstr ""
-		IL_016d: ldc.i4.0
+		IL_0112: ldc.i4.0
+		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0118: stloc.s 8
+		IL_011a: ldnull
+		IL_011b: ldstr "Concat String Object"
+		IL_0120: ldloc.s 8
+		IL_0122: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_0127: pop
+		IL_0128: ldc.i4.1
+		IL_0129: newarr [System.Runtime]System.Object
+		IL_012e: dup
+		IL_012f: ldc.i4.0
+		IL_0130: ldloc.0
+		IL_0131: stelem.ref
+		IL_0132: stloc.s 6
+		IL_0134: ldloc.s 6
+		IL_0136: ldc.i4.0
+		IL_0137: ldelem.ref
+		IL_0138: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_013d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0142: ldc.i4.0
+		IL_0143: conv.r8
+		IL_0144: ldstr ""
+		IL_0149: ldc.i4.0
+		IL_014a: ldc.i4.0
+		IL_014b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0150: stloc.s 9
+		IL_0152: ldnull
+		IL_0153: ldstr "Concat String from charCode"
+		IL_0158: ldloc.s 9
+		IL_015a: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_015f: pop
+		IL_0160: ldc.i4.1
+		IL_0161: newarr [System.Runtime]System.Object
+		IL_0166: dup
+		IL_0167: ldc.i4.0
+		IL_0168: ldloc.0
+		IL_0169: stelem.ref
+		IL_016a: stloc.s 6
+		IL_016c: ldloc.s 6
 		IL_016e: ldc.i4.0
-		IL_016f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0174: stloc.s 10
-		IL_0176: ldloc.s 4
-		IL_0178: ldloc.s 6
-		IL_017a: ldstr "Concat String from charCode"
-		IL_017f: ldloc.s 10
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0186: pop
-		IL_0187: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_018c: stloc.s 6
-		IL_018e: ldc.i4.1
-		IL_018f: newarr [System.Runtime]System.Object
-		IL_0194: dup
-		IL_0195: ldc.i4.0
-		IL_0196: ldloc.0
-		IL_0197: stelem.ref
-		IL_0198: stloc.s 7
-		IL_019a: ldloc.s 7
-		IL_019c: ldc.i4.0
-		IL_019d: ldelem.ref
-		IL_019e: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_01a3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_01a8: ldc.i4.0
-		IL_01a9: conv.r8
-		IL_01aa: ldstr ""
-		IL_01af: ldc.i4.0
-		IL_01b0: ldc.i4.0
-		IL_01b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01b6: stloc.s 11
-		IL_01b8: ldloc.s 4
-		IL_01ba: ldloc.s 6
-		IL_01bc: ldstr "Array String Join"
-		IL_01c1: ldloc.s 11
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01c8: pop
-		IL_01c9: ldc.i4.0
-		IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01cf: stloc.s 12
-		IL_01d1: ldloc.0
-		IL_01d2: ldloc.s 12
-		IL_01d4: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_01d9: ldloc.0
-		IL_01da: ldnull
-		IL_01db: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp
-		IL_01e0: ldloc.0
-		IL_01e1: ldnull
-		IL_01e2: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp2
-		IL_01e7: ldloc.0
-		IL_01e8: ldc.r8 5000
-		IL_01f1: box [System.Runtime]System.Double
-		IL_01f6: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
-		IL_01fb: ldloc.0
-		IL_01fc: ldnull
-		IL_01fd: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
-		IL_0202: ldc.r8 0.0
-		IL_020b: stloc.s 5
-		// loop start (head: IL_020d)
-			IL_020d: ldloc.s 5
-			IL_020f: stloc.s 13
-			IL_0211: ldloc.s 13
-			IL_0213: ldc.r8 16384
-			IL_021c: clt
-			IL_021e: brfalse IL_029a
+		IL_016f: ldelem.ref
+		IL_0170: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0175: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_017a: ldc.i4.0
+		IL_017b: conv.r8
+		IL_017c: ldstr ""
+		IL_0181: ldc.i4.0
+		IL_0182: ldc.i4.0
+		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0188: stloc.s 10
+		IL_018a: ldnull
+		IL_018b: ldstr "Array String Join"
+		IL_0190: ldloc.s 10
+		IL_0192: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_0197: pop
+		IL_0198: ldc.i4.0
+		IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_019e: stloc.s 11
+		IL_01a0: ldloc.0
+		IL_01a1: ldloc.s 11
+		IL_01a3: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_01a8: ldloc.0
+		IL_01a9: ldnull
+		IL_01aa: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp
+		IL_01af: ldloc.0
+		IL_01b0: ldnull
+		IL_01b1: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp2
+		IL_01b6: ldloc.0
+		IL_01b7: ldc.r8 5000
+		IL_01c0: box [System.Runtime]System.Double
+		IL_01c5: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+		IL_01ca: ldloc.0
+		IL_01cb: ldnull
+		IL_01cc: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+		IL_01d1: ldc.r8 0.0
+		IL_01da: stloc.s 5
+		// loop start (head: IL_01dc)
+			IL_01dc: ldloc.s 5
+			IL_01de: stloc.s 12
+			IL_01e0: ldloc.s 12
+			IL_01e2: ldc.r8 16384
+			IL_01eb: clt
+			IL_01ed: brfalse IL_0269
 
-			IL_0223: ldloc.0
-			IL_0224: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022e: ldc.r8 25
-			IL_0237: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-			IL_023c: mul
-			IL_023d: ldc.r8 97
-			IL_0246: add
-			IL_0247: box [System.Runtime]System.Double
-			IL_024c: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
-			IL_0251: stloc.s 14
-			IL_0253: volatile.
-			IL_0255: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-			IL_025a: brfalse IL_0270
+			IL_01f2: ldloc.0
+			IL_01f3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01fd: ldc.r8 25
+			IL_0206: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_020b: mul
+			IL_020c: ldc.r8 97
+			IL_0215: add
+			IL_0216: box [System.Runtime]System.Double
+			IL_021b: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
+			IL_0220: stloc.s 13
+			IL_0222: volatile.
+			IL_0224: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0229: brfalse IL_023f
 
-			IL_025f: ldstr "push"
-			IL_0264: ldloc.s 14
-			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_026b: br IL_0286
+			IL_022e: ldstr "push"
+			IL_0233: ldloc.s 13
+			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_023a: br IL_0255
 
-			IL_0270: ldstr "push"
-			IL_0275: ldloc.s 14
-			IL_0277: ldstr "Compile_Performance_Dromaeo_Object_String:Modules.Compile_Performance_Dromaeo_Object_String:__js_module_init__:85"
-			IL_027c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_023f: ldstr "push"
+			IL_0244: ldloc.s 13
+			IL_0246: ldstr "Compile_Performance_Dromaeo_Object_String:Modules.Compile_Performance_Dromaeo_Object_String:__js_module_init__:85"
+			IL_024b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0286: pop
-			IL_0287: ldloc.s 5
-			IL_0289: ldc.r8 1
-			IL_0292: add
-			IL_0293: stloc.s 5
-			IL_0295: br IL_020d
+			IL_0255: pop
+			IL_0256: ldloc.s 5
+			IL_0258: ldc.r8 1
+			IL_0261: add
+			IL_0262: stloc.s 5
+			IL_0264: br IL_01dc
 		// end loop
 
-		IL_029a: ldloc.0
-		IL_029b: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a5: volatile.
-		IL_02a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_02ac: brfalse IL_02c5
+		IL_0269: ldloc.0
+		IL_026a: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0274: volatile.
+		IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_027b: brfalse IL_0294
 
-		IL_02b1: ldstr "join"
-		IL_02b6: ldstr ""
-		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c0: br IL_02de
+		IL_0280: ldstr "join"
+		IL_0285: ldstr ""
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028f: br IL_02ad
 
-		IL_02c5: ldstr "join"
-		IL_02ca: ldstr ""
-		IL_02cf: ldstr "Compile_Performance_Dromaeo_Object_String:Modules.Compile_Performance_Dromaeo_Object_String:__js_module_init__:96"
-		IL_02d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0294: ldstr "join"
+		IL_0299: ldstr ""
+		IL_029e: ldstr "Compile_Performance_Dromaeo_Object_String:Modules.Compile_Performance_Dromaeo_Object_String:__js_module_init__:96"
+		IL_02a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_02de: stloc.s 15
-		IL_02e0: ldloc.0
-		IL_02e1: ldloc.s 15
-		IL_02e3: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_02e8: ldloc.0
-		IL_02e9: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_02ee: stloc.s 15
-		IL_02f0: ldloc.0
-		IL_02f1: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_02f6: stloc.s 16
-		IL_02f8: ldloc.s 15
-		IL_02fa: ldloc.s 16
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0301: stloc.s 17
-		IL_0303: ldloc.0
-		IL_0304: ldloc.s 17
-		IL_0306: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_030b: ldloc.0
-		IL_030c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_0311: stloc.s 16
-		IL_0313: ldloc.0
-		IL_0314: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_0319: stloc.s 15
-		IL_031b: ldloc.s 16
-		IL_031d: ldloc.s 15
-		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0324: stloc.s 17
-		IL_0326: ldloc.0
-		IL_0327: ldloc.s 17
-		IL_0329: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
-		IL_032e: ldloc.0
-		IL_032f: ldnull
-		IL_0330: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-		IL_0335: ldc.r8 52288
-		IL_033e: stloc.s 5
-		IL_0340: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0345: stloc.s 6
-		IL_0347: ldc.i4.1
-		IL_0348: newarr [System.Runtime]System.Object
-		IL_034d: dup
-		IL_034e: ldc.i4.0
-		IL_034f: ldloc.0
-		IL_0350: stelem.ref
-		IL_0351: stloc.s 7
-		IL_0353: ldloc.s 7
-		IL_0355: ldc.i4.0
-		IL_0356: ldelem.ref
-		IL_0357: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_035c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0361: ldc.i4.0
-		IL_0362: conv.r8
-		IL_0363: ldstr ""
-		IL_0368: ldc.i4.0
-		IL_0369: ldc.i4.0
-		IL_036a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_036f: stloc.s 18
-		IL_0371: ldloc.3
-		IL_0372: ldloc.s 6
-		IL_0374: ldloc.s 18
-		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_037b: pop
-		IL_037c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0381: stloc.s 6
-		IL_0383: ldc.i4.1
-		IL_0384: newarr [System.Runtime]System.Object
-		IL_0389: dup
-		IL_038a: ldc.i4.0
-		IL_038b: ldloc.0
-		IL_038c: stelem.ref
-		IL_038d: stloc.s 7
-		IL_038f: ldloc.s 7
-		IL_0391: ldc.i4.0
-		IL_0392: ldelem.ref
-		IL_0393: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0398: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_039d: ldc.i4.0
-		IL_039e: conv.r8
-		IL_039f: ldstr ""
-		IL_03a4: ldc.i4.0
-		IL_03a5: ldc.i4.0
-		IL_03a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03ab: stloc.s 19
-		IL_03ad: ldloc.s 4
-		IL_03af: ldloc.s 6
-		IL_03b1: ldstr "String Split"
-		IL_03b6: ldloc.s 19
-		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_03bd: pop
-		IL_03be: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03c3: stloc.s 6
-		IL_03c5: ldc.i4.1
-		IL_03c6: newarr [System.Runtime]System.Object
-		IL_03cb: dup
-		IL_03cc: ldc.i4.0
-		IL_03cd: ldloc.0
-		IL_03ce: stelem.ref
-		IL_03cf: stloc.s 7
-		IL_03d1: ldloc.s 7
-		IL_03d3: ldc.i4.0
-		IL_03d4: ldelem.ref
-		IL_03d5: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_03da: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_03df: ldc.i4.0
-		IL_03e0: conv.r8
-		IL_03e1: ldstr ""
-		IL_03e6: ldc.i4.0
-		IL_03e7: ldc.i4.0
-		IL_03e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03ed: stloc.s 20
-		IL_03ef: ldloc.3
-		IL_03f0: ldloc.s 6
-		IL_03f2: ldloc.s 20
-		IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03f9: pop
-		IL_03fa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03ff: stloc.s 6
-		IL_0401: ldc.i4.1
-		IL_0402: newarr [System.Runtime]System.Object
-		IL_0407: dup
-		IL_0408: ldc.i4.0
-		IL_0409: ldloc.0
-		IL_040a: stelem.ref
-		IL_040b: stloc.s 7
-		IL_040d: ldloc.s 7
-		IL_040f: ldc.i4.0
-		IL_0410: ldelem.ref
-		IL_0411: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0416: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_041b: ldc.i4.0
-		IL_041c: conv.r8
-		IL_041d: ldstr ""
-		IL_0422: ldc.i4.0
-		IL_0423: ldc.i4.0
-		IL_0424: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0429: stloc.s 21
-		IL_042b: ldloc.s 4
-		IL_042d: ldloc.s 6
-		IL_042f: ldstr "String Split on Char"
-		IL_0434: ldloc.s 21
-		IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_043b: pop
-		IL_043c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0441: stloc.s 6
-		IL_0443: ldc.i4.1
-		IL_0444: newarr [System.Runtime]System.Object
-		IL_0449: dup
-		IL_044a: ldc.i4.0
-		IL_044b: ldloc.0
-		IL_044c: stelem.ref
-		IL_044d: stloc.s 7
-		IL_044f: ldloc.s 7
-		IL_0451: ldc.i4.0
-		IL_0452: ldelem.ref
-		IL_0453: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0458: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_045d: ldc.i4.0
-		IL_045e: conv.r8
-		IL_045f: ldstr ""
-		IL_0464: ldc.i4.0
-		IL_0465: ldc.i4.0
-		IL_0466: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_046b: stloc.s 22
-		IL_046d: ldloc.3
-		IL_046e: ldloc.s 6
-		IL_0470: ldloc.s 22
-		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0477: pop
-		IL_0478: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_047d: stloc.s 6
-		IL_047f: ldc.i4.1
-		IL_0480: newarr [System.Runtime]System.Object
-		IL_0485: dup
-		IL_0486: ldc.i4.0
-		IL_0487: ldloc.0
-		IL_0488: stelem.ref
-		IL_0489: stloc.s 7
-		IL_048b: ldloc.s 7
-		IL_048d: ldc.i4.0
-		IL_048e: ldelem.ref
-		IL_048f: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0494: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0499: ldc.i4.0
-		IL_049a: conv.r8
-		IL_049b: ldstr ""
-		IL_04a0: ldc.i4.0
-		IL_04a1: ldc.i4.0
-		IL_04a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04a7: stloc.s 23
-		IL_04a9: ldloc.s 4
-		IL_04ab: ldloc.s 6
-		IL_04ad: ldstr "charAt"
-		IL_04b2: ldloc.s 23
-		IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_04b9: pop
-		IL_04ba: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04bf: stloc.s 6
-		IL_04c1: ldc.i4.1
-		IL_04c2: newarr [System.Runtime]System.Object
-		IL_04c7: dup
-		IL_04c8: ldc.i4.0
-		IL_04c9: ldloc.0
-		IL_04ca: stelem.ref
-		IL_04cb: stloc.s 7
-		IL_04cd: ldloc.s 7
-		IL_04cf: ldc.i4.0
-		IL_04d0: ldelem.ref
-		IL_04d1: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_04d6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_04db: ldc.i4.0
-		IL_04dc: conv.r8
-		IL_04dd: ldstr ""
+		IL_02ad: stloc.s 14
+		IL_02af: ldloc.0
+		IL_02b0: ldloc.s 14
+		IL_02b2: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02b7: ldloc.0
+		IL_02b8: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02bd: stloc.s 14
+		IL_02bf: ldloc.0
+		IL_02c0: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02c5: stloc.s 15
+		IL_02c7: ldloc.s 14
+		IL_02c9: ldloc.s 15
+		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02d0: stloc.s 16
+		IL_02d2: ldloc.0
+		IL_02d3: ldloc.s 16
+		IL_02d5: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02da: ldloc.0
+		IL_02db: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02e0: stloc.s 15
+		IL_02e2: ldloc.0
+		IL_02e3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02e8: stloc.s 14
+		IL_02ea: ldloc.s 15
+		IL_02ec: ldloc.s 14
+		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02f3: stloc.s 16
+		IL_02f5: ldloc.0
+		IL_02f6: ldloc.s 16
+		IL_02f8: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02fd: ldloc.0
+		IL_02fe: ldnull
+		IL_02ff: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+		IL_0304: ldc.r8 52288
+		IL_030d: stloc.s 5
+		IL_030f: ldc.i4.1
+		IL_0310: newarr [System.Runtime]System.Object
+		IL_0315: dup
+		IL_0316: ldc.i4.0
+		IL_0317: ldloc.0
+		IL_0318: stelem.ref
+		IL_0319: stloc.s 6
+		IL_031b: ldloc.s 6
+		IL_031d: ldc.i4.0
+		IL_031e: ldelem.ref
+		IL_031f: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0324: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0329: ldc.i4.0
+		IL_032a: conv.r8
+		IL_032b: ldstr ""
+		IL_0330: ldc.i4.0
+		IL_0331: ldc.i4.0
+		IL_0332: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0337: stloc.s 17
+		IL_0339: ldnull
+		IL_033a: ldloc.s 17
+		IL_033c: call object Modules.Compile_Performance_Dromaeo_Object_String/prep::__js_call__(object, object)
+		IL_0341: pop
+		IL_0342: ldc.i4.1
+		IL_0343: newarr [System.Runtime]System.Object
+		IL_0348: dup
+		IL_0349: ldc.i4.0
+		IL_034a: ldloc.0
+		IL_034b: stelem.ref
+		IL_034c: stloc.s 6
+		IL_034e: ldloc.s 6
+		IL_0350: ldc.i4.0
+		IL_0351: ldelem.ref
+		IL_0352: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0357: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_035c: ldc.i4.0
+		IL_035d: conv.r8
+		IL_035e: ldstr ""
+		IL_0363: ldc.i4.0
+		IL_0364: ldc.i4.0
+		IL_0365: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_036a: stloc.s 18
+		IL_036c: ldnull
+		IL_036d: ldstr "String Split"
+		IL_0372: ldloc.s 18
+		IL_0374: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_0379: pop
+		IL_037a: ldc.i4.1
+		IL_037b: newarr [System.Runtime]System.Object
+		IL_0380: dup
+		IL_0381: ldc.i4.0
+		IL_0382: ldloc.0
+		IL_0383: stelem.ref
+		IL_0384: stloc.s 6
+		IL_0386: ldloc.s 6
+		IL_0388: ldc.i4.0
+		IL_0389: ldelem.ref
+		IL_038a: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_038f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0394: ldc.i4.0
+		IL_0395: conv.r8
+		IL_0396: ldstr ""
+		IL_039b: ldc.i4.0
+		IL_039c: ldc.i4.0
+		IL_039d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03a2: stloc.s 19
+		IL_03a4: ldnull
+		IL_03a5: ldloc.s 19
+		IL_03a7: call object Modules.Compile_Performance_Dromaeo_Object_String/prep::__js_call__(object, object)
+		IL_03ac: pop
+		IL_03ad: ldc.i4.1
+		IL_03ae: newarr [System.Runtime]System.Object
+		IL_03b3: dup
+		IL_03b4: ldc.i4.0
+		IL_03b5: ldloc.0
+		IL_03b6: stelem.ref
+		IL_03b7: stloc.s 6
+		IL_03b9: ldloc.s 6
+		IL_03bb: ldc.i4.0
+		IL_03bc: ldelem.ref
+		IL_03bd: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_03c2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_03c7: ldc.i4.0
+		IL_03c8: conv.r8
+		IL_03c9: ldstr ""
+		IL_03ce: ldc.i4.0
+		IL_03cf: ldc.i4.0
+		IL_03d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03d5: stloc.s 20
+		IL_03d7: ldnull
+		IL_03d8: ldstr "String Split on Char"
+		IL_03dd: ldloc.s 20
+		IL_03df: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_03e4: pop
+		IL_03e5: ldc.i4.1
+		IL_03e6: newarr [System.Runtime]System.Object
+		IL_03eb: dup
+		IL_03ec: ldc.i4.0
+		IL_03ed: ldloc.0
+		IL_03ee: stelem.ref
+		IL_03ef: stloc.s 6
+		IL_03f1: ldloc.s 6
+		IL_03f3: ldc.i4.0
+		IL_03f4: ldelem.ref
+		IL_03f5: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_03fa: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_03ff: ldc.i4.0
+		IL_0400: conv.r8
+		IL_0401: ldstr ""
+		IL_0406: ldc.i4.0
+		IL_0407: ldc.i4.0
+		IL_0408: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_040d: stloc.s 21
+		IL_040f: ldnull
+		IL_0410: ldloc.s 21
+		IL_0412: call object Modules.Compile_Performance_Dromaeo_Object_String/prep::__js_call__(object, object)
+		IL_0417: pop
+		IL_0418: ldc.i4.1
+		IL_0419: newarr [System.Runtime]System.Object
+		IL_041e: dup
+		IL_041f: ldc.i4.0
+		IL_0420: ldloc.0
+		IL_0421: stelem.ref
+		IL_0422: stloc.s 6
+		IL_0424: ldloc.s 6
+		IL_0426: ldc.i4.0
+		IL_0427: ldelem.ref
+		IL_0428: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_042d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0432: ldc.i4.0
+		IL_0433: conv.r8
+		IL_0434: ldstr ""
+		IL_0439: ldc.i4.0
+		IL_043a: ldc.i4.0
+		IL_043b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0440: stloc.s 22
+		IL_0442: ldnull
+		IL_0443: ldstr "charAt"
+		IL_0448: ldloc.s 22
+		IL_044a: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_044f: pop
+		IL_0450: ldc.i4.1
+		IL_0451: newarr [System.Runtime]System.Object
+		IL_0456: dup
+		IL_0457: ldc.i4.0
+		IL_0458: ldloc.0
+		IL_0459: stelem.ref
+		IL_045a: stloc.s 6
+		IL_045c: ldloc.s 6
+		IL_045e: ldc.i4.0
+		IL_045f: ldelem.ref
+		IL_0460: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0465: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_046a: ldc.i4.0
+		IL_046b: conv.r8
+		IL_046c: ldstr ""
+		IL_0471: ldc.i4.0
+		IL_0472: ldc.i4.0
+		IL_0473: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0478: stloc.s 23
+		IL_047a: ldnull
+		IL_047b: ldstr "[Number]"
+		IL_0480: ldloc.s 23
+		IL_0482: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_0487: pop
+		IL_0488: ldc.i4.1
+		IL_0489: newarr [System.Runtime]System.Object
+		IL_048e: dup
+		IL_048f: ldc.i4.0
+		IL_0490: ldloc.0
+		IL_0491: stelem.ref
+		IL_0492: stloc.s 6
+		IL_0494: ldloc.s 6
+		IL_0496: ldc.i4.0
+		IL_0497: ldelem.ref
+		IL_0498: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_049d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_04a2: ldc.i4.0
+		IL_04a3: conv.r8
+		IL_04a4: ldstr ""
+		IL_04a9: ldc.i4.0
+		IL_04aa: ldc.i4.0
+		IL_04ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04b0: stloc.s 24
+		IL_04b2: ldnull
+		IL_04b3: ldstr "charCodeAt"
+		IL_04b8: ldloc.s 24
+		IL_04ba: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_04bf: pop
+		IL_04c0: ldc.i4.1
+		IL_04c1: newarr [System.Runtime]System.Object
+		IL_04c6: dup
+		IL_04c7: ldc.i4.0
+		IL_04c8: ldloc.0
+		IL_04c9: stelem.ref
+		IL_04ca: stloc.s 6
+		IL_04cc: ldloc.s 6
+		IL_04ce: ldc.i4.0
+		IL_04cf: ldelem.ref
+		IL_04d0: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_04d5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_04da: ldc.i4.0
+		IL_04db: conv.r8
+		IL_04dc: ldstr ""
+		IL_04e1: ldc.i4.0
 		IL_04e2: ldc.i4.0
-		IL_04e3: ldc.i4.0
-		IL_04e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04e9: stloc.s 24
-		IL_04eb: ldloc.s 4
-		IL_04ed: ldloc.s 6
-		IL_04ef: ldstr "[Number]"
-		IL_04f4: ldloc.s 24
-		IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_04fb: pop
-		IL_04fc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0501: stloc.s 6
-		IL_0503: ldc.i4.1
-		IL_0504: newarr [System.Runtime]System.Object
-		IL_0509: dup
-		IL_050a: ldc.i4.0
-		IL_050b: ldloc.0
-		IL_050c: stelem.ref
-		IL_050d: stloc.s 7
-		IL_050f: ldloc.s 7
-		IL_0511: ldc.i4.0
-		IL_0512: ldelem.ref
-		IL_0513: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0518: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_051d: ldc.i4.0
-		IL_051e: conv.r8
-		IL_051f: ldstr ""
-		IL_0524: ldc.i4.0
-		IL_0525: ldc.i4.0
-		IL_0526: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_052b: stloc.s 25
-		IL_052d: ldloc.s 4
-		IL_052f: ldloc.s 6
-		IL_0531: ldstr "charCodeAt"
-		IL_0536: ldloc.s 25
-		IL_0538: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_053d: pop
-		IL_053e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0543: stloc.s 6
-		IL_0545: ldc.i4.1
-		IL_0546: newarr [System.Runtime]System.Object
-		IL_054b: dup
-		IL_054c: ldc.i4.0
-		IL_054d: ldloc.0
-		IL_054e: stelem.ref
-		IL_054f: stloc.s 7
-		IL_0551: ldloc.s 7
-		IL_0553: ldc.i4.0
-		IL_0554: ldelem.ref
-		IL_0555: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_055a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_055f: ldc.i4.0
-		IL_0560: conv.r8
-		IL_0561: ldstr ""
-		IL_0566: ldc.i4.0
-		IL_0567: ldc.i4.0
-		IL_0568: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_056d: stloc.s 26
-		IL_056f: ldloc.s 4
-		IL_0571: ldloc.s 6
-		IL_0573: ldstr "indexOf"
-		IL_0578: ldloc.s 26
-		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_057f: pop
-		IL_0580: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0585: stloc.s 6
-		IL_0587: ldc.i4.1
-		IL_0588: newarr [System.Runtime]System.Object
-		IL_058d: dup
-		IL_058e: ldc.i4.0
-		IL_058f: ldloc.0
-		IL_0590: stelem.ref
-		IL_0591: stloc.s 7
-		IL_0593: ldloc.s 7
-		IL_0595: ldc.i4.0
-		IL_0596: ldelem.ref
-		IL_0597: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_059c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_05a1: ldc.i4.0
-		IL_05a2: conv.r8
-		IL_05a3: ldstr ""
-		IL_05a8: ldc.i4.0
-		IL_05a9: ldc.i4.0
-		IL_05aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05af: stloc.s 27
-		IL_05b1: ldloc.s 4
-		IL_05b3: ldloc.s 6
-		IL_05b5: ldstr "lastIndexOf"
-		IL_05ba: ldloc.s 27
-		IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_05c1: pop
-		IL_05c2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05c7: stloc.s 6
-		IL_05c9: ldc.i4.1
-		IL_05ca: newarr [System.Runtime]System.Object
-		IL_05cf: dup
-		IL_05d0: ldc.i4.0
-		IL_05d1: ldloc.0
-		IL_05d2: stelem.ref
-		IL_05d3: stloc.s 7
-		IL_05d5: ldloc.s 7
-		IL_05d7: ldc.i4.0
-		IL_05d8: ldelem.ref
-		IL_05d9: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_05de: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_05e3: ldc.i4.0
-		IL_05e4: conv.r8
-		IL_05e5: ldstr ""
-		IL_05ea: ldc.i4.0
-		IL_05eb: ldc.i4.0
-		IL_05ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05f1: stloc.s 28
-		IL_05f3: ldloc.s 4
-		IL_05f5: ldloc.s 6
-		IL_05f7: ldstr "slice"
-		IL_05fc: ldloc.s 28
-		IL_05fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0603: pop
-		IL_0604: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0609: stloc.s 6
-		IL_060b: ldc.i4.1
-		IL_060c: newarr [System.Runtime]System.Object
-		IL_0611: dup
-		IL_0612: ldc.i4.0
-		IL_0613: ldloc.0
-		IL_0614: stelem.ref
-		IL_0615: stloc.s 7
-		IL_0617: ldloc.s 7
-		IL_0619: ldc.i4.0
-		IL_061a: ldelem.ref
-		IL_061b: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0620: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0625: ldc.i4.0
-		IL_0626: conv.r8
-		IL_0627: ldstr ""
-		IL_062c: ldc.i4.0
-		IL_062d: ldc.i4.0
-		IL_062e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0633: stloc.s 29
-		IL_0635: ldloc.s 4
-		IL_0637: ldloc.s 6
-		IL_0639: ldstr "substr"
-		IL_063e: ldloc.s 29
-		IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0645: pop
-		IL_0646: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_064b: stloc.s 6
-		IL_064d: ldc.i4.1
-		IL_064e: newarr [System.Runtime]System.Object
-		IL_0653: dup
-		IL_0654: ldc.i4.0
-		IL_0655: ldloc.0
-		IL_0656: stelem.ref
-		IL_0657: stloc.s 7
-		IL_0659: ldloc.s 7
-		IL_065b: ldc.i4.0
-		IL_065c: ldelem.ref
-		IL_065d: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0662: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0667: ldc.i4.0
-		IL_0668: conv.r8
-		IL_0669: ldstr ""
-		IL_066e: ldc.i4.0
-		IL_066f: ldc.i4.0
-		IL_0670: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0675: stloc.s 30
-		IL_0677: ldloc.s 4
-		IL_0679: ldloc.s 6
-		IL_067b: ldstr "substring"
-		IL_0680: ldloc.s 30
-		IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0687: pop
-		IL_0688: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_068d: stloc.s 6
-		IL_068f: ldc.i4.1
-		IL_0690: newarr [System.Runtime]System.Object
-		IL_0695: dup
-		IL_0696: ldc.i4.0
-		IL_0697: ldloc.0
-		IL_0698: stelem.ref
-		IL_0699: stloc.s 7
-		IL_069b: ldloc.s 7
+		IL_04e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04e8: stloc.s 25
+		IL_04ea: ldnull
+		IL_04eb: ldstr "indexOf"
+		IL_04f0: ldloc.s 25
+		IL_04f2: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_04f7: pop
+		IL_04f8: ldc.i4.1
+		IL_04f9: newarr [System.Runtime]System.Object
+		IL_04fe: dup
+		IL_04ff: ldc.i4.0
+		IL_0500: ldloc.0
+		IL_0501: stelem.ref
+		IL_0502: stloc.s 6
+		IL_0504: ldloc.s 6
+		IL_0506: ldc.i4.0
+		IL_0507: ldelem.ref
+		IL_0508: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_050d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0512: ldc.i4.0
+		IL_0513: conv.r8
+		IL_0514: ldstr ""
+		IL_0519: ldc.i4.0
+		IL_051a: ldc.i4.0
+		IL_051b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0520: stloc.s 26
+		IL_0522: ldnull
+		IL_0523: ldstr "lastIndexOf"
+		IL_0528: ldloc.s 26
+		IL_052a: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_052f: pop
+		IL_0530: ldc.i4.1
+		IL_0531: newarr [System.Runtime]System.Object
+		IL_0536: dup
+		IL_0537: ldc.i4.0
+		IL_0538: ldloc.0
+		IL_0539: stelem.ref
+		IL_053a: stloc.s 6
+		IL_053c: ldloc.s 6
+		IL_053e: ldc.i4.0
+		IL_053f: ldelem.ref
+		IL_0540: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0545: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_054a: ldc.i4.0
+		IL_054b: conv.r8
+		IL_054c: ldstr ""
+		IL_0551: ldc.i4.0
+		IL_0552: ldc.i4.0
+		IL_0553: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0558: stloc.s 27
+		IL_055a: ldnull
+		IL_055b: ldstr "slice"
+		IL_0560: ldloc.s 27
+		IL_0562: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_0567: pop
+		IL_0568: ldc.i4.1
+		IL_0569: newarr [System.Runtime]System.Object
+		IL_056e: dup
+		IL_056f: ldc.i4.0
+		IL_0570: ldloc.0
+		IL_0571: stelem.ref
+		IL_0572: stloc.s 6
+		IL_0574: ldloc.s 6
+		IL_0576: ldc.i4.0
+		IL_0577: ldelem.ref
+		IL_0578: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_057d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0582: ldc.i4.0
+		IL_0583: conv.r8
+		IL_0584: ldstr ""
+		IL_0589: ldc.i4.0
+		IL_058a: ldc.i4.0
+		IL_058b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0590: stloc.s 28
+		IL_0592: ldnull
+		IL_0593: ldstr "substr"
+		IL_0598: ldloc.s 28
+		IL_059a: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_059f: pop
+		IL_05a0: ldc.i4.1
+		IL_05a1: newarr [System.Runtime]System.Object
+		IL_05a6: dup
+		IL_05a7: ldc.i4.0
+		IL_05a8: ldloc.0
+		IL_05a9: stelem.ref
+		IL_05aa: stloc.s 6
+		IL_05ac: ldloc.s 6
+		IL_05ae: ldc.i4.0
+		IL_05af: ldelem.ref
+		IL_05b0: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_05b5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_05ba: ldc.i4.0
+		IL_05bb: conv.r8
+		IL_05bc: ldstr ""
+		IL_05c1: ldc.i4.0
+		IL_05c2: ldc.i4.0
+		IL_05c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05c8: stloc.s 29
+		IL_05ca: ldnull
+		IL_05cb: ldstr "substring"
+		IL_05d0: ldloc.s 29
+		IL_05d2: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_05d7: pop
+		IL_05d8: ldc.i4.1
+		IL_05d9: newarr [System.Runtime]System.Object
+		IL_05de: dup
+		IL_05df: ldc.i4.0
+		IL_05e0: ldloc.0
+		IL_05e1: stelem.ref
+		IL_05e2: stloc.s 6
+		IL_05e4: ldloc.s 6
+		IL_05e6: ldc.i4.0
+		IL_05e7: ldelem.ref
+		IL_05e8: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_05ed: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_05f2: ldc.i4.0
+		IL_05f3: conv.r8
+		IL_05f4: ldstr ""
+		IL_05f9: ldc.i4.0
+		IL_05fa: ldc.i4.0
+		IL_05fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0600: stloc.s 30
+		IL_0602: ldnull
+		IL_0603: ldstr "toLowerCase"
+		IL_0608: ldloc.s 30
+		IL_060a: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_060f: pop
+		IL_0610: ldc.i4.1
+		IL_0611: newarr [System.Runtime]System.Object
+		IL_0616: dup
+		IL_0617: ldc.i4.0
+		IL_0618: ldloc.0
+		IL_0619: stelem.ref
+		IL_061a: stloc.s 6
+		IL_061c: ldloc.s 6
+		IL_061e: ldc.i4.0
+		IL_061f: ldelem.ref
+		IL_0620: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0625: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_062a: ldc.i4.0
+		IL_062b: conv.r8
+		IL_062c: ldstr ""
+		IL_0631: ldc.i4.0
+		IL_0632: ldc.i4.0
+		IL_0633: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0638: stloc.s 31
+		IL_063a: ldnull
+		IL_063b: ldstr "toUpperCase"
+		IL_0640: ldloc.s 31
+		IL_0642: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_0647: pop
+		IL_0648: ldc.i4.1
+		IL_0649: newarr [System.Runtime]System.Object
+		IL_064e: dup
+		IL_064f: ldc.i4.0
+		IL_0650: ldloc.0
+		IL_0651: stelem.ref
+		IL_0652: stloc.s 6
+		IL_0654: ldloc.s 6
+		IL_0656: ldc.i4.0
+		IL_0657: ldelem.ref
+		IL_0658: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_065d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0662: ldc.i4.0
+		IL_0663: conv.r8
+		IL_0664: ldstr ""
+		IL_0669: ldc.i4.0
+		IL_066a: ldc.i4.0
+		IL_066b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0670: stloc.s 32
+		IL_0672: ldnull
+		IL_0673: ldloc.s 32
+		IL_0675: call object Modules.Compile_Performance_Dromaeo_Object_String/prep::__js_call__(object, object)
+		IL_067a: pop
+		IL_067b: ldc.i4.1
+		IL_067c: newarr [System.Runtime]System.Object
+		IL_0681: dup
+		IL_0682: ldc.i4.0
+		IL_0683: ldloc.0
+		IL_0684: stelem.ref
+		IL_0685: stloc.s 6
+		IL_0687: ldloc.s 6
+		IL_0689: ldc.i4.0
+		IL_068a: ldelem.ref
+		IL_068b: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0690: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0695: ldc.i4.0
+		IL_0696: conv.r8
+		IL_0697: ldstr ""
+		IL_069c: ldc.i4.0
 		IL_069d: ldc.i4.0
-		IL_069e: ldelem.ref
-		IL_069f: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_06a4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_06a9: ldc.i4.0
-		IL_06aa: conv.r8
-		IL_06ab: ldstr ""
-		IL_06b0: ldc.i4.0
-		IL_06b1: ldc.i4.0
-		IL_06b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06b7: stloc.s 31
-		IL_06b9: ldloc.s 4
-		IL_06bb: ldloc.s 6
-		IL_06bd: ldstr "toLowerCase"
-		IL_06c2: ldloc.s 31
-		IL_06c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_06c9: pop
-		IL_06ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06cf: stloc.s 6
-		IL_06d1: ldc.i4.1
-		IL_06d2: newarr [System.Runtime]System.Object
-		IL_06d7: dup
-		IL_06d8: ldc.i4.0
-		IL_06d9: ldloc.0
-		IL_06da: stelem.ref
-		IL_06db: stloc.s 7
-		IL_06dd: ldloc.s 7
-		IL_06df: ldc.i4.0
-		IL_06e0: ldelem.ref
-		IL_06e1: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_06e6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_06eb: ldc.i4.0
-		IL_06ec: conv.r8
-		IL_06ed: ldstr ""
-		IL_06f2: ldc.i4.0
-		IL_06f3: ldc.i4.0
-		IL_06f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06f9: stloc.s 32
-		IL_06fb: ldloc.s 4
-		IL_06fd: ldloc.s 6
-		IL_06ff: ldstr "toUpperCase"
-		IL_0704: ldloc.s 32
-		IL_0706: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_070b: pop
-		IL_070c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0711: stloc.s 6
-		IL_0713: ldc.i4.1
-		IL_0714: newarr [System.Runtime]System.Object
-		IL_0719: dup
-		IL_071a: ldc.i4.0
-		IL_071b: ldloc.0
-		IL_071c: stelem.ref
-		IL_071d: stloc.s 7
-		IL_071f: ldloc.s 7
-		IL_0721: ldc.i4.0
-		IL_0722: ldelem.ref
-		IL_0723: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0728: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_072d: ldc.i4.0
-		IL_072e: conv.r8
-		IL_072f: ldstr ""
-		IL_0734: ldc.i4.0
-		IL_0735: ldc.i4.0
-		IL_0736: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_073b: stloc.s 33
-		IL_073d: ldloc.3
-		IL_073e: ldloc.s 6
-		IL_0740: ldloc.s 33
-		IL_0742: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0747: pop
-		IL_0748: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_074d: stloc.s 6
-		IL_074f: ldc.i4.1
-		IL_0750: newarr [System.Runtime]System.Object
-		IL_0755: dup
-		IL_0756: ldc.i4.0
-		IL_0757: ldloc.0
-		IL_0758: stelem.ref
-		IL_0759: stloc.s 7
-		IL_075b: ldloc.s 7
-		IL_075d: ldc.i4.0
-		IL_075e: ldelem.ref
-		IL_075f: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
-		IL_0764: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
-		IL_0769: ldc.i4.0
-		IL_076a: conv.r8
-		IL_076b: ldstr ""
-		IL_0770: ldc.i4.0
-		IL_0771: ldc.i4.0
-		IL_0772: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0777: stloc.s 34
-		IL_0779: ldloc.s 4
-		IL_077b: ldloc.s 6
-		IL_077d: ldstr "comparing"
-		IL_0782: ldloc.s 34
-		IL_0784: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0789: pop
-		IL_078a: ldloc.2
-		IL_078b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0795: pop
-		IL_0796: ret
+		IL_069e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06a3: stloc.s 33
+		IL_06a5: ldnull
+		IL_06a6: ldstr "comparing"
+		IL_06ab: ldloc.s 33
+		IL_06ad: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+		IL_06b2: pop
+		IL_06b3: ldnull
+		IL_06b4: call object Modules.Compile_Performance_Dromaeo_Object_String/endTest::__js_call__(object)
+		IL_06b9: pop
+		IL_06ba: ret
 	} // end of method Compile_Performance_Dromaeo_Object_String::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_String

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -1832,7 +1832,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 471 (0x1d7)
+			// Code size: 481 (0x1e1)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1842,7 +1842,7 @@
 				[4] float64,
 				[5] object,
 				[6] object,
-				[7] float64
+				[7] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldc.i4.0
@@ -1908,111 +1908,103 @@
 				IL_009e: br IL_0022
 			// end loop
 
-			IL_00a3: ldarg.0
-			IL_00a4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcCross
-			IL_00a9: ldc.i4.1
-			IL_00aa: newarr [System.Runtime]System.Object
-			IL_00af: dup
-			IL_00b0: ldc.i4.0
-			IL_00b1: ldarg.0
-			IL_00b2: stelem.ref
-			IL_00b3: ldloc.0
-			IL_00b4: ldloc.1
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_00ba: stloc.s 5
-			IL_00bc: ldloc.s 5
-			IL_00be: stloc.0
-			IL_00bf: ldloc.0
+			IL_00a3: ldnull
+			IL_00a4: ldloc.0
+			IL_00a5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00aa: ldloc.1
+			IL_00ab: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_00b5: stloc.s 7
+			IL_00b7: ldloc.s 7
+			IL_00b9: stloc.0
+			IL_00ba: ldloc.0
+			IL_00bb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 			IL_00c0: ldc.r8 0.0
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_00ce: stloc.s 5
 			IL_00d0: ldloc.0
-			IL_00d1: ldc.r8 0.0
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00df: stloc.s 6
-			IL_00e1: ldloc.s 5
-			IL_00e3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00e8: ldloc.s 6
-			IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ef: mul
-			IL_00f0: stloc.s 4
-			IL_00f2: ldloc.0
-			IL_00f3: ldc.r8 1
-			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0101: stloc.s 6
-			IL_0103: ldloc.0
-			IL_0104: ldc.r8 1
-			IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0112: stloc.s 5
-			IL_0114: ldloc.s 6
-			IL_0116: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_011b: ldloc.s 5
-			IL_011d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0122: mul
-			IL_0123: stloc.s 7
-			IL_0125: ldloc.s 4
-			IL_0127: ldloc.s 7
-			IL_0129: add
-			IL_012a: stloc.s 7
-			IL_012c: ldloc.0
-			IL_012d: ldc.r8 2
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_013b: stloc.s 5
-			IL_013d: ldloc.0
-			IL_013e: ldc.r8 2
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_014c: stloc.s 6
-			IL_014e: ldloc.s 5
-			IL_0150: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0155: ldloc.s 6
-			IL_0157: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_015c: mul
-			IL_015d: stloc.s 4
-			IL_015f: ldloc.s 7
-			IL_0161: ldloc.s 4
-			IL_0163: add
-			IL_0164: stloc.s 4
-			IL_0166: ldloc.s 4
-			IL_0168: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
-			IL_016d: stloc.3
-			IL_016e: ldc.r8 0.0
-			IL_0177: stloc.2
-			// loop start (head: IL_0178)
-				IL_0178: ldloc.2
-				IL_0179: stloc.s 4
-				IL_017b: ldloc.s 4
-				IL_017d: ldc.r8 3
-				IL_0186: clt
-				IL_0188: brfalse IL_01b7
+			IL_00d1: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00d6: ldc.r8 0.0
+			IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00e4: stloc.s 6
+			IL_00e6: ldloc.s 5
+			IL_00e8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00ed: ldloc.s 6
+			IL_00ef: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00f4: mul
+			IL_00f5: ldloc.0
+			IL_00f6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00fb: ldc.r8 1
+			IL_0104: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0109: stloc.s 6
+			IL_010b: ldloc.0
+			IL_010c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0111: ldc.r8 1
+			IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_011f: stloc.s 5
+			IL_0121: ldloc.s 6
+			IL_0123: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0128: ldloc.s 5
+			IL_012a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_012f: mul
+			IL_0130: add
+			IL_0131: ldloc.0
+			IL_0132: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0137: ldc.r8 2
+			IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0145: stloc.s 5
+			IL_0147: ldloc.0
+			IL_0148: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_014d: ldc.r8 2
+			IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_015b: stloc.s 6
+			IL_015d: ldloc.s 5
+			IL_015f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0164: ldloc.s 6
+			IL_0166: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_016b: mul
+			IL_016c: add
+			IL_016d: stloc.s 4
+			IL_016f: ldloc.s 4
+			IL_0171: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
+			IL_0176: stloc.3
+			IL_0177: ldc.r8 0.0
+			IL_0180: stloc.2
+			// loop start (head: IL_0181)
+				IL_0181: ldloc.2
+				IL_0182: stloc.s 4
+				IL_0184: ldloc.s 4
+				IL_0186: ldc.r8 3
+				IL_018f: clt
+				IL_0191: brfalse IL_01c1
 
-				IL_018d: ldloc.0
-				IL_018e: ldloc.2
-				IL_018f: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, float64)
-				IL_0194: stloc.s 4
-				IL_0196: ldloc.s 4
-				IL_0198: ldloc.3
-				IL_0199: div
-				IL_019a: stloc.s 4
-				IL_019c: ldloc.0
-				IL_019d: ldloc.2
-				IL_019e: ldloc.s 4
-				IL_01a0: ldc.i4.1
-				IL_01a1: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-				IL_01a6: ldloc.2
-				IL_01a7: ldc.r8 1
-				IL_01b0: add
-				IL_01b1: stloc.2
-				IL_01b2: br IL_0178
+				IL_0196: ldloc.0
+				IL_0197: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_019c: ldloc.2
+				IL_019d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::GetItemAsNumber(float64)
+				IL_01a2: ldloc.3
+				IL_01a3: div
+				IL_01a4: stloc.s 4
+				IL_01a6: ldloc.0
+				IL_01a7: ldloc.2
+				IL_01a8: ldloc.s 4
+				IL_01aa: ldc.i4.1
+				IL_01ab: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+				IL_01b0: ldloc.2
+				IL_01b1: ldc.r8 1
+				IL_01ba: add
+				IL_01bb: stloc.2
+				IL_01bc: br IL_0181
 			// end loop
 
-			IL_01b7: ldloc.0
-			IL_01b8: ldc.r8 3
-			IL_01c1: ldc.r8 1
-			IL_01ca: ldc.i4.1
-			IL_01cb: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
-			IL_01d0: ldloc.0
-			IL_01d1: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01d6: ret
+			IL_01c1: ldloc.0
+			IL_01c2: ldc.r8 3
+			IL_01cb: ldc.r8 1
+			IL_01d4: ldc.i4.1
+			IL_01d5: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItemNumber(object, float64, float64, bool)
+			IL_01da: ldloc.0
+			IL_01db: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01e0: ret
 		} // end of method CalcNormal::__js_call__
 
 	} // end of class CalcNormal
@@ -5155,7 +5147,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 6973 (0x1b3d)
+			// Code size: 6479 (0x194f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5163,11 +5155,9 @@
 				[2] object,
 				[3] float64,
 				[4] float64,
-				[5] object[],
-				[6] object,
-				[7] bool,
-				[8] object,
-				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[5] object,
+				[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[7] bool
 			)
 
 			IL_0000: ldc.i4.0
@@ -5194,2145 +5184,1921 @@
 				IL_0041: ldloc.3
 				IL_0042: ldloc.s 4
 				IL_0044: cgt
-				IL_0046: brfalse IL_00cd
+				IL_0046: brfalse IL_00bf
 
 				IL_004b: ldarg.0
-				IL_004c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti2
-				IL_0051: ldc.i4.1
-				IL_0052: newarr [System.Runtime]System.Object
-				IL_0057: dup
-				IL_0058: ldc.i4.0
-				IL_0059: ldarg.0
-				IL_005a: stelem.ref
-				IL_005b: stloc.s 5
-				IL_005d: ldarg.0
-				IL_005e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-				IL_0063: stloc.2
-				IL_0064: ldarg.0
-				IL_0065: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_006a: volatile.
-				IL_006c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-				IL_0071: brfalse IL_0085
+				IL_004c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+				IL_0051: stloc.2
+				IL_0052: ldarg.0
+				IL_0053: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0058: volatile.
+				IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+				IL_005f: brfalse IL_0073
 
-				IL_0076: ldstr "Normal"
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0080: br IL_0099
+				IL_0064: ldstr "Normal"
+				IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_006e: br IL_0087
 
-				IL_0085: ldstr "Normal"
-				IL_008a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:24"
-				IL_008f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0073: ldstr "Normal"
+				IL_0078: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:22"
+				IL_007d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0099: stloc.s 6
-				IL_009b: ldloc.s 6
-				IL_009d: ldloc.1
-				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00a3: stloc.s 6
-				IL_00a5: ldloc.s 5
-				IL_00a7: ldloc.2
-				IL_00a8: ldloc.s 6
-				IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_00af: stloc.s 6
-				IL_00b1: ldloc.0
-				IL_00b2: ldloc.1
-				IL_00b3: ldloc.s 6
-				IL_00b5: ldc.i4.1
-				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-				IL_00bb: pop
-				IL_00bc: ldloc.1
-				IL_00bd: ldc.r8 1
-				IL_00c6: sub
-				IL_00c7: stloc.1
-				IL_00c8: br IL_0033
+				IL_0087: stloc.s 5
+				IL_0089: ldloc.s 5
+				IL_008b: ldloc.1
+				IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0091: stloc.s 5
+				IL_0093: ldnull
+				IL_0094: ldloc.2
+				IL_0095: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_009a: ldloc.s 5
+				IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+				IL_00a1: stloc.s 6
+				IL_00a3: ldloc.0
+				IL_00a4: ldloc.1
+				IL_00a5: ldloc.s 6
+				IL_00a7: ldc.i4.1
+				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+				IL_00ad: pop
+				IL_00ae: ldloc.1
+				IL_00af: ldc.r8 1
+				IL_00b8: sub
+				IL_00b9: stloc.1
+				IL_00ba: br IL_0033
 			// end loop
 
-			IL_00cd: ldloc.0
-			IL_00ce: ldc.r8 0.0
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00dc: stloc.s 6
-			IL_00de: ldloc.s 6
-			IL_00e0: ldc.r8 2
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00ee: stloc.s 6
-			IL_00f0: ldloc.s 6
-			IL_00f2: ldc.r8 0.0
-			IL_00fb: box [System.Runtime]System.Double
-			IL_0100: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_0105: stloc.s 7
-			IL_0107: ldloc.s 7
-			IL_0109: brfalse IL_0512
+			IL_00bf: ldloc.0
+			IL_00c0: ldc.r8 0.0
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00ce: stloc.s 5
+			IL_00d0: ldloc.s 5
+			IL_00d2: ldc.r8 2
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00e0: stloc.s 5
+			IL_00e2: ldloc.s 5
+			IL_00e4: ldc.r8 0.0
+			IL_00ed: box [System.Runtime]System.Double
+			IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_00f7: stloc.s 7
+			IL_00f9: ldloc.s 7
+			IL_00fb: brfalse IL_04b4
 
-			IL_010e: ldarg.0
-			IL_010f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0114: volatile.
-			IL_0116: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-			IL_011b: brfalse IL_012f
+			IL_0100: ldarg.0
+			IL_0101: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0106: volatile.
+			IL_0108: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_010d: brfalse IL_0121
 
-			IL_0120: ldstr "Line"
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_012a: br IL_0143
+			IL_0112: ldstr "Line"
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_011c: br IL_0135
 
-			IL_012f: ldstr "Line"
-			IL_0134: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:46"
-			IL_0139: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0121: ldstr "Line"
+			IL_0126: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:45"
+			IL_012b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0143: stloc.s 6
-			IL_0145: ldloc.s 6
-			IL_0147: ldc.r8 0.0
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0155: stloc.s 6
-			IL_0157: ldloc.s 6
-			IL_0159: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_015e: ldc.i4.0
-			IL_015f: ceq
-			IL_0161: stloc.s 7
-			IL_0163: ldloc.s 7
-			IL_0165: brfalse IL_020f
+			IL_0135: stloc.s 5
+			IL_0137: ldloc.s 5
+			IL_0139: ldc.r8 0.0
+			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0147: stloc.s 5
+			IL_0149: ldloc.s 5
+			IL_014b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0150: ldc.i4.0
+			IL_0151: ceq
+			IL_0153: stloc.s 7
+			IL_0155: ldloc.s 7
+			IL_0157: brfalse IL_01ee
 
-			IL_016a: ldarg.0
-			IL_016b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0170: stloc.s 6
-			IL_0172: ldc.i4.1
-			IL_0173: newarr [System.Runtime]System.Object
-			IL_0178: dup
-			IL_0179: ldc.i4.0
-			IL_017a: ldarg.0
-			IL_017b: stelem.ref
-			IL_017c: stloc.s 5
-			IL_017e: ldarg.0
-			IL_017f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0184: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0189: ldc.r8 0.0
-			IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0197: stloc.2
-			IL_0198: ldarg.0
-			IL_0199: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_019e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01a3: ldc.r8 1
-			IL_01ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01b1: stloc.s 8
-			IL_01b3: ldloc.s 6
-			IL_01b5: ldloc.s 5
-			IL_01b7: ldloc.2
-			IL_01b8: ldloc.s 8
-			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01bf: pop
-			IL_01c0: ldarg.0
-			IL_01c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01c6: volatile.
-			IL_01c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_01cd: brfalse IL_01e1
+			IL_015c: ldarg.0
+			IL_015d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0162: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0167: ldc.r8 0.0
+			IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0175: stloc.s 5
+			IL_0177: ldarg.0
+			IL_0178: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_017d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0182: ldc.r8 1
+			IL_018b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0190: stloc.2
+			IL_0191: ldarg.0
+			IL_0192: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0197: ldnull
+			IL_0198: ldloc.s 5
+			IL_019a: ldloc.2
+			IL_019b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_01a0: pop
+			IL_01a1: ldarg.0
+			IL_01a2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_01a7: volatile.
+			IL_01a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_01ae: brfalse IL_01c2
 
-			IL_01d2: ldstr "Line"
-			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01dc: br IL_01f5
+			IL_01b3: ldstr "Line"
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01bd: br IL_01d6
 
-			IL_01e1: ldstr "Line"
-			IL_01e6: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:64"
-			IL_01eb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
-			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01c2: ldstr "Line"
+			IL_01c7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:62"
+			IL_01cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_41
+			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01f5: stloc.s 8
-			IL_01f7: ldloc.s 8
-			IL_01f9: ldc.r8 0.0
-			IL_0202: ldc.i4.1
-			IL_0203: box [System.Runtime]System.Boolean
-			IL_0208: ldc.i4.1
-			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_020e: pop
+			IL_01d6: stloc.2
+			IL_01d7: ldloc.2
+			IL_01d8: ldc.r8 0.0
+			IL_01e1: ldc.i4.1
+			IL_01e2: box [System.Runtime]System.Boolean
+			IL_01e7: ldc.i4.1
+			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_01ed: pop
 
-			IL_020f: ldarg.0
-			IL_0210: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0215: volatile.
-			IL_0217: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-			IL_021c: brfalse IL_0230
+			IL_01ee: ldarg.0
+			IL_01ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_01f4: volatile.
+			IL_01f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_01fb: brfalse IL_020f
 
-			IL_0221: ldstr "Line"
-			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_022b: br IL_0244
+			IL_0200: ldstr "Line"
+			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_020a: br IL_0223
 
-			IL_0230: ldstr "Line"
-			IL_0235: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:72"
-			IL_023a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_020f: ldstr "Line"
+			IL_0214: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:70"
+			IL_0219: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0244: stloc.s 8
-			IL_0246: ldloc.s 8
-			IL_0248: ldc.r8 1
-			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0256: stloc.s 8
-			IL_0258: ldloc.s 8
-			IL_025a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_025f: ldc.i4.0
-			IL_0260: ceq
-			IL_0262: stloc.s 7
-			IL_0264: ldloc.s 7
-			IL_0266: brfalse IL_0310
+			IL_0223: stloc.2
+			IL_0224: ldloc.2
+			IL_0225: ldc.r8 1
+			IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0233: stloc.2
+			IL_0234: ldloc.2
+			IL_0235: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_023a: ldc.i4.0
+			IL_023b: ceq
+			IL_023d: stloc.s 7
+			IL_023f: ldloc.s 7
+			IL_0241: brfalse IL_02da
 
-			IL_026b: ldarg.0
-			IL_026c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0271: stloc.s 8
-			IL_0273: ldc.i4.1
-			IL_0274: newarr [System.Runtime]System.Object
-			IL_0279: dup
-			IL_027a: ldc.i4.0
+			IL_0246: ldarg.0
+			IL_0247: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_024c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0251: ldc.r8 1
+			IL_025a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_025f: stloc.2
+			IL_0260: ldarg.0
+			IL_0261: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0266: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_026b: ldc.r8 2
+			IL_0274: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0279: stloc.s 5
 			IL_027b: ldarg.0
-			IL_027c: stelem.ref
-			IL_027d: stloc.s 5
-			IL_027f: ldarg.0
-			IL_0280: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0285: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_028a: ldc.r8 1
-			IL_0293: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0298: stloc.2
-			IL_0299: ldarg.0
-			IL_029a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_029f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_02a4: ldc.r8 2
-			IL_02ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_02b2: stloc.s 6
-			IL_02b4: ldloc.s 8
-			IL_02b6: ldloc.s 5
-			IL_02b8: ldloc.2
-			IL_02b9: ldloc.s 6
-			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02c0: pop
-			IL_02c1: ldarg.0
-			IL_02c2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02c7: volatile.
-			IL_02c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-			IL_02ce: brfalse IL_02e2
+			IL_027c: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0281: ldnull
+			IL_0282: ldloc.2
+			IL_0283: ldloc.s 5
+			IL_0285: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_028a: pop
+			IL_028b: ldarg.0
+			IL_028c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0291: volatile.
+			IL_0293: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_0298: brfalse IL_02ac
 
-			IL_02d3: ldstr "Line"
-			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02dd: br IL_02f6
+			IL_029d: ldstr "Line"
+			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a7: br IL_02c0
 
-			IL_02e2: ldstr "Line"
-			IL_02e7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:90"
-			IL_02ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02ac: ldstr "Line"
+			IL_02b1: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:87"
+			IL_02b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02f6: stloc.s 6
-			IL_02f8: ldloc.s 6
-			IL_02fa: ldc.r8 1
-			IL_0303: ldc.i4.1
-			IL_0304: box [System.Runtime]System.Boolean
-			IL_0309: ldc.i4.1
-			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_030f: pop
+			IL_02c0: stloc.s 5
+			IL_02c2: ldloc.s 5
+			IL_02c4: ldc.r8 1
+			IL_02cd: ldc.i4.1
+			IL_02ce: box [System.Runtime]System.Boolean
+			IL_02d3: ldc.i4.1
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_02d9: pop
 
-			IL_0310: ldarg.0
-			IL_0311: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0316: volatile.
-			IL_0318: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-			IL_031d: brfalse IL_0331
+			IL_02da: ldarg.0
+			IL_02db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02e0: volatile.
+			IL_02e2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_02e7: brfalse IL_02fb
 
-			IL_0322: ldstr "Line"
-			IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_032c: br IL_0345
+			IL_02ec: ldstr "Line"
+			IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f6: br IL_030f
 
-			IL_0331: ldstr "Line"
-			IL_0336: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:98"
-			IL_033b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-			IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02fb: ldstr "Line"
+			IL_0300: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:95"
+			IL_0305: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0345: stloc.s 6
-			IL_0347: ldloc.s 6
-			IL_0349: ldc.r8 2
-			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0357: stloc.s 6
-			IL_0359: ldloc.s 6
-			IL_035b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0360: ldc.i4.0
-			IL_0361: ceq
-			IL_0363: stloc.s 7
-			IL_0365: ldloc.s 7
-			IL_0367: brfalse IL_0411
+			IL_030f: stloc.s 5
+			IL_0311: ldloc.s 5
+			IL_0313: ldc.r8 2
+			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0321: stloc.s 5
+			IL_0323: ldloc.s 5
+			IL_0325: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_032a: ldc.i4.0
+			IL_032b: ceq
+			IL_032d: stloc.s 7
+			IL_032f: ldloc.s 7
+			IL_0331: brfalse IL_03c8
 
-			IL_036c: ldarg.0
-			IL_036d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0372: stloc.s 6
-			IL_0374: ldc.i4.1
-			IL_0375: newarr [System.Runtime]System.Object
-			IL_037a: dup
-			IL_037b: ldc.i4.0
-			IL_037c: ldarg.0
-			IL_037d: stelem.ref
-			IL_037e: stloc.s 5
-			IL_0380: ldarg.0
-			IL_0381: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0386: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_038b: ldc.r8 2
-			IL_0394: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0399: stloc.2
-			IL_039a: ldarg.0
-			IL_039b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03a0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_03a5: ldc.r8 3
-			IL_03ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_03b3: stloc.s 8
-			IL_03b5: ldloc.s 6
-			IL_03b7: ldloc.s 5
-			IL_03b9: ldloc.2
-			IL_03ba: ldloc.s 8
-			IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03c1: pop
-			IL_03c2: ldarg.0
-			IL_03c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03c8: volatile.
-			IL_03ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-			IL_03cf: brfalse IL_03e3
+			IL_0336: ldarg.0
+			IL_0337: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_033c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0341: ldc.r8 2
+			IL_034a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_034f: stloc.s 5
+			IL_0351: ldarg.0
+			IL_0352: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0357: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_035c: ldc.r8 3
+			IL_0365: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_036a: stloc.2
+			IL_036b: ldarg.0
+			IL_036c: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0371: ldnull
+			IL_0372: ldloc.s 5
+			IL_0374: ldloc.2
+			IL_0375: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_037a: pop
+			IL_037b: ldarg.0
+			IL_037c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0381: volatile.
+			IL_0383: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_0388: brfalse IL_039c
 
-			IL_03d4: ldstr "Line"
-			IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03de: br IL_03f7
+			IL_038d: ldstr "Line"
+			IL_0392: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0397: br IL_03b0
 
-			IL_03e3: ldstr "Line"
-			IL_03e8: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:116"
-			IL_03ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-			IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_039c: ldstr "Line"
+			IL_03a1: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:112"
+			IL_03a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03f7: stloc.s 8
-			IL_03f9: ldloc.s 8
-			IL_03fb: ldc.r8 2
-			IL_0404: ldc.i4.1
-			IL_0405: box [System.Runtime]System.Boolean
-			IL_040a: ldc.i4.1
-			IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0410: pop
+			IL_03b0: stloc.2
+			IL_03b1: ldloc.2
+			IL_03b2: ldc.r8 2
+			IL_03bb: ldc.i4.1
+			IL_03bc: box [System.Runtime]System.Boolean
+			IL_03c1: ldc.i4.1
+			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_03c7: pop
 
-			IL_0411: ldarg.0
-			IL_0412: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0417: volatile.
-			IL_0419: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-			IL_041e: brfalse IL_0432
+			IL_03c8: ldarg.0
+			IL_03c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_03ce: volatile.
+			IL_03d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_03d5: brfalse IL_03e9
 
-			IL_0423: ldstr "Line"
-			IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_042d: br IL_0446
+			IL_03da: ldstr "Line"
+			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e4: br IL_03fd
 
-			IL_0432: ldstr "Line"
-			IL_0437: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:124"
-			IL_043c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03e9: ldstr "Line"
+			IL_03ee: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:120"
+			IL_03f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0446: stloc.s 8
-			IL_0448: ldloc.s 8
-			IL_044a: ldc.r8 3
-			IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0458: stloc.s 8
-			IL_045a: ldloc.s 8
-			IL_045c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0461: ldc.i4.0
-			IL_0462: ceq
-			IL_0464: stloc.s 7
-			IL_0466: ldloc.s 7
-			IL_0468: brfalse IL_0512
+			IL_03fd: stloc.2
+			IL_03fe: ldloc.2
+			IL_03ff: ldc.r8 3
+			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_040d: stloc.2
+			IL_040e: ldloc.2
+			IL_040f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0414: ldc.i4.0
+			IL_0415: ceq
+			IL_0417: stloc.s 7
+			IL_0419: ldloc.s 7
+			IL_041b: brfalse IL_04b4
 
-			IL_046d: ldarg.0
-			IL_046e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0473: stloc.s 8
-			IL_0475: ldc.i4.1
-			IL_0476: newarr [System.Runtime]System.Object
-			IL_047b: dup
-			IL_047c: ldc.i4.0
-			IL_047d: ldarg.0
-			IL_047e: stelem.ref
-			IL_047f: stloc.s 5
-			IL_0481: ldarg.0
-			IL_0482: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0487: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_048c: ldc.r8 3
-			IL_0495: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_049a: stloc.2
-			IL_049b: ldarg.0
-			IL_049c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_04a1: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_04a6: ldc.r8 0.0
-			IL_04af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_04b4: stloc.s 6
-			IL_04b6: ldloc.s 8
-			IL_04b8: ldloc.s 5
-			IL_04ba: ldloc.2
-			IL_04bb: ldloc.s 6
-			IL_04bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04c2: pop
-			IL_04c3: ldarg.0
-			IL_04c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_04c9: volatile.
-			IL_04cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-			IL_04d0: brfalse IL_04e4
+			IL_0420: ldarg.0
+			IL_0421: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0426: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_042b: ldc.r8 3
+			IL_0434: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0439: stloc.2
+			IL_043a: ldarg.0
+			IL_043b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0440: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0445: ldc.r8 0.0
+			IL_044e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0453: stloc.s 5
+			IL_0455: ldarg.0
+			IL_0456: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_045b: ldnull
+			IL_045c: ldloc.2
+			IL_045d: ldloc.s 5
+			IL_045f: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_0464: pop
+			IL_0465: ldarg.0
+			IL_0466: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_046b: volatile.
+			IL_046d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_0472: brfalse IL_0486
 
-			IL_04d5: ldstr "Line"
-			IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04df: br IL_04f8
+			IL_0477: ldstr "Line"
+			IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0481: br IL_049a
 
-			IL_04e4: ldstr "Line"
-			IL_04e9: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:142"
-			IL_04ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0486: ldstr "Line"
+			IL_048b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:137"
+			IL_0490: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+			IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04f8: stloc.s 6
-			IL_04fa: ldloc.s 6
-			IL_04fc: ldc.r8 3
-			IL_0505: ldc.i4.1
-			IL_0506: box [System.Runtime]System.Boolean
-			IL_050b: ldc.i4.1
-			IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0511: pop
+			IL_049a: stloc.s 5
+			IL_049c: ldloc.s 5
+			IL_049e: ldc.r8 3
+			IL_04a7: ldc.i4.1
+			IL_04a8: box [System.Runtime]System.Boolean
+			IL_04ad: ldc.i4.1
+			IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_04b3: pop
 
-			IL_0512: ldloc.0
-			IL_0513: ldc.r8 1
-			IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0521: stloc.s 6
-			IL_0523: ldloc.s 6
-			IL_0525: ldc.r8 2
-			IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0533: stloc.s 6
-			IL_0535: ldloc.s 6
-			IL_0537: ldc.r8 0.0
-			IL_0540: box [System.Runtime]System.Double
-			IL_0545: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_054a: stloc.s 7
-			IL_054c: ldloc.s 7
-			IL_054e: brfalse IL_0957
+			IL_04b4: ldloc.0
+			IL_04b5: ldc.r8 1
+			IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_04c3: stloc.s 5
+			IL_04c5: ldloc.s 5
+			IL_04c7: ldc.r8 2
+			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_04d5: stloc.s 5
+			IL_04d7: ldloc.s 5
+			IL_04d9: ldc.r8 0.0
+			IL_04e2: box [System.Runtime]System.Double
+			IL_04e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_04ec: stloc.s 7
+			IL_04ee: ldloc.s 7
+			IL_04f0: brfalse IL_08a9
 
-			IL_0553: ldarg.0
-			IL_0554: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0559: volatile.
-			IL_055b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_0560: brfalse IL_0574
+			IL_04f5: ldarg.0
+			IL_04f6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_04fb: volatile.
+			IL_04fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_0502: brfalse IL_0516
 
-			IL_0565: ldstr "Line"
-			IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_056f: br IL_0588
+			IL_0507: ldstr "Line"
+			IL_050c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0511: br IL_052a
 
-			IL_0574: ldstr "Line"
-			IL_0579: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:160"
-			IL_057e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0516: ldstr "Line"
+			IL_051b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:155"
+			IL_0520: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0588: stloc.s 6
-			IL_058a: ldloc.s 6
-			IL_058c: ldc.r8 2
-			IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_059a: stloc.s 6
-			IL_059c: ldloc.s 6
-			IL_059e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_05a3: ldc.i4.0
-			IL_05a4: ceq
-			IL_05a6: stloc.s 7
-			IL_05a8: ldloc.s 7
-			IL_05aa: brfalse IL_0654
+			IL_052a: stloc.s 5
+			IL_052c: ldloc.s 5
+			IL_052e: ldc.r8 2
+			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_053c: stloc.s 5
+			IL_053e: ldloc.s 5
+			IL_0540: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0545: ldc.i4.0
+			IL_0546: ceq
+			IL_0548: stloc.s 7
+			IL_054a: ldloc.s 7
+			IL_054c: brfalse IL_05e3
 
-			IL_05af: ldarg.0
-			IL_05b0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_05b5: stloc.s 6
-			IL_05b7: ldc.i4.1
-			IL_05b8: newarr [System.Runtime]System.Object
-			IL_05bd: dup
-			IL_05be: ldc.i4.0
-			IL_05bf: ldarg.0
-			IL_05c0: stelem.ref
-			IL_05c1: stloc.s 5
-			IL_05c3: ldarg.0
-			IL_05c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_05c9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_05ce: ldc.r8 3
-			IL_05d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_05dc: stloc.2
-			IL_05dd: ldarg.0
-			IL_05de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_05e3: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_05e8: ldc.r8 2
-			IL_05f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_05f6: stloc.s 8
-			IL_05f8: ldloc.s 6
-			IL_05fa: ldloc.s 5
-			IL_05fc: ldloc.2
-			IL_05fd: ldloc.s 8
-			IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0604: pop
-			IL_0605: ldarg.0
-			IL_0606: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_060b: volatile.
-			IL_060d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-			IL_0612: brfalse IL_0626
+			IL_0551: ldarg.0
+			IL_0552: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0557: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_055c: ldc.r8 3
+			IL_0565: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_056a: stloc.s 5
+			IL_056c: ldarg.0
+			IL_056d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0572: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0577: ldc.r8 2
+			IL_0580: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0585: stloc.2
+			IL_0586: ldarg.0
+			IL_0587: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_058c: ldnull
+			IL_058d: ldloc.s 5
+			IL_058f: ldloc.2
+			IL_0590: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_0595: pop
+			IL_0596: ldarg.0
+			IL_0597: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_059c: volatile.
+			IL_059e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_05a3: brfalse IL_05b7
 
-			IL_0617: ldstr "Line"
-			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0621: br IL_063a
+			IL_05a8: ldstr "Line"
+			IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b2: br IL_05cb
 
-			IL_0626: ldstr "Line"
-			IL_062b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:178"
-			IL_0630: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-			IL_0635: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_05b7: ldstr "Line"
+			IL_05bc: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:172"
+			IL_05c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_063a: stloc.s 8
-			IL_063c: ldloc.s 8
-			IL_063e: ldc.r8 2
-			IL_0647: ldc.i4.1
-			IL_0648: box [System.Runtime]System.Boolean
-			IL_064d: ldc.i4.1
-			IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0653: pop
+			IL_05cb: stloc.2
+			IL_05cc: ldloc.2
+			IL_05cd: ldc.r8 2
+			IL_05d6: ldc.i4.1
+			IL_05d7: box [System.Runtime]System.Boolean
+			IL_05dc: ldc.i4.1
+			IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_05e2: pop
 
-			IL_0654: ldarg.0
-			IL_0655: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_065a: volatile.
-			IL_065c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-			IL_0661: brfalse IL_0675
+			IL_05e3: ldarg.0
+			IL_05e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_05e9: volatile.
+			IL_05eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_05f0: brfalse IL_0604
 
-			IL_0666: ldstr "Line"
-			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0670: br IL_0689
+			IL_05f5: ldstr "Line"
+			IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05ff: br IL_0618
 
-			IL_0675: ldstr "Line"
-			IL_067a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:186"
-			IL_067f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-			IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0604: ldstr "Line"
+			IL_0609: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:180"
+			IL_060e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0689: stloc.s 8
-			IL_068b: ldloc.s 8
-			IL_068d: ldc.r8 9
-			IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_069b: stloc.s 8
-			IL_069d: ldloc.s 8
-			IL_069f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_06a4: ldc.i4.0
-			IL_06a5: ceq
-			IL_06a7: stloc.s 7
-			IL_06a9: ldloc.s 7
-			IL_06ab: brfalse IL_0755
+			IL_0618: stloc.2
+			IL_0619: ldloc.2
+			IL_061a: ldc.r8 9
+			IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0628: stloc.2
+			IL_0629: ldloc.2
+			IL_062a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_062f: ldc.i4.0
+			IL_0630: ceq
+			IL_0632: stloc.s 7
+			IL_0634: ldloc.s 7
+			IL_0636: brfalse IL_06cf
 
-			IL_06b0: ldarg.0
-			IL_06b1: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_06b6: stloc.s 8
-			IL_06b8: ldc.i4.1
-			IL_06b9: newarr [System.Runtime]System.Object
-			IL_06be: dup
-			IL_06bf: ldc.i4.0
-			IL_06c0: ldarg.0
-			IL_06c1: stelem.ref
-			IL_06c2: stloc.s 5
-			IL_06c4: ldarg.0
-			IL_06c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_06ca: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_06cf: ldc.r8 2
-			IL_06d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_06dd: stloc.2
-			IL_06de: ldarg.0
-			IL_06df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_06e4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_06e9: ldc.r8 6
-			IL_06f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_06f7: stloc.s 6
-			IL_06f9: ldloc.s 8
-			IL_06fb: ldloc.s 5
-			IL_06fd: ldloc.2
-			IL_06fe: ldloc.s 6
-			IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0705: pop
-			IL_0706: ldarg.0
-			IL_0707: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_070c: volatile.
-			IL_070e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-			IL_0713: brfalse IL_0727
+			IL_063b: ldarg.0
+			IL_063c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0641: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0646: ldc.r8 2
+			IL_064f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0654: stloc.2
+			IL_0655: ldarg.0
+			IL_0656: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_065b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0660: ldc.r8 6
+			IL_0669: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_066e: stloc.s 5
+			IL_0670: ldarg.0
+			IL_0671: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0676: ldnull
+			IL_0677: ldloc.2
+			IL_0678: ldloc.s 5
+			IL_067a: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_067f: pop
+			IL_0680: ldarg.0
+			IL_0681: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0686: volatile.
+			IL_0688: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_068d: brfalse IL_06a1
 
-			IL_0718: ldstr "Line"
-			IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0722: br IL_073b
+			IL_0692: ldstr "Line"
+			IL_0697: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_069c: br IL_06b5
 
-			IL_0727: ldstr "Line"
-			IL_072c: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:204"
-			IL_0731: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-			IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06a1: ldstr "Line"
+			IL_06a6: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:197"
+			IL_06ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_073b: stloc.s 6
-			IL_073d: ldloc.s 6
-			IL_073f: ldc.r8 9
-			IL_0748: ldc.i4.1
-			IL_0749: box [System.Runtime]System.Boolean
-			IL_074e: ldc.i4.1
-			IL_074f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0754: pop
+			IL_06b5: stloc.s 5
+			IL_06b7: ldloc.s 5
+			IL_06b9: ldc.r8 9
+			IL_06c2: ldc.i4.1
+			IL_06c3: box [System.Runtime]System.Boolean
+			IL_06c8: ldc.i4.1
+			IL_06c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_06ce: pop
 
-			IL_0755: ldarg.0
-			IL_0756: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_075b: volatile.
-			IL_075d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-			IL_0762: brfalse IL_0776
+			IL_06cf: ldarg.0
+			IL_06d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_06d5: volatile.
+			IL_06d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_06dc: brfalse IL_06f0
 
-			IL_0767: ldstr "Line"
-			IL_076c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0771: br IL_078a
+			IL_06e1: ldstr "Line"
+			IL_06e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06eb: br IL_0704
 
-			IL_0776: ldstr "Line"
-			IL_077b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:212"
-			IL_0780: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-			IL_0785: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06f0: ldstr "Line"
+			IL_06f5: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:205"
+			IL_06fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_078a: stloc.s 6
-			IL_078c: ldloc.s 6
-			IL_078e: ldc.r8 6
-			IL_0797: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_079c: stloc.s 6
-			IL_079e: ldloc.s 6
-			IL_07a0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_07a5: ldc.i4.0
-			IL_07a6: ceq
-			IL_07a8: stloc.s 7
-			IL_07aa: ldloc.s 7
-			IL_07ac: brfalse IL_0856
+			IL_0704: stloc.s 5
+			IL_0706: ldloc.s 5
+			IL_0708: ldc.r8 6
+			IL_0711: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0716: stloc.s 5
+			IL_0718: ldloc.s 5
+			IL_071a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_071f: ldc.i4.0
+			IL_0720: ceq
+			IL_0722: stloc.s 7
+			IL_0724: ldloc.s 7
+			IL_0726: brfalse IL_07bd
 
-			IL_07b1: ldarg.0
-			IL_07b2: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_07b7: stloc.s 6
-			IL_07b9: ldc.i4.1
-			IL_07ba: newarr [System.Runtime]System.Object
-			IL_07bf: dup
-			IL_07c0: ldc.i4.0
-			IL_07c1: ldarg.0
-			IL_07c2: stelem.ref
-			IL_07c3: stloc.s 5
-			IL_07c5: ldarg.0
-			IL_07c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07cb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_07d0: ldc.r8 6
-			IL_07d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_07de: stloc.2
-			IL_07df: ldarg.0
-			IL_07e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07e5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_07ea: ldc.r8 7
-			IL_07f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_07f8: stloc.s 8
-			IL_07fa: ldloc.s 6
-			IL_07fc: ldloc.s 5
-			IL_07fe: ldloc.2
-			IL_07ff: ldloc.s 8
-			IL_0801: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0806: pop
-			IL_0807: ldarg.0
-			IL_0808: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_080d: volatile.
-			IL_080f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-			IL_0814: brfalse IL_0828
+			IL_072b: ldarg.0
+			IL_072c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0731: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0736: ldc.r8 6
+			IL_073f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0744: stloc.s 5
+			IL_0746: ldarg.0
+			IL_0747: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_074c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0751: ldc.r8 7
+			IL_075a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_075f: stloc.2
+			IL_0760: ldarg.0
+			IL_0761: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0766: ldnull
+			IL_0767: ldloc.s 5
+			IL_0769: ldloc.2
+			IL_076a: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_076f: pop
+			IL_0770: ldarg.0
+			IL_0771: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0776: volatile.
+			IL_0778: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_077d: brfalse IL_0791
 
-			IL_0819: ldstr "Line"
-			IL_081e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0823: br IL_083c
+			IL_0782: ldstr "Line"
+			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_078c: br IL_07a5
 
-			IL_0828: ldstr "Line"
-			IL_082d: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:230"
-			IL_0832: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-			IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0791: ldstr "Line"
+			IL_0796: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:222"
+			IL_079b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_083c: stloc.s 8
-			IL_083e: ldloc.s 8
-			IL_0840: ldc.r8 6
-			IL_0849: ldc.i4.1
-			IL_084a: box [System.Runtime]System.Boolean
-			IL_084f: ldc.i4.1
-			IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0855: pop
+			IL_07a5: stloc.2
+			IL_07a6: ldloc.2
+			IL_07a7: ldc.r8 6
+			IL_07b0: ldc.i4.1
+			IL_07b1: box [System.Runtime]System.Boolean
+			IL_07b6: ldc.i4.1
+			IL_07b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_07bc: pop
 
-			IL_0856: ldarg.0
-			IL_0857: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_085c: volatile.
-			IL_085e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-			IL_0863: brfalse IL_0877
+			IL_07bd: ldarg.0
+			IL_07be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07c3: volatile.
+			IL_07c5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_07ca: brfalse IL_07de
 
-			IL_0868: ldstr "Line"
-			IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0872: br IL_088b
+			IL_07cf: ldstr "Line"
+			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d9: br IL_07f2
 
-			IL_0877: ldstr "Line"
-			IL_087c: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:238"
-			IL_0881: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-			IL_0886: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07de: ldstr "Line"
+			IL_07e3: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:230"
+			IL_07e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_088b: stloc.s 8
-			IL_088d: ldloc.s 8
-			IL_088f: ldc.r8 10
-			IL_0898: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_089d: stloc.s 8
-			IL_089f: ldloc.s 8
-			IL_08a1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_08a6: ldc.i4.0
-			IL_08a7: ceq
-			IL_08a9: stloc.s 7
-			IL_08ab: ldloc.s 7
-			IL_08ad: brfalse IL_0957
+			IL_07f2: stloc.2
+			IL_07f3: ldloc.2
+			IL_07f4: ldc.r8 10
+			IL_07fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0802: stloc.2
+			IL_0803: ldloc.2
+			IL_0804: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0809: ldc.i4.0
+			IL_080a: ceq
+			IL_080c: stloc.s 7
+			IL_080e: ldloc.s 7
+			IL_0810: brfalse IL_08a9
 
-			IL_08b2: ldarg.0
-			IL_08b3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_08b8: stloc.s 8
-			IL_08ba: ldc.i4.1
-			IL_08bb: newarr [System.Runtime]System.Object
-			IL_08c0: dup
-			IL_08c1: ldc.i4.0
-			IL_08c2: ldarg.0
-			IL_08c3: stelem.ref
-			IL_08c4: stloc.s 5
-			IL_08c6: ldarg.0
-			IL_08c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_08cc: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_08d1: ldc.r8 7
-			IL_08da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_08df: stloc.2
-			IL_08e0: ldarg.0
-			IL_08e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_08e6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_08eb: ldc.r8 3
-			IL_08f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_08f9: stloc.s 6
-			IL_08fb: ldloc.s 8
-			IL_08fd: ldloc.s 5
-			IL_08ff: ldloc.2
-			IL_0900: ldloc.s 6
-			IL_0902: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0907: pop
-			IL_0908: ldarg.0
-			IL_0909: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_090e: volatile.
-			IL_0910: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-			IL_0915: brfalse IL_0929
+			IL_0815: ldarg.0
+			IL_0816: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_081b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0820: ldc.r8 7
+			IL_0829: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_082e: stloc.2
+			IL_082f: ldarg.0
+			IL_0830: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0835: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_083a: ldc.r8 3
+			IL_0843: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0848: stloc.s 5
+			IL_084a: ldarg.0
+			IL_084b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0850: ldnull
+			IL_0851: ldloc.2
+			IL_0852: ldloc.s 5
+			IL_0854: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_0859: pop
+			IL_085a: ldarg.0
+			IL_085b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0860: volatile.
+			IL_0862: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_0867: brfalse IL_087b
 
-			IL_091a: ldstr "Line"
-			IL_091f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0924: br IL_093d
+			IL_086c: ldstr "Line"
+			IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0876: br IL_088f
 
-			IL_0929: ldstr "Line"
-			IL_092e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:256"
-			IL_0933: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-			IL_0938: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_087b: ldstr "Line"
+			IL_0880: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:247"
+			IL_0885: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+			IL_088a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_093d: stloc.s 6
-			IL_093f: ldloc.s 6
-			IL_0941: ldc.r8 10
-			IL_094a: ldc.i4.1
-			IL_094b: box [System.Runtime]System.Boolean
-			IL_0950: ldc.i4.1
-			IL_0951: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0956: pop
+			IL_088f: stloc.s 5
+			IL_0891: ldloc.s 5
+			IL_0893: ldc.r8 10
+			IL_089c: ldc.i4.1
+			IL_089d: box [System.Runtime]System.Boolean
+			IL_08a2: ldc.i4.1
+			IL_08a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_08a8: pop
 
-			IL_0957: ldloc.0
-			IL_0958: ldc.r8 2
-			IL_0961: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0966: stloc.s 6
-			IL_0968: ldloc.s 6
-			IL_096a: ldc.r8 2
-			IL_0973: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0978: stloc.s 6
-			IL_097a: ldloc.s 6
-			IL_097c: ldc.r8 0.0
-			IL_0985: box [System.Runtime]System.Double
-			IL_098a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_098f: stloc.s 7
-			IL_0991: ldloc.s 7
-			IL_0993: brfalse IL_0d9c
+			IL_08a9: ldloc.0
+			IL_08aa: ldc.r8 2
+			IL_08b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_08b8: stloc.s 5
+			IL_08ba: ldloc.s 5
+			IL_08bc: ldc.r8 2
+			IL_08c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_08ca: stloc.s 5
+			IL_08cc: ldloc.s 5
+			IL_08ce: ldc.r8 0.0
+			IL_08d7: box [System.Runtime]System.Double
+			IL_08dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_08e1: stloc.s 7
+			IL_08e3: ldloc.s 7
+			IL_08e5: brfalse IL_0c9e
 
-			IL_0998: ldarg.0
-			IL_0999: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_099e: volatile.
-			IL_09a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-			IL_09a5: brfalse IL_09b9
+			IL_08ea: ldarg.0
+			IL_08eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_08f0: volatile.
+			IL_08f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_08f7: brfalse IL_090b
 
-			IL_09aa: ldstr "Line"
-			IL_09af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09b4: br IL_09cd
+			IL_08fc: ldstr "Line"
+			IL_0901: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0906: br IL_091f
 
-			IL_09b9: ldstr "Line"
-			IL_09be: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:274"
-			IL_09c3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-			IL_09c8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_090b: ldstr "Line"
+			IL_0910: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:265"
+			IL_0915: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+			IL_091a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_09cd: stloc.s 6
-			IL_09cf: ldloc.s 6
-			IL_09d1: ldc.r8 4
-			IL_09da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_09df: stloc.s 6
-			IL_09e1: ldloc.s 6
-			IL_09e3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_09e8: ldc.i4.0
-			IL_09e9: ceq
-			IL_09eb: stloc.s 7
-			IL_09ed: ldloc.s 7
-			IL_09ef: brfalse IL_0a99
+			IL_091f: stloc.s 5
+			IL_0921: ldloc.s 5
+			IL_0923: ldc.r8 4
+			IL_092c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0931: stloc.s 5
+			IL_0933: ldloc.s 5
+			IL_0935: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_093a: ldc.i4.0
+			IL_093b: ceq
+			IL_093d: stloc.s 7
+			IL_093f: ldloc.s 7
+			IL_0941: brfalse IL_09d8
 
-			IL_09f4: ldarg.0
-			IL_09f5: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_09fa: stloc.s 6
-			IL_09fc: ldc.i4.1
-			IL_09fd: newarr [System.Runtime]System.Object
-			IL_0a02: dup
-			IL_0a03: ldc.i4.0
-			IL_0a04: ldarg.0
-			IL_0a05: stelem.ref
-			IL_0a06: stloc.s 5
-			IL_0a08: ldarg.0
-			IL_0a09: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a0e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0a13: ldc.r8 4
-			IL_0a1c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0a21: stloc.2
-			IL_0a22: ldarg.0
-			IL_0a23: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a28: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0a2d: ldc.r8 5
-			IL_0a36: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0a3b: stloc.s 8
-			IL_0a3d: ldloc.s 6
-			IL_0a3f: ldloc.s 5
-			IL_0a41: ldloc.2
-			IL_0a42: ldloc.s 8
-			IL_0a44: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0a49: pop
+			IL_0946: ldarg.0
+			IL_0947: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_094c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0951: ldc.r8 4
+			IL_095a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_095f: stloc.s 5
+			IL_0961: ldarg.0
+			IL_0962: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0967: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_096c: ldc.r8 5
+			IL_0975: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_097a: stloc.2
+			IL_097b: ldarg.0
+			IL_097c: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0981: ldnull
+			IL_0982: ldloc.s 5
+			IL_0984: ldloc.2
+			IL_0985: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_098a: pop
+			IL_098b: ldarg.0
+			IL_098c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0991: volatile.
+			IL_0993: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_0998: brfalse IL_09ac
+
+			IL_099d: ldstr "Line"
+			IL_09a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09a7: br IL_09c0
+
+			IL_09ac: ldstr "Line"
+			IL_09b1: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:282"
+			IL_09b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+			IL_09bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_09c0: stloc.2
+			IL_09c1: ldloc.2
+			IL_09c2: ldc.r8 4
+			IL_09cb: ldc.i4.1
+			IL_09cc: box [System.Runtime]System.Boolean
+			IL_09d1: ldc.i4.1
+			IL_09d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_09d7: pop
+
+			IL_09d8: ldarg.0
+			IL_09d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_09de: volatile.
+			IL_09e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_09e5: brfalse IL_09f9
+
+			IL_09ea: ldstr "Line"
+			IL_09ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09f4: br IL_0a0d
+
+			IL_09f9: ldstr "Line"
+			IL_09fe: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:290"
+			IL_0a03: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+			IL_0a08: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_0a0d: stloc.2
+			IL_0a0e: ldloc.2
+			IL_0a0f: ldc.r8 5
+			IL_0a18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0a1d: stloc.2
+			IL_0a1e: ldloc.2
+			IL_0a1f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0a24: ldc.i4.0
+			IL_0a25: ceq
+			IL_0a27: stloc.s 7
+			IL_0a29: ldloc.s 7
+			IL_0a2b: brfalse IL_0ac4
+
+			IL_0a30: ldarg.0
+			IL_0a31: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a36: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0a3b: ldc.r8 5
+			IL_0a44: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0a49: stloc.2
 			IL_0a4a: ldarg.0
 			IL_0a4b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a50: volatile.
-			IL_0a52: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-			IL_0a57: brfalse IL_0a6b
+			IL_0a50: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0a55: ldc.r8 6
+			IL_0a5e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0a63: stloc.s 5
+			IL_0a65: ldarg.0
+			IL_0a66: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0a6b: ldnull
+			IL_0a6c: ldloc.2
+			IL_0a6d: ldloc.s 5
+			IL_0a6f: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_0a74: pop
+			IL_0a75: ldarg.0
+			IL_0a76: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a7b: volatile.
+			IL_0a7d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_0a82: brfalse IL_0a96
 
-			IL_0a5c: ldstr "Line"
-			IL_0a61: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a66: br IL_0a7f
+			IL_0a87: ldstr "Line"
+			IL_0a8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a91: br IL_0aaa
 
-			IL_0a6b: ldstr "Line"
-			IL_0a70: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:292"
-			IL_0a75: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0a96: ldstr "Line"
+			IL_0a9b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:307"
+			IL_0aa0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+			IL_0aa5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0a7f: stloc.s 8
-			IL_0a81: ldloc.s 8
-			IL_0a83: ldc.r8 4
-			IL_0a8c: ldc.i4.1
-			IL_0a8d: box [System.Runtime]System.Boolean
-			IL_0a92: ldc.i4.1
-			IL_0a93: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0a98: pop
+			IL_0aaa: stloc.s 5
+			IL_0aac: ldloc.s 5
+			IL_0aae: ldc.r8 5
+			IL_0ab7: ldc.i4.1
+			IL_0ab8: box [System.Runtime]System.Boolean
+			IL_0abd: ldc.i4.1
+			IL_0abe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0ac3: pop
 
-			IL_0a99: ldarg.0
-			IL_0a9a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a9f: volatile.
-			IL_0aa1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-			IL_0aa6: brfalse IL_0aba
+			IL_0ac4: ldarg.0
+			IL_0ac5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0aca: volatile.
+			IL_0acc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0ad1: brfalse IL_0ae5
 
-			IL_0aab: ldstr "Line"
-			IL_0ab0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ab5: br IL_0ace
+			IL_0ad6: ldstr "Line"
+			IL_0adb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ae0: br IL_0af9
 
-			IL_0aba: ldstr "Line"
-			IL_0abf: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:300"
-			IL_0ac4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-			IL_0ac9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0ae5: ldstr "Line"
+			IL_0aea: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:315"
+			IL_0aef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0af4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0ace: stloc.s 8
-			IL_0ad0: ldloc.s 8
-			IL_0ad2: ldc.r8 5
-			IL_0adb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ae0: stloc.s 8
-			IL_0ae2: ldloc.s 8
-			IL_0ae4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0ae9: ldc.i4.0
-			IL_0aea: ceq
-			IL_0aec: stloc.s 7
-			IL_0aee: ldloc.s 7
-			IL_0af0: brfalse IL_0b9a
+			IL_0af9: stloc.s 5
+			IL_0afb: ldloc.s 5
+			IL_0afd: ldc.r8 6
+			IL_0b06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0b0b: stloc.s 5
+			IL_0b0d: ldloc.s 5
+			IL_0b0f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0b14: ldc.i4.0
+			IL_0b15: ceq
+			IL_0b17: stloc.s 7
+			IL_0b19: ldloc.s 7
+			IL_0b1b: brfalse IL_0bb2
 
-			IL_0af5: ldarg.0
-			IL_0af6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0afb: stloc.s 8
-			IL_0afd: ldc.i4.1
-			IL_0afe: newarr [System.Runtime]System.Object
-			IL_0b03: dup
-			IL_0b04: ldc.i4.0
-			IL_0b05: ldarg.0
-			IL_0b06: stelem.ref
-			IL_0b07: stloc.s 5
-			IL_0b09: ldarg.0
-			IL_0b0a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b0f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0b14: ldc.r8 5
-			IL_0b1d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0b22: stloc.2
-			IL_0b23: ldarg.0
-			IL_0b24: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b29: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0b2e: ldc.r8 6
-			IL_0b37: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0b3c: stloc.s 6
-			IL_0b3e: ldloc.s 8
-			IL_0b40: ldloc.s 5
-			IL_0b42: ldloc.2
-			IL_0b43: ldloc.s 6
-			IL_0b45: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b4a: pop
-			IL_0b4b: ldarg.0
-			IL_0b4c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b51: volatile.
-			IL_0b53: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-			IL_0b58: brfalse IL_0b6c
+			IL_0b20: ldarg.0
+			IL_0b21: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b26: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0b2b: ldc.r8 6
+			IL_0b34: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0b39: stloc.s 5
+			IL_0b3b: ldarg.0
+			IL_0b3c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b41: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0b46: ldc.r8 7
+			IL_0b4f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0b54: stloc.2
+			IL_0b55: ldarg.0
+			IL_0b56: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0b5b: ldnull
+			IL_0b5c: ldloc.s 5
+			IL_0b5e: ldloc.2
+			IL_0b5f: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_0b64: pop
+			IL_0b65: ldarg.0
+			IL_0b66: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b6b: volatile.
+			IL_0b6d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_0b72: brfalse IL_0b86
 
-			IL_0b5d: ldstr "Line"
-			IL_0b62: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b67: br IL_0b80
+			IL_0b77: ldstr "Line"
+			IL_0b7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b81: br IL_0b9a
 
-			IL_0b6c: ldstr "Line"
-			IL_0b71: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:318"
-			IL_0b76: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-			IL_0b7b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0b86: ldstr "Line"
+			IL_0b8b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:332"
+			IL_0b90: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_0b95: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0b80: stloc.s 6
-			IL_0b82: ldloc.s 6
-			IL_0b84: ldc.r8 5
-			IL_0b8d: ldc.i4.1
-			IL_0b8e: box [System.Runtime]System.Boolean
-			IL_0b93: ldc.i4.1
-			IL_0b94: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0b99: pop
+			IL_0b9a: stloc.2
+			IL_0b9b: ldloc.2
+			IL_0b9c: ldc.r8 6
+			IL_0ba5: ldc.i4.1
+			IL_0ba6: box [System.Runtime]System.Boolean
+			IL_0bab: ldc.i4.1
+			IL_0bac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0bb1: pop
 
-			IL_0b9a: ldarg.0
-			IL_0b9b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ba0: volatile.
-			IL_0ba2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-			IL_0ba7: brfalse IL_0bbb
+			IL_0bb2: ldarg.0
+			IL_0bb3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0bb8: volatile.
+			IL_0bba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_0bbf: brfalse IL_0bd3
 
-			IL_0bac: ldstr "Line"
-			IL_0bb1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bb6: br IL_0bcf
+			IL_0bc4: ldstr "Line"
+			IL_0bc9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bce: br IL_0be7
 
-			IL_0bbb: ldstr "Line"
-			IL_0bc0: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:326"
-			IL_0bc5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-			IL_0bca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0bd3: ldstr "Line"
+			IL_0bd8: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:340"
+			IL_0bdd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_0be2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0bcf: stloc.s 6
-			IL_0bd1: ldloc.s 6
-			IL_0bd3: ldc.r8 6
-			IL_0bdc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0be1: stloc.s 6
-			IL_0be3: ldloc.s 6
-			IL_0be5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0bea: ldc.i4.0
-			IL_0beb: ceq
-			IL_0bed: stloc.s 7
-			IL_0bef: ldloc.s 7
-			IL_0bf1: brfalse IL_0c9b
+			IL_0be7: stloc.2
+			IL_0be8: ldloc.2
+			IL_0be9: ldc.r8 7
+			IL_0bf2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0bf7: stloc.2
+			IL_0bf8: ldloc.2
+			IL_0bf9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0bfe: ldc.i4.0
+			IL_0bff: ceq
+			IL_0c01: stloc.s 7
+			IL_0c03: ldloc.s 7
+			IL_0c05: brfalse IL_0c9e
 
-			IL_0bf6: ldarg.0
-			IL_0bf7: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0bfc: stloc.s 6
-			IL_0bfe: ldc.i4.1
-			IL_0bff: newarr [System.Runtime]System.Object
-			IL_0c04: dup
-			IL_0c05: ldc.i4.0
-			IL_0c06: ldarg.0
-			IL_0c07: stelem.ref
-			IL_0c08: stloc.s 5
 			IL_0c0a: ldarg.0
 			IL_0c0b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0c10: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0c15: ldc.r8 6
+			IL_0c15: ldc.r8 7
 			IL_0c1e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
 			IL_0c23: stloc.2
 			IL_0c24: ldarg.0
 			IL_0c25: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0c2a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0c2f: ldc.r8 7
+			IL_0c2f: ldc.r8 4
 			IL_0c38: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0c3d: stloc.s 8
-			IL_0c3f: ldloc.s 6
-			IL_0c41: ldloc.s 5
-			IL_0c43: ldloc.2
-			IL_0c44: ldloc.s 8
-			IL_0c46: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0c4b: pop
-			IL_0c4c: ldarg.0
-			IL_0c4d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c52: volatile.
-			IL_0c54: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-			IL_0c59: brfalse IL_0c6d
+			IL_0c3d: stloc.s 5
+			IL_0c3f: ldarg.0
+			IL_0c40: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0c45: ldnull
+			IL_0c46: ldloc.2
+			IL_0c47: ldloc.s 5
+			IL_0c49: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_0c4e: pop
+			IL_0c4f: ldarg.0
+			IL_0c50: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c55: volatile.
+			IL_0c57: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0c5c: brfalse IL_0c70
 
-			IL_0c5e: ldstr "Line"
-			IL_0c63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c68: br IL_0c81
+			IL_0c61: ldstr "Line"
+			IL_0c66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c6b: br IL_0c84
 
-			IL_0c6d: ldstr "Line"
-			IL_0c72: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:344"
-			IL_0c77: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-			IL_0c7c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0c70: ldstr "Line"
+			IL_0c75: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:357"
+			IL_0c7a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0c7f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0c81: stloc.s 8
-			IL_0c83: ldloc.s 8
-			IL_0c85: ldc.r8 6
-			IL_0c8e: ldc.i4.1
-			IL_0c8f: box [System.Runtime]System.Boolean
-			IL_0c94: ldc.i4.1
-			IL_0c95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0c9a: pop
+			IL_0c84: stloc.s 5
+			IL_0c86: ldloc.s 5
+			IL_0c88: ldc.r8 7
+			IL_0c91: ldc.i4.1
+			IL_0c92: box [System.Runtime]System.Boolean
+			IL_0c97: ldc.i4.1
+			IL_0c98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0c9d: pop
 
-			IL_0c9b: ldarg.0
-			IL_0c9c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ca1: volatile.
-			IL_0ca3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_0ca8: brfalse IL_0cbc
+			IL_0c9e: ldloc.0
+			IL_0c9f: ldc.r8 3
+			IL_0ca8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0cad: stloc.s 5
+			IL_0caf: ldloc.s 5
+			IL_0cb1: ldc.r8 2
+			IL_0cba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0cbf: stloc.s 5
+			IL_0cc1: ldloc.s 5
+			IL_0cc3: ldc.r8 0.0
+			IL_0ccc: box [System.Runtime]System.Double
+			IL_0cd1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_0cd6: stloc.s 7
+			IL_0cd8: ldloc.s 7
+			IL_0cda: brfalse IL_1093
 
-			IL_0cad: ldstr "Line"
-			IL_0cb2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cb7: br IL_0cd0
+			IL_0cdf: ldarg.0
+			IL_0ce0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ce5: volatile.
+			IL_0ce7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_0cec: brfalse IL_0d00
 
-			IL_0cbc: ldstr "Line"
-			IL_0cc1: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:352"
-			IL_0cc6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_0ccb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0cf1: ldstr "Line"
+			IL_0cf6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0cfb: br IL_0d14
 
-			IL_0cd0: stloc.s 8
-			IL_0cd2: ldloc.s 8
-			IL_0cd4: ldc.r8 7
-			IL_0cdd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ce2: stloc.s 8
-			IL_0ce4: ldloc.s 8
-			IL_0ce6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0ceb: ldc.i4.0
-			IL_0cec: ceq
-			IL_0cee: stloc.s 7
-			IL_0cf0: ldloc.s 7
-			IL_0cf2: brfalse IL_0d9c
+			IL_0d00: ldstr "Line"
+			IL_0d05: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:375"
+			IL_0d0a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_0d0f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0cf7: ldarg.0
-			IL_0cf8: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0cfd: stloc.s 8
-			IL_0cff: ldc.i4.1
-			IL_0d00: newarr [System.Runtime]System.Object
-			IL_0d05: dup
-			IL_0d06: ldc.i4.0
-			IL_0d07: ldarg.0
-			IL_0d08: stelem.ref
-			IL_0d09: stloc.s 5
-			IL_0d0b: ldarg.0
-			IL_0d0c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d11: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0d16: ldc.r8 7
-			IL_0d1f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0d24: stloc.2
-			IL_0d25: ldarg.0
-			IL_0d26: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d2b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0d30: ldc.r8 4
-			IL_0d39: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0d3e: stloc.s 6
-			IL_0d40: ldloc.s 8
-			IL_0d42: ldloc.s 5
-			IL_0d44: ldloc.2
-			IL_0d45: ldloc.s 6
-			IL_0d47: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0d4c: pop
-			IL_0d4d: ldarg.0
-			IL_0d4e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d53: volatile.
-			IL_0d55: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_0d5a: brfalse IL_0d6e
+			IL_0d14: stloc.s 5
+			IL_0d16: ldloc.s 5
+			IL_0d18: ldc.r8 4
+			IL_0d21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d26: stloc.s 5
+			IL_0d28: ldloc.s 5
+			IL_0d2a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0d2f: ldc.i4.0
+			IL_0d30: ceq
+			IL_0d32: stloc.s 7
+			IL_0d34: ldloc.s 7
+			IL_0d36: brfalse IL_0dcd
 
-			IL_0d5f: ldstr "Line"
-			IL_0d64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d69: br IL_0d82
+			IL_0d3b: ldarg.0
+			IL_0d3c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d41: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0d46: ldc.r8 4
+			IL_0d4f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0d54: stloc.s 5
+			IL_0d56: ldarg.0
+			IL_0d57: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d5c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0d61: ldc.r8 5
+			IL_0d6a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0d6f: stloc.2
+			IL_0d70: ldarg.0
+			IL_0d71: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0d76: ldnull
+			IL_0d77: ldloc.s 5
+			IL_0d79: ldloc.2
+			IL_0d7a: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_0d7f: pop
+			IL_0d80: ldarg.0
+			IL_0d81: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d86: volatile.
+			IL_0d88: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_0d8d: brfalse IL_0da1
 
-			IL_0d6e: ldstr "Line"
-			IL_0d73: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:370"
-			IL_0d78: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_0d7d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0d92: ldstr "Line"
+			IL_0d97: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d9c: br IL_0db5
 
-			IL_0d82: stloc.s 6
-			IL_0d84: ldloc.s 6
-			IL_0d86: ldc.r8 7
-			IL_0d8f: ldc.i4.1
-			IL_0d90: box [System.Runtime]System.Boolean
-			IL_0d95: ldc.i4.1
-			IL_0d96: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0d9b: pop
+			IL_0da1: ldstr "Line"
+			IL_0da6: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:392"
+			IL_0dab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_0db0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0d9c: ldloc.0
-			IL_0d9d: ldc.r8 3
-			IL_0da6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0dab: stloc.s 6
-			IL_0dad: ldloc.s 6
-			IL_0daf: ldc.r8 2
-			IL_0db8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0dbd: stloc.s 6
-			IL_0dbf: ldloc.s 6
-			IL_0dc1: ldc.r8 0.0
-			IL_0dca: box [System.Runtime]System.Double
-			IL_0dcf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_0dd4: stloc.s 7
-			IL_0dd6: ldloc.s 7
-			IL_0dd8: brfalse IL_11e1
+			IL_0db5: stloc.2
+			IL_0db6: ldloc.2
+			IL_0db7: ldc.r8 4
+			IL_0dc0: ldc.i4.1
+			IL_0dc1: box [System.Runtime]System.Boolean
+			IL_0dc6: ldc.i4.1
+			IL_0dc7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0dcc: pop
 
-			IL_0ddd: ldarg.0
-			IL_0dde: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0de3: volatile.
-			IL_0de5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-			IL_0dea: brfalse IL_0dfe
+			IL_0dcd: ldarg.0
+			IL_0dce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0dd3: volatile.
+			IL_0dd5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0dda: brfalse IL_0dee
 
-			IL_0def: ldstr "Line"
-			IL_0df4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0df9: br IL_0e12
+			IL_0ddf: ldstr "Line"
+			IL_0de4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0de9: br IL_0e02
 
-			IL_0dfe: ldstr "Line"
-			IL_0e03: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:388"
-			IL_0e08: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-			IL_0e0d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0dee: ldstr "Line"
+			IL_0df3: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:400"
+			IL_0df8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0dfd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e12: stloc.s 6
-			IL_0e14: ldloc.s 6
-			IL_0e16: ldc.r8 4
-			IL_0e1f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e24: stloc.s 6
-			IL_0e26: ldloc.s 6
-			IL_0e28: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0e2d: ldc.i4.0
-			IL_0e2e: ceq
-			IL_0e30: stloc.s 7
-			IL_0e32: ldloc.s 7
-			IL_0e34: brfalse IL_0ede
+			IL_0e02: stloc.2
+			IL_0e03: ldloc.2
+			IL_0e04: ldc.r8 8
+			IL_0e0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e12: stloc.2
+			IL_0e13: ldloc.2
+			IL_0e14: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0e19: ldc.i4.0
+			IL_0e1a: ceq
+			IL_0e1c: stloc.s 7
+			IL_0e1e: ldloc.s 7
+			IL_0e20: brfalse IL_0eb9
 
-			IL_0e39: ldarg.0
-			IL_0e3a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0e3f: stloc.s 6
-			IL_0e41: ldc.i4.1
-			IL_0e42: newarr [System.Runtime]System.Object
-			IL_0e47: dup
-			IL_0e48: ldc.i4.0
-			IL_0e49: ldarg.0
-			IL_0e4a: stelem.ref
-			IL_0e4b: stloc.s 5
-			IL_0e4d: ldarg.0
-			IL_0e4e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e53: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0e58: ldc.r8 4
-			IL_0e61: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0e66: stloc.2
-			IL_0e67: ldarg.0
-			IL_0e68: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e6d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0e72: ldc.r8 5
-			IL_0e7b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0e80: stloc.s 8
-			IL_0e82: ldloc.s 6
-			IL_0e84: ldloc.s 5
-			IL_0e86: ldloc.2
-			IL_0e87: ldloc.s 8
-			IL_0e89: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0e8e: pop
-			IL_0e8f: ldarg.0
-			IL_0e90: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e95: volatile.
-			IL_0e97: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_0e9c: brfalse IL_0eb0
+			IL_0e25: ldarg.0
+			IL_0e26: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e2b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e30: ldc.r8 5
+			IL_0e39: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0e3e: stloc.2
+			IL_0e3f: ldarg.0
+			IL_0e40: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e45: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e4a: ldc.r8 1
+			IL_0e53: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0e58: stloc.s 5
+			IL_0e5a: ldarg.0
+			IL_0e5b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0e60: ldnull
+			IL_0e61: ldloc.2
+			IL_0e62: ldloc.s 5
+			IL_0e64: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_0e69: pop
+			IL_0e6a: ldarg.0
+			IL_0e6b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e70: volatile.
+			IL_0e72: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0e77: brfalse IL_0e8b
 
-			IL_0ea1: ldstr "Line"
-			IL_0ea6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0eab: br IL_0ec4
+			IL_0e7c: ldstr "Line"
+			IL_0e81: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e86: br IL_0e9f
 
-			IL_0eb0: ldstr "Line"
-			IL_0eb5: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:406"
-			IL_0eba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_0ebf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0e8b: ldstr "Line"
+			IL_0e90: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:417"
+			IL_0e95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0e9a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0ec4: stloc.s 8
-			IL_0ec6: ldloc.s 8
-			IL_0ec8: ldc.r8 4
-			IL_0ed1: ldc.i4.1
-			IL_0ed2: box [System.Runtime]System.Boolean
-			IL_0ed7: ldc.i4.1
-			IL_0ed8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0edd: pop
+			IL_0e9f: stloc.s 5
+			IL_0ea1: ldloc.s 5
+			IL_0ea3: ldc.r8 8
+			IL_0eac: ldc.i4.1
+			IL_0ead: box [System.Runtime]System.Boolean
+			IL_0eb2: ldc.i4.1
+			IL_0eb3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0eb8: pop
 
-			IL_0ede: ldarg.0
-			IL_0edf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ee4: volatile.
-			IL_0ee6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_0eeb: brfalse IL_0eff
+			IL_0eb9: ldarg.0
+			IL_0eba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ebf: volatile.
+			IL_0ec1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0ec6: brfalse IL_0eda
 
-			IL_0ef0: ldstr "Line"
-			IL_0ef5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0efa: br IL_0f13
+			IL_0ecb: ldstr "Line"
+			IL_0ed0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ed5: br IL_0eee
 
-			IL_0eff: ldstr "Line"
-			IL_0f04: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:414"
-			IL_0f09: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_0f0e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0eda: ldstr "Line"
+			IL_0edf: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:425"
+			IL_0ee4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0ee9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f13: stloc.s 8
-			IL_0f15: ldloc.s 8
-			IL_0f17: ldc.r8 8
-			IL_0f20: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0f25: stloc.s 8
-			IL_0f27: ldloc.s 8
-			IL_0f29: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0f2e: ldc.i4.0
-			IL_0f2f: ceq
-			IL_0f31: stloc.s 7
-			IL_0f33: ldloc.s 7
-			IL_0f35: brfalse IL_0fdf
+			IL_0eee: stloc.s 5
+			IL_0ef0: ldloc.s 5
+			IL_0ef2: ldc.r8 0.0
+			IL_0efb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0f00: stloc.s 5
+			IL_0f02: ldloc.s 5
+			IL_0f04: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0f09: ldc.i4.0
+			IL_0f0a: ceq
+			IL_0f0c: stloc.s 7
+			IL_0f0e: ldloc.s 7
+			IL_0f10: brfalse IL_0fa7
 
-			IL_0f3a: ldarg.0
-			IL_0f3b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_0f40: stloc.s 8
-			IL_0f42: ldc.i4.1
-			IL_0f43: newarr [System.Runtime]System.Object
-			IL_0f48: dup
-			IL_0f49: ldc.i4.0
+			IL_0f15: ldarg.0
+			IL_0f16: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0f1b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0f20: ldc.r8 1
+			IL_0f29: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0f2e: stloc.s 5
+			IL_0f30: ldarg.0
+			IL_0f31: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0f36: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0f3b: ldc.r8 0.0
+			IL_0f44: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0f49: stloc.2
 			IL_0f4a: ldarg.0
-			IL_0f4b: stelem.ref
-			IL_0f4c: stloc.s 5
-			IL_0f4e: ldarg.0
-			IL_0f4f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f54: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0f59: ldc.r8 5
-			IL_0f62: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0f67: stloc.2
-			IL_0f68: ldarg.0
-			IL_0f69: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f6e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0f73: ldc.r8 1
-			IL_0f7c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0f81: stloc.s 6
-			IL_0f83: ldloc.s 8
-			IL_0f85: ldloc.s 5
-			IL_0f87: ldloc.2
-			IL_0f88: ldloc.s 6
-			IL_0f8a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0f8f: pop
-			IL_0f90: ldarg.0
-			IL_0f91: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f96: volatile.
-			IL_0f98: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_0f9d: brfalse IL_0fb1
+			IL_0f4b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0f50: ldnull
+			IL_0f51: ldloc.s 5
+			IL_0f53: ldloc.2
+			IL_0f54: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_0f59: pop
+			IL_0f5a: ldarg.0
+			IL_0f5b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0f60: volatile.
+			IL_0f62: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0f67: brfalse IL_0f7b
 
-			IL_0fa2: ldstr "Line"
-			IL_0fa7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0fac: br IL_0fc5
+			IL_0f6c: ldstr "Line"
+			IL_0f71: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f76: br IL_0f8f
 
-			IL_0fb1: ldstr "Line"
-			IL_0fb6: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:432"
-			IL_0fbb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_0fc0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0f7b: ldstr "Line"
+			IL_0f80: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:442"
+			IL_0f85: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0f8a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0fc5: stloc.s 6
-			IL_0fc7: ldloc.s 6
-			IL_0fc9: ldc.r8 8
-			IL_0fd2: ldc.i4.1
-			IL_0fd3: box [System.Runtime]System.Boolean
-			IL_0fd8: ldc.i4.1
-			IL_0fd9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0fde: pop
+			IL_0f8f: stloc.2
+			IL_0f90: ldloc.2
+			IL_0f91: ldc.r8 0.0
+			IL_0f9a: ldc.i4.1
+			IL_0f9b: box [System.Runtime]System.Boolean
+			IL_0fa0: ldc.i4.1
+			IL_0fa1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0fa6: pop
 
-			IL_0fdf: ldarg.0
-			IL_0fe0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0fe5: volatile.
-			IL_0fe7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_0fec: brfalse IL_1000
+			IL_0fa7: ldarg.0
+			IL_0fa8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0fad: volatile.
+			IL_0faf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_0fb4: brfalse IL_0fc8
 
-			IL_0ff1: ldstr "Line"
-			IL_0ff6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ffb: br IL_1014
+			IL_0fb9: ldstr "Line"
+			IL_0fbe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fc3: br IL_0fdc
 
-			IL_1000: ldstr "Line"
-			IL_1005: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:440"
-			IL_100a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_100f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0fc8: ldstr "Line"
+			IL_0fcd: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:450"
+			IL_0fd2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_0fd7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1014: stloc.s 6
-			IL_1016: ldloc.s 6
-			IL_1018: ldc.r8 0.0
-			IL_1021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1026: stloc.s 6
-			IL_1028: ldloc.s 6
-			IL_102a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_102f: ldc.i4.0
-			IL_1030: ceq
-			IL_1032: stloc.s 7
-			IL_1034: ldloc.s 7
-			IL_1036: brfalse IL_10e0
+			IL_0fdc: stloc.2
+			IL_0fdd: ldloc.2
+			IL_0fde: ldc.r8 11
+			IL_0fe7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0fec: stloc.2
+			IL_0fed: ldloc.2
+			IL_0fee: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0ff3: ldc.i4.0
+			IL_0ff4: ceq
+			IL_0ff6: stloc.s 7
+			IL_0ff8: ldloc.s 7
+			IL_0ffa: brfalse IL_1093
 
-			IL_103b: ldarg.0
-			IL_103c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1041: stloc.s 6
-			IL_1043: ldc.i4.1
-			IL_1044: newarr [System.Runtime]System.Object
-			IL_1049: dup
-			IL_104a: ldc.i4.0
-			IL_104b: ldarg.0
-			IL_104c: stelem.ref
-			IL_104d: stloc.s 5
-			IL_104f: ldarg.0
-			IL_1050: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1055: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_105a: ldc.r8 1
-			IL_1063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1068: stloc.2
-			IL_1069: ldarg.0
-			IL_106a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_106f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_1074: ldc.r8 0.0
-			IL_107d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1082: stloc.s 8
-			IL_1084: ldloc.s 6
-			IL_1086: ldloc.s 5
-			IL_1088: ldloc.2
-			IL_1089: ldloc.s 8
-			IL_108b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1090: pop
-			IL_1091: ldarg.0
-			IL_1092: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1097: volatile.
-			IL_1099: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_109e: brfalse IL_10b2
+			IL_0fff: ldarg.0
+			IL_1000: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1005: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_100a: ldc.r8 0.0
+			IL_1013: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1018: stloc.2
+			IL_1019: ldarg.0
+			IL_101a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_101f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1024: ldc.r8 4
+			IL_102d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1032: stloc.s 5
+			IL_1034: ldarg.0
+			IL_1035: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_103a: ldnull
+			IL_103b: ldloc.2
+			IL_103c: ldloc.s 5
+			IL_103e: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_1043: pop
+			IL_1044: ldarg.0
+			IL_1045: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_104a: volatile.
+			IL_104c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_1051: brfalse IL_1065
 
-			IL_10a3: ldstr "Line"
-			IL_10a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10ad: br IL_10c6
+			IL_1056: ldstr "Line"
+			IL_105b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1060: br IL_1079
 
-			IL_10b2: ldstr "Line"
-			IL_10b7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:458"
-			IL_10bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_10c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1065: ldstr "Line"
+			IL_106a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:467"
+			IL_106f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_1074: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_10c6: stloc.s 8
-			IL_10c8: ldloc.s 8
-			IL_10ca: ldc.r8 0.0
-			IL_10d3: ldc.i4.1
-			IL_10d4: box [System.Runtime]System.Boolean
-			IL_10d9: ldc.i4.1
-			IL_10da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_10df: pop
+			IL_1079: stloc.s 5
+			IL_107b: ldloc.s 5
+			IL_107d: ldc.r8 11
+			IL_1086: ldc.i4.1
+			IL_1087: box [System.Runtime]System.Boolean
+			IL_108c: ldc.i4.1
+			IL_108d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_1092: pop
 
-			IL_10e0: ldarg.0
-			IL_10e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_10e6: volatile.
-			IL_10e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_10ed: brfalse IL_1101
+			IL_1093: ldloc.0
+			IL_1094: ldc.r8 4
+			IL_109d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_10a2: stloc.s 5
+			IL_10a4: ldloc.s 5
+			IL_10a6: ldc.r8 2
+			IL_10af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_10b4: stloc.s 5
+			IL_10b6: ldloc.s 5
+			IL_10b8: ldc.r8 0.0
+			IL_10c1: box [System.Runtime]System.Double
+			IL_10c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_10cb: stloc.s 7
+			IL_10cd: ldloc.s 7
+			IL_10cf: brfalse IL_1488
 
-			IL_10f2: ldstr "Line"
-			IL_10f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10fc: br IL_1115
+			IL_10d4: ldarg.0
+			IL_10d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_10da: volatile.
+			IL_10dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_10e1: brfalse IL_10f5
 
-			IL_1101: ldstr "Line"
-			IL_1106: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:466"
-			IL_110b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_1110: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_10e6: ldstr "Line"
+			IL_10eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_10f0: br IL_1109
 
-			IL_1115: stloc.s 8
-			IL_1117: ldloc.s 8
-			IL_1119: ldc.r8 11
-			IL_1122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1127: stloc.s 8
-			IL_1129: ldloc.s 8
-			IL_112b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1130: ldc.i4.0
-			IL_1131: ceq
-			IL_1133: stloc.s 7
-			IL_1135: ldloc.s 7
-			IL_1137: brfalse IL_11e1
+			IL_10f5: ldstr "Line"
+			IL_10fa: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:485"
+			IL_10ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_1104: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_113c: ldarg.0
-			IL_113d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1142: stloc.s 8
-			IL_1144: ldc.i4.1
-			IL_1145: newarr [System.Runtime]System.Object
-			IL_114a: dup
-			IL_114b: ldc.i4.0
-			IL_114c: ldarg.0
-			IL_114d: stelem.ref
-			IL_114e: stloc.s 5
-			IL_1150: ldarg.0
-			IL_1151: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1156: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_115b: ldc.r8 0.0
-			IL_1164: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1169: stloc.2
-			IL_116a: ldarg.0
-			IL_116b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1170: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_1175: ldc.r8 4
-			IL_117e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1183: stloc.s 6
-			IL_1185: ldloc.s 8
-			IL_1187: ldloc.s 5
-			IL_1189: ldloc.2
-			IL_118a: ldloc.s 6
-			IL_118c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1191: pop
-			IL_1192: ldarg.0
-			IL_1193: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1198: volatile.
-			IL_119a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_119f: brfalse IL_11b3
+			IL_1109: stloc.s 5
+			IL_110b: ldloc.s 5
+			IL_110d: ldc.r8 11
+			IL_1116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_111b: stloc.s 5
+			IL_111d: ldloc.s 5
+			IL_111f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_1124: ldc.i4.0
+			IL_1125: ceq
+			IL_1127: stloc.s 7
+			IL_1129: ldloc.s 7
+			IL_112b: brfalse IL_11c2
 
-			IL_11a4: ldstr "Line"
-			IL_11a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_11ae: br IL_11c7
+			IL_1130: ldarg.0
+			IL_1131: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1136: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_113b: ldc.r8 4
+			IL_1144: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1149: stloc.s 5
+			IL_114b: ldarg.0
+			IL_114c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1151: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1156: ldc.r8 0.0
+			IL_115f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1164: stloc.2
+			IL_1165: ldarg.0
+			IL_1166: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_116b: ldnull
+			IL_116c: ldloc.s 5
+			IL_116e: ldloc.2
+			IL_116f: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_1174: pop
+			IL_1175: ldarg.0
+			IL_1176: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_117b: volatile.
+			IL_117d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_1182: brfalse IL_1196
 
-			IL_11b3: ldstr "Line"
-			IL_11b8: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:484"
-			IL_11bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_11c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1187: ldstr "Line"
+			IL_118c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1191: br IL_11aa
 
-			IL_11c7: stloc.s 6
-			IL_11c9: ldloc.s 6
-			IL_11cb: ldc.r8 11
-			IL_11d4: ldc.i4.1
-			IL_11d5: box [System.Runtime]System.Boolean
-			IL_11da: ldc.i4.1
-			IL_11db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_11e0: pop
+			IL_1196: ldstr "Line"
+			IL_119b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:502"
+			IL_11a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_11a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_11e1: ldloc.0
-			IL_11e2: ldc.r8 4
-			IL_11eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_11f0: stloc.s 6
-			IL_11f2: ldloc.s 6
-			IL_11f4: ldc.r8 2
-			IL_11fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1202: stloc.s 6
-			IL_1204: ldloc.s 6
-			IL_1206: ldc.r8 0.0
-			IL_120f: box [System.Runtime]System.Double
-			IL_1214: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_1219: stloc.s 7
-			IL_121b: ldloc.s 7
-			IL_121d: brfalse IL_1626
+			IL_11aa: stloc.2
+			IL_11ab: ldloc.2
+			IL_11ac: ldc.r8 11
+			IL_11b5: ldc.i4.1
+			IL_11b6: box [System.Runtime]System.Boolean
+			IL_11bb: ldc.i4.1
+			IL_11bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_11c1: pop
 
-			IL_1222: ldarg.0
-			IL_1223: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1228: volatile.
-			IL_122a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_122f: brfalse IL_1243
+			IL_11c2: ldarg.0
+			IL_11c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_11c8: volatile.
+			IL_11ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_11cf: brfalse IL_11e3
 
-			IL_1234: ldstr "Line"
-			IL_1239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_123e: br IL_1257
+			IL_11d4: ldstr "Line"
+			IL_11d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_11de: br IL_11f7
 
-			IL_1243: ldstr "Line"
-			IL_1248: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:502"
-			IL_124d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_1252: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_11e3: ldstr "Line"
+			IL_11e8: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:510"
+			IL_11ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_11f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1257: stloc.s 6
-			IL_1259: ldloc.s 6
-			IL_125b: ldc.r8 11
-			IL_1264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1269: stloc.s 6
-			IL_126b: ldloc.s 6
-			IL_126d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1272: ldc.i4.0
-			IL_1273: ceq
-			IL_1275: stloc.s 7
-			IL_1277: ldloc.s 7
-			IL_1279: brfalse IL_1323
+			IL_11f7: stloc.2
+			IL_11f8: ldloc.2
+			IL_11f9: ldc.r8 3
+			IL_1202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1207: stloc.2
+			IL_1208: ldloc.2
+			IL_1209: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_120e: ldc.i4.0
+			IL_120f: ceq
+			IL_1211: stloc.s 7
+			IL_1213: ldloc.s 7
+			IL_1215: brfalse IL_12ae
 
-			IL_127e: ldarg.0
-			IL_127f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1284: stloc.s 6
-			IL_1286: ldc.i4.1
-			IL_1287: newarr [System.Runtime]System.Object
-			IL_128c: dup
-			IL_128d: ldc.i4.0
-			IL_128e: ldarg.0
-			IL_128f: stelem.ref
-			IL_1290: stloc.s 5
-			IL_1292: ldarg.0
-			IL_1293: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1298: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_129d: ldc.r8 4
-			IL_12a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_12ab: stloc.2
-			IL_12ac: ldarg.0
-			IL_12ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_12b2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_12b7: ldc.r8 0.0
-			IL_12c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_12c5: stloc.s 8
-			IL_12c7: ldloc.s 6
-			IL_12c9: ldloc.s 5
-			IL_12cb: ldloc.2
-			IL_12cc: ldloc.s 8
-			IL_12ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_12d3: pop
-			IL_12d4: ldarg.0
-			IL_12d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_12da: volatile.
-			IL_12dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_12e1: brfalse IL_12f5
+			IL_121a: ldarg.0
+			IL_121b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1220: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1225: ldc.r8 0.0
+			IL_122e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1233: stloc.2
+			IL_1234: ldarg.0
+			IL_1235: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_123a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_123f: ldc.r8 3
+			IL_1248: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_124d: stloc.s 5
+			IL_124f: ldarg.0
+			IL_1250: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_1255: ldnull
+			IL_1256: ldloc.2
+			IL_1257: ldloc.s 5
+			IL_1259: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_125e: pop
+			IL_125f: ldarg.0
+			IL_1260: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1265: volatile.
+			IL_1267: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_126c: brfalse IL_1280
 
-			IL_12e6: ldstr "Line"
-			IL_12eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_12f0: br IL_1309
+			IL_1271: ldstr "Line"
+			IL_1276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_127b: br IL_1294
 
-			IL_12f5: ldstr "Line"
-			IL_12fa: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:520"
-			IL_12ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_1304: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1280: ldstr "Line"
+			IL_1285: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:527"
+			IL_128a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_128f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1309: stloc.s 8
-			IL_130b: ldloc.s 8
-			IL_130d: ldc.r8 11
-			IL_1316: ldc.i4.1
-			IL_1317: box [System.Runtime]System.Boolean
-			IL_131c: ldc.i4.1
-			IL_131d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_1322: pop
+			IL_1294: stloc.s 5
+			IL_1296: ldloc.s 5
+			IL_1298: ldc.r8 3
+			IL_12a1: ldc.i4.1
+			IL_12a2: box [System.Runtime]System.Boolean
+			IL_12a7: ldc.i4.1
+			IL_12a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_12ad: pop
 
-			IL_1323: ldarg.0
-			IL_1324: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1329: volatile.
-			IL_132b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_1330: brfalse IL_1344
+			IL_12ae: ldarg.0
+			IL_12af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_12b4: volatile.
+			IL_12b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_12bb: brfalse IL_12cf
 
-			IL_1335: ldstr "Line"
-			IL_133a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_133f: br IL_1358
+			IL_12c0: ldstr "Line"
+			IL_12c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_12ca: br IL_12e3
 
-			IL_1344: ldstr "Line"
-			IL_1349: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:528"
-			IL_134e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_1353: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_12cf: ldstr "Line"
+			IL_12d4: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:535"
+			IL_12d9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_12de: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1358: stloc.s 8
-			IL_135a: ldloc.s 8
-			IL_135c: ldc.r8 3
-			IL_1365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_136a: stloc.s 8
-			IL_136c: ldloc.s 8
-			IL_136e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1373: ldc.i4.0
-			IL_1374: ceq
-			IL_1376: stloc.s 7
-			IL_1378: ldloc.s 7
-			IL_137a: brfalse IL_1424
+			IL_12e3: stloc.s 5
+			IL_12e5: ldloc.s 5
+			IL_12e7: ldc.r8 10
+			IL_12f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_12f5: stloc.s 5
+			IL_12f7: ldloc.s 5
+			IL_12f9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_12fe: ldc.i4.0
+			IL_12ff: ceq
+			IL_1301: stloc.s 7
+			IL_1303: ldloc.s 7
+			IL_1305: brfalse IL_139c
 
-			IL_137f: ldarg.0
-			IL_1380: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1385: stloc.s 8
-			IL_1387: ldc.i4.1
-			IL_1388: newarr [System.Runtime]System.Object
-			IL_138d: dup
-			IL_138e: ldc.i4.0
-			IL_138f: ldarg.0
-			IL_1390: stelem.ref
-			IL_1391: stloc.s 5
-			IL_1393: ldarg.0
-			IL_1394: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1399: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_139e: ldc.r8 0.0
-			IL_13a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_13ac: stloc.2
-			IL_13ad: ldarg.0
-			IL_13ae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_13b3: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_13b8: ldc.r8 3
-			IL_13c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_13c6: stloc.s 6
-			IL_13c8: ldloc.s 8
-			IL_13ca: ldloc.s 5
-			IL_13cc: ldloc.2
-			IL_13cd: ldloc.s 6
-			IL_13cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_13d4: pop
-			IL_13d5: ldarg.0
-			IL_13d6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_13db: volatile.
-			IL_13dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_13e2: brfalse IL_13f6
+			IL_130a: ldarg.0
+			IL_130b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1310: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1315: ldc.r8 3
+			IL_131e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1323: stloc.s 5
+			IL_1325: ldarg.0
+			IL_1326: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_132b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1330: ldc.r8 7
+			IL_1339: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_133e: stloc.2
+			IL_133f: ldarg.0
+			IL_1340: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_1345: ldnull
+			IL_1346: ldloc.s 5
+			IL_1348: ldloc.2
+			IL_1349: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_134e: pop
+			IL_134f: ldarg.0
+			IL_1350: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1355: volatile.
+			IL_1357: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_135c: brfalse IL_1370
 
-			IL_13e7: ldstr "Line"
-			IL_13ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_13f1: br IL_140a
+			IL_1361: ldstr "Line"
+			IL_1366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_136b: br IL_1384
 
-			IL_13f6: ldstr "Line"
-			IL_13fb: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:546"
-			IL_1400: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_1405: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1370: ldstr "Line"
+			IL_1375: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:552"
+			IL_137a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_137f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_140a: stloc.s 6
-			IL_140c: ldloc.s 6
-			IL_140e: ldc.r8 3
-			IL_1417: ldc.i4.1
-			IL_1418: box [System.Runtime]System.Boolean
-			IL_141d: ldc.i4.1
-			IL_141e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_1423: pop
+			IL_1384: stloc.2
+			IL_1385: ldloc.2
+			IL_1386: ldc.r8 10
+			IL_138f: ldc.i4.1
+			IL_1390: box [System.Runtime]System.Boolean
+			IL_1395: ldc.i4.1
+			IL_1396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_139b: pop
 
-			IL_1424: ldarg.0
-			IL_1425: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_142a: volatile.
-			IL_142c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_1431: brfalse IL_1445
+			IL_139c: ldarg.0
+			IL_139d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_13a2: volatile.
+			IL_13a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_13a9: brfalse IL_13bd
 
-			IL_1436: ldstr "Line"
-			IL_143b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1440: br IL_1459
+			IL_13ae: ldstr "Line"
+			IL_13b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_13b8: br IL_13d1
 
-			IL_1445: ldstr "Line"
-			IL_144a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:554"
-			IL_144f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_1454: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_13bd: ldstr "Line"
+			IL_13c2: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:560"
+			IL_13c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_13cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1459: stloc.s 6
-			IL_145b: ldloc.s 6
-			IL_145d: ldc.r8 10
-			IL_1466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_146b: stloc.s 6
-			IL_146d: ldloc.s 6
-			IL_146f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1474: ldc.i4.0
-			IL_1475: ceq
-			IL_1477: stloc.s 7
-			IL_1479: ldloc.s 7
-			IL_147b: brfalse IL_1525
+			IL_13d1: stloc.2
+			IL_13d2: ldloc.2
+			IL_13d3: ldc.r8 7
+			IL_13dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_13e1: stloc.2
+			IL_13e2: ldloc.2
+			IL_13e3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_13e8: ldc.i4.0
+			IL_13e9: ceq
+			IL_13eb: stloc.s 7
+			IL_13ed: ldloc.s 7
+			IL_13ef: brfalse IL_1488
 
-			IL_1480: ldarg.0
-			IL_1481: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1486: stloc.s 6
-			IL_1488: ldc.i4.1
-			IL_1489: newarr [System.Runtime]System.Object
-			IL_148e: dup
-			IL_148f: ldc.i4.0
-			IL_1490: ldarg.0
-			IL_1491: stelem.ref
-			IL_1492: stloc.s 5
-			IL_1494: ldarg.0
-			IL_1495: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_149a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_149f: ldc.r8 3
-			IL_14a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_14ad: stloc.2
-			IL_14ae: ldarg.0
-			IL_14af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_14b4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_14b9: ldc.r8 7
-			IL_14c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_14c7: stloc.s 8
-			IL_14c9: ldloc.s 6
-			IL_14cb: ldloc.s 5
-			IL_14cd: ldloc.2
-			IL_14ce: ldloc.s 8
-			IL_14d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_14d5: pop
-			IL_14d6: ldarg.0
-			IL_14d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_14dc: volatile.
-			IL_14de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_14e3: brfalse IL_14f7
+			IL_13f4: ldarg.0
+			IL_13f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_13fa: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_13ff: ldc.r8 7
+			IL_1408: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_140d: stloc.2
+			IL_140e: ldarg.0
+			IL_140f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1414: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1419: ldc.r8 4
+			IL_1422: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1427: stloc.s 5
+			IL_1429: ldarg.0
+			IL_142a: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_142f: ldnull
+			IL_1430: ldloc.2
+			IL_1431: ldloc.s 5
+			IL_1433: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_1438: pop
+			IL_1439: ldarg.0
+			IL_143a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_143f: volatile.
+			IL_1441: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_1446: brfalse IL_145a
 
-			IL_14e8: ldstr "Line"
-			IL_14ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_14f2: br IL_150b
+			IL_144b: ldstr "Line"
+			IL_1450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1455: br IL_146e
 
-			IL_14f7: ldstr "Line"
-			IL_14fc: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:572"
-			IL_1501: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_1506: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_145a: ldstr "Line"
+			IL_145f: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:577"
+			IL_1464: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_1469: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_150b: stloc.s 8
-			IL_150d: ldloc.s 8
-			IL_150f: ldc.r8 10
-			IL_1518: ldc.i4.1
-			IL_1519: box [System.Runtime]System.Boolean
-			IL_151e: ldc.i4.1
-			IL_151f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_1524: pop
+			IL_146e: stloc.s 5
+			IL_1470: ldloc.s 5
+			IL_1472: ldc.r8 7
+			IL_147b: ldc.i4.1
+			IL_147c: box [System.Runtime]System.Boolean
+			IL_1481: ldc.i4.1
+			IL_1482: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_1487: pop
+
+			IL_1488: ldloc.0
+			IL_1489: ldc.r8 5
+			IL_1492: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1497: stloc.s 5
+			IL_1499: ldloc.s 5
+			IL_149b: ldc.r8 2
+			IL_14a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_14a9: stloc.s 5
+			IL_14ab: ldloc.s 5
+			IL_14ad: ldc.r8 0.0
+			IL_14b6: box [System.Runtime]System.Double
+			IL_14bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_14c0: stloc.s 7
+			IL_14c2: ldloc.s 7
+			IL_14c4: brfalse IL_187d
+
+			IL_14c9: ldarg.0
+			IL_14ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_14cf: volatile.
+			IL_14d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_14d6: brfalse IL_14ea
+
+			IL_14db: ldstr "Line"
+			IL_14e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_14e5: br IL_14fe
+
+			IL_14ea: ldstr "Line"
+			IL_14ef: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:595"
+			IL_14f4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_14f9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_14fe: stloc.s 5
+			IL_1500: ldloc.s 5
+			IL_1502: ldc.r8 8
+			IL_150b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1510: stloc.s 5
+			IL_1512: ldloc.s 5
+			IL_1514: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_1519: ldc.i4.0
+			IL_151a: ceq
+			IL_151c: stloc.s 7
+			IL_151e: ldloc.s 7
+			IL_1520: brfalse IL_15b7
 
 			IL_1525: ldarg.0
 			IL_1526: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_152b: volatile.
-			IL_152d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_1532: brfalse IL_1546
+			IL_152b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1530: ldc.r8 1
+			IL_1539: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_153e: stloc.s 5
+			IL_1540: ldarg.0
+			IL_1541: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1546: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_154b: ldc.r8 5
+			IL_1554: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1559: stloc.2
+			IL_155a: ldarg.0
+			IL_155b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_1560: ldnull
+			IL_1561: ldloc.s 5
+			IL_1563: ldloc.2
+			IL_1564: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_1569: pop
+			IL_156a: ldarg.0
+			IL_156b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1570: volatile.
+			IL_1572: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_1577: brfalse IL_158b
 
-			IL_1537: ldstr "Line"
-			IL_153c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1541: br IL_155a
+			IL_157c: ldstr "Line"
+			IL_1581: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1586: br IL_159f
 
-			IL_1546: ldstr "Line"
-			IL_154b: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:580"
-			IL_1550: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_1555: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_158b: ldstr "Line"
+			IL_1590: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:612"
+			IL_1595: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_159a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_155a: stloc.s 8
-			IL_155c: ldloc.s 8
-			IL_155e: ldc.r8 7
-			IL_1567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_156c: stloc.s 8
-			IL_156e: ldloc.s 8
-			IL_1570: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_1575: ldc.i4.0
-			IL_1576: ceq
-			IL_1578: stloc.s 7
-			IL_157a: ldloc.s 7
-			IL_157c: brfalse IL_1626
+			IL_159f: stloc.2
+			IL_15a0: ldloc.2
+			IL_15a1: ldc.r8 8
+			IL_15aa: ldc.i4.1
+			IL_15ab: box [System.Runtime]System.Boolean
+			IL_15b0: ldc.i4.1
+			IL_15b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_15b6: pop
 
-			IL_1581: ldarg.0
-			IL_1582: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_1587: stloc.s 8
-			IL_1589: ldc.i4.1
-			IL_158a: newarr [System.Runtime]System.Object
-			IL_158f: dup
-			IL_1590: ldc.i4.0
-			IL_1591: ldarg.0
-			IL_1592: stelem.ref
-			IL_1593: stloc.s 5
-			IL_1595: ldarg.0
-			IL_1596: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_159b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_15a0: ldc.r8 7
-			IL_15a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_15ae: stloc.2
-			IL_15af: ldarg.0
-			IL_15b0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_15b5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_15ba: ldc.r8 4
-			IL_15c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_15c8: stloc.s 6
-			IL_15ca: ldloc.s 8
-			IL_15cc: ldloc.s 5
-			IL_15ce: ldloc.2
-			IL_15cf: ldloc.s 6
-			IL_15d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_15d6: pop
-			IL_15d7: ldarg.0
-			IL_15d8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_15dd: volatile.
-			IL_15df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_15e4: brfalse IL_15f8
+			IL_15b7: ldarg.0
+			IL_15b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_15bd: volatile.
+			IL_15bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_15c4: brfalse IL_15d8
 
-			IL_15e9: ldstr "Line"
-			IL_15ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_15f3: br IL_160c
+			IL_15c9: ldstr "Line"
+			IL_15ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_15d3: br IL_15ec
 
-			IL_15f8: ldstr "Line"
-			IL_15fd: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:598"
-			IL_1602: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_1607: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_15d8: ldstr "Line"
+			IL_15dd: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:620"
+			IL_15e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_15e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_160c: stloc.s 6
-			IL_160e: ldloc.s 6
-			IL_1610: ldc.r8 7
-			IL_1619: ldc.i4.1
-			IL_161a: box [System.Runtime]System.Boolean
-			IL_161f: ldc.i4.1
-			IL_1620: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_1625: pop
+			IL_15ec: stloc.2
+			IL_15ed: ldloc.2
+			IL_15ee: ldc.r8 5
+			IL_15f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_15fc: stloc.2
+			IL_15fd: ldloc.2
+			IL_15fe: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_1603: ldc.i4.0
+			IL_1604: ceq
+			IL_1606: stloc.s 7
+			IL_1608: ldloc.s 7
+			IL_160a: brfalse IL_16a3
 
-			IL_1626: ldloc.0
-			IL_1627: ldc.r8 5
-			IL_1630: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1635: stloc.s 6
-			IL_1637: ldloc.s 6
-			IL_1639: ldc.r8 2
-			IL_1642: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1647: stloc.s 6
-			IL_1649: ldloc.s 6
-			IL_164b: ldc.r8 0.0
-			IL_1654: box [System.Runtime]System.Double
-			IL_1659: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_165e: stloc.s 7
-			IL_1660: ldloc.s 7
-			IL_1662: brfalse IL_1a6b
+			IL_160f: ldarg.0
+			IL_1610: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1615: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_161a: ldc.r8 5
+			IL_1623: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1628: stloc.2
+			IL_1629: ldarg.0
+			IL_162a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_162f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1634: ldc.r8 6
+			IL_163d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1642: stloc.s 5
+			IL_1644: ldarg.0
+			IL_1645: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_164a: ldnull
+			IL_164b: ldloc.2
+			IL_164c: ldloc.s 5
+			IL_164e: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_1653: pop
+			IL_1654: ldarg.0
+			IL_1655: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_165a: volatile.
+			IL_165c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_1661: brfalse IL_1675
 
-			IL_1667: ldarg.0
-			IL_1668: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_166d: volatile.
-			IL_166f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_1674: brfalse IL_1688
+			IL_1666: ldstr "Line"
+			IL_166b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1670: br IL_1689
 
-			IL_1679: ldstr "Line"
-			IL_167e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1683: br IL_169c
+			IL_1675: ldstr "Line"
+			IL_167a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:637"
+			IL_167f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_1684: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1688: ldstr "Line"
-			IL_168d: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:616"
-			IL_1692: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_1697: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1689: stloc.s 5
+			IL_168b: ldloc.s 5
+			IL_168d: ldc.r8 5
+			IL_1696: ldc.i4.1
+			IL_1697: box [System.Runtime]System.Boolean
+			IL_169c: ldc.i4.1
+			IL_169d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_16a2: pop
 
-			IL_169c: stloc.s 6
-			IL_169e: ldloc.s 6
-			IL_16a0: ldc.r8 8
-			IL_16a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_16ae: stloc.s 6
-			IL_16b0: ldloc.s 6
-			IL_16b2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_16b7: ldc.i4.0
-			IL_16b8: ceq
-			IL_16ba: stloc.s 7
-			IL_16bc: ldloc.s 7
-			IL_16be: brfalse IL_1768
+			IL_16a3: ldarg.0
+			IL_16a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_16a9: volatile.
+			IL_16ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_16b0: brfalse IL_16c4
 
-			IL_16c3: ldarg.0
-			IL_16c4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_16c9: stloc.s 6
-			IL_16cb: ldc.i4.1
-			IL_16cc: newarr [System.Runtime]System.Object
-			IL_16d1: dup
-			IL_16d2: ldc.i4.0
-			IL_16d3: ldarg.0
-			IL_16d4: stelem.ref
-			IL_16d5: stloc.s 5
-			IL_16d7: ldarg.0
-			IL_16d8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_16dd: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_16e2: ldc.r8 1
-			IL_16eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_16f0: stloc.2
-			IL_16f1: ldarg.0
-			IL_16f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_16f7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_16fc: ldc.r8 5
-			IL_1705: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_170a: stloc.s 8
-			IL_170c: ldloc.s 6
-			IL_170e: ldloc.s 5
-			IL_1710: ldloc.2
-			IL_1711: ldloc.s 8
-			IL_1713: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1718: pop
-			IL_1719: ldarg.0
-			IL_171a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_171f: volatile.
-			IL_1721: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_1726: brfalse IL_173a
+			IL_16b5: ldstr "Line"
+			IL_16ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_16bf: br IL_16d8
 
-			IL_172b: ldstr "Line"
-			IL_1730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1735: br IL_174e
+			IL_16c4: ldstr "Line"
+			IL_16c9: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:645"
+			IL_16ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_16d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_173a: ldstr "Line"
-			IL_173f: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:634"
-			IL_1744: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_1749: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_16d8: stloc.s 5
+			IL_16da: ldloc.s 5
+			IL_16dc: ldc.r8 9
+			IL_16e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_16ea: stloc.s 5
+			IL_16ec: ldloc.s 5
+			IL_16ee: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_16f3: ldc.i4.0
+			IL_16f4: ceq
+			IL_16f6: stloc.s 7
+			IL_16f8: ldloc.s 7
+			IL_16fa: brfalse IL_1791
 
-			IL_174e: stloc.s 8
-			IL_1750: ldloc.s 8
-			IL_1752: ldc.r8 8
-			IL_175b: ldc.i4.1
-			IL_175c: box [System.Runtime]System.Boolean
-			IL_1761: ldc.i4.1
-			IL_1762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_1767: pop
+			IL_16ff: ldarg.0
+			IL_1700: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1705: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_170a: ldc.r8 6
+			IL_1713: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1718: stloc.s 5
+			IL_171a: ldarg.0
+			IL_171b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1720: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_1725: ldc.r8 2
+			IL_172e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1733: stloc.2
+			IL_1734: ldarg.0
+			IL_1735: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_173a: ldnull
+			IL_173b: ldloc.s 5
+			IL_173d: ldloc.2
+			IL_173e: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_1743: pop
+			IL_1744: ldarg.0
+			IL_1745: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_174a: volatile.
+			IL_174c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_1751: brfalse IL_1765
 
-			IL_1768: ldarg.0
-			IL_1769: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_176e: volatile.
-			IL_1770: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-			IL_1775: brfalse IL_1789
+			IL_1756: ldstr "Line"
+			IL_175b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1760: br IL_1779
 
-			IL_177a: ldstr "Line"
-			IL_177f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1784: br IL_179d
+			IL_1765: ldstr "Line"
+			IL_176a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:662"
+			IL_176f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_1774: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_1789: ldstr "Line"
-			IL_178e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:642"
-			IL_1793: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-			IL_1798: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1779: stloc.2
+			IL_177a: ldloc.2
+			IL_177b: ldc.r8 9
+			IL_1784: ldc.i4.1
+			IL_1785: box [System.Runtime]System.Boolean
+			IL_178a: ldc.i4.1
+			IL_178b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_1790: pop
 
-			IL_179d: stloc.s 8
-			IL_179f: ldloc.s 8
-			IL_17a1: ldc.r8 5
-			IL_17aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_17af: stloc.s 8
-			IL_17b1: ldloc.s 8
-			IL_17b3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_17b8: ldc.i4.0
-			IL_17b9: ceq
-			IL_17bb: stloc.s 7
-			IL_17bd: ldloc.s 7
-			IL_17bf: brfalse IL_1869
+			IL_1791: ldarg.0
+			IL_1792: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1797: volatile.
+			IL_1799: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_179e: brfalse IL_17b2
 
-			IL_17c4: ldarg.0
-			IL_17c5: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_17ca: stloc.s 8
-			IL_17cc: ldc.i4.1
-			IL_17cd: newarr [System.Runtime]System.Object
-			IL_17d2: dup
-			IL_17d3: ldc.i4.0
-			IL_17d4: ldarg.0
-			IL_17d5: stelem.ref
-			IL_17d6: stloc.s 5
-			IL_17d8: ldarg.0
-			IL_17d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_17de: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_17e3: ldc.r8 5
-			IL_17ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_17f1: stloc.2
-			IL_17f2: ldarg.0
-			IL_17f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_17f8: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_17fd: ldc.r8 6
-			IL_1806: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_180b: stloc.s 6
-			IL_180d: ldloc.s 8
-			IL_180f: ldloc.s 5
-			IL_1811: ldloc.2
-			IL_1812: ldloc.s 6
-			IL_1814: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1819: pop
-			IL_181a: ldarg.0
-			IL_181b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1820: volatile.
-			IL_1822: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-			IL_1827: brfalse IL_183b
+			IL_17a3: ldstr "Line"
+			IL_17a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_17ad: br IL_17c6
 
-			IL_182c: ldstr "Line"
-			IL_1831: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1836: br IL_184f
+			IL_17b2: ldstr "Line"
+			IL_17b7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:670"
+			IL_17bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_17c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_183b: ldstr "Line"
-			IL_1840: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:660"
-			IL_1845: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-			IL_184a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_17c6: stloc.2
+			IL_17c7: ldloc.2
+			IL_17c8: ldc.r8 1
+			IL_17d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_17d6: stloc.2
+			IL_17d7: ldloc.2
+			IL_17d8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_17dd: ldc.i4.0
+			IL_17de: ceq
+			IL_17e0: stloc.s 7
+			IL_17e2: ldloc.s 7
+			IL_17e4: brfalse IL_187d
 
-			IL_184f: stloc.s 6
-			IL_1851: ldloc.s 6
-			IL_1853: ldc.r8 5
-			IL_185c: ldc.i4.1
-			IL_185d: box [System.Runtime]System.Boolean
-			IL_1862: ldc.i4.1
-			IL_1863: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_1868: pop
+			IL_17e9: ldarg.0
+			IL_17ea: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_17ef: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_17f4: ldc.r8 2
+			IL_17fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1802: stloc.2
+			IL_1803: ldarg.0
+			IL_1804: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1809: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_180e: ldc.r8 1
+			IL_1817: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_181c: stloc.s 5
+			IL_181e: ldarg.0
+			IL_181f: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_1824: ldnull
+			IL_1825: ldloc.2
+			IL_1826: ldloc.s 5
+			IL_1828: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+			IL_182d: pop
+			IL_182e: ldarg.0
+			IL_182f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1834: volatile.
+			IL_1836: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_183b: brfalse IL_184f
 
-			IL_1869: ldarg.0
-			IL_186a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_186f: volatile.
-			IL_1871: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-			IL_1876: brfalse IL_188a
+			IL_1840: ldstr "Line"
+			IL_1845: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_184a: br IL_1863
 
-			IL_187b: ldstr "Line"
-			IL_1880: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1885: br IL_189e
+			IL_184f: ldstr "Line"
+			IL_1854: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:687"
+			IL_1859: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_185e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_188a: ldstr "Line"
-			IL_188f: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:668"
-			IL_1894: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-			IL_1899: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_1863: stloc.s 5
+			IL_1865: ldloc.s 5
+			IL_1867: ldc.r8 1
+			IL_1870: ldc.i4.1
+			IL_1871: box [System.Runtime]System.Boolean
+			IL_1876: ldc.i4.1
+			IL_1877: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_187c: pop
 
-			IL_189e: stloc.s 6
-			IL_18a0: ldloc.s 6
-			IL_18a2: ldc.r8 9
-			IL_18ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_18b0: stloc.s 6
-			IL_18b2: ldloc.s 6
-			IL_18b4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_18b9: ldc.i4.0
-			IL_18ba: ceq
-			IL_18bc: stloc.s 7
-			IL_18be: ldloc.s 7
-			IL_18c0: brfalse IL_196a
-
-			IL_18c5: ldarg.0
-			IL_18c6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_18cb: stloc.s 6
-			IL_18cd: ldc.i4.1
-			IL_18ce: newarr [System.Runtime]System.Object
-			IL_18d3: dup
-			IL_18d4: ldc.i4.0
-			IL_18d5: ldarg.0
-			IL_18d6: stelem.ref
-			IL_18d7: stloc.s 5
-			IL_18d9: ldarg.0
-			IL_18da: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_18df: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_18e4: ldc.r8 6
-			IL_18ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_18f2: stloc.2
-			IL_18f3: ldarg.0
-			IL_18f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_18f9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_18fe: ldc.r8 2
-			IL_1907: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_190c: stloc.s 8
-			IL_190e: ldloc.s 6
-			IL_1910: ldloc.s 5
-			IL_1912: ldloc.2
-			IL_1913: ldloc.s 8
-			IL_1915: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_191a: pop
-			IL_191b: ldarg.0
-			IL_191c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1921: volatile.
-			IL_1923: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-			IL_1928: brfalse IL_193c
-
-			IL_192d: ldstr "Line"
-			IL_1932: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1937: br IL_1950
-
-			IL_193c: ldstr "Line"
-			IL_1941: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:686"
-			IL_1946: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-			IL_194b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1950: stloc.s 8
-			IL_1952: ldloc.s 8
-			IL_1954: ldc.r8 9
-			IL_195d: ldc.i4.1
-			IL_195e: box [System.Runtime]System.Boolean
-			IL_1963: ldc.i4.1
-			IL_1964: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_1969: pop
-
-			IL_196a: ldarg.0
-			IL_196b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1970: volatile.
-			IL_1972: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_1977: brfalse IL_198b
-
-			IL_197c: ldstr "Line"
-			IL_1981: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1986: br IL_199f
-
-			IL_198b: ldstr "Line"
-			IL_1990: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:694"
-			IL_1995: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_199a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_199f: stloc.s 8
-			IL_19a1: ldloc.s 8
-			IL_19a3: ldc.r8 1
-			IL_19ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_19b1: stloc.s 8
-			IL_19b3: ldloc.s 8
-			IL_19b5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_19ba: ldc.i4.0
-			IL_19bb: ceq
-			IL_19bd: stloc.s 7
-			IL_19bf: ldloc.s 7
-			IL_19c1: brfalse IL_1a6b
-
-			IL_19c6: ldarg.0
-			IL_19c7: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
-			IL_19cc: stloc.s 8
-			IL_19ce: ldc.i4.1
-			IL_19cf: newarr [System.Runtime]System.Object
-			IL_19d4: dup
-			IL_19d5: ldc.i4.0
-			IL_19d6: ldarg.0
-			IL_19d7: stelem.ref
-			IL_19d8: stloc.s 5
-			IL_19da: ldarg.0
-			IL_19db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_19e0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_19e5: ldc.r8 2
-			IL_19ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_19f3: stloc.2
-			IL_19f4: ldarg.0
-			IL_19f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_19fa: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_19ff: ldc.r8 1
-			IL_1a08: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1a0d: stloc.s 6
-			IL_1a0f: ldloc.s 8
-			IL_1a11: ldloc.s 5
-			IL_1a13: ldloc.2
-			IL_1a14: ldloc.s 6
-			IL_1a16: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_1a1b: pop
-			IL_1a1c: ldarg.0
-			IL_1a1d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1a22: volatile.
-			IL_1a24: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_1a29: brfalse IL_1a3d
-
-			IL_1a2e: ldstr "Line"
-			IL_1a33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1a38: br IL_1a51
-
-			IL_1a3d: ldstr "Line"
-			IL_1a42: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M20>:__js_call__:712"
-			IL_1a47: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_1a4c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_1a51: stloc.s 6
-			IL_1a53: ldloc.s 6
-			IL_1a55: ldc.r8 1
-			IL_1a5e: ldc.i4.1
-			IL_1a5f: box [System.Runtime]System.Boolean
-			IL_1a64: ldc.i4.1
-			IL_1a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_1a6a: pop
-
-			IL_1a6b: ldarg.0
-			IL_1a6c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1a71: stloc.s 6
-			IL_1a73: ldc.i4.s 12
-			IL_1a75: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_1a7a: dup
-			IL_1a7b: ldc.i4.0
-			IL_1a7c: box [System.Runtime]System.Boolean
-			IL_1a81: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1a86: dup
-			IL_1a87: ldc.i4.0
-			IL_1a88: box [System.Runtime]System.Boolean
-			IL_1a8d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1a92: dup
-			IL_1a93: ldc.i4.0
-			IL_1a94: box [System.Runtime]System.Boolean
-			IL_1a99: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1a9e: dup
-			IL_1a9f: ldc.i4.0
-			IL_1aa0: box [System.Runtime]System.Boolean
-			IL_1aa5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1aaa: dup
-			IL_1aab: ldc.i4.0
-			IL_1aac: box [System.Runtime]System.Boolean
-			IL_1ab1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1ab6: dup
-			IL_1ab7: ldc.i4.0
-			IL_1ab8: box [System.Runtime]System.Boolean
-			IL_1abd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1ac2: dup
-			IL_1ac3: ldc.i4.0
-			IL_1ac4: box [System.Runtime]System.Boolean
-			IL_1ac9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1ace: dup
-			IL_1acf: ldc.i4.0
-			IL_1ad0: box [System.Runtime]System.Boolean
-			IL_1ad5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1ada: dup
-			IL_1adb: ldc.i4.0
-			IL_1adc: box [System.Runtime]System.Boolean
-			IL_1ae1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1ae6: dup
-			IL_1ae7: ldc.i4.0
-			IL_1ae8: box [System.Runtime]System.Boolean
-			IL_1aed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1af2: dup
-			IL_1af3: ldc.i4.0
-			IL_1af4: box [System.Runtime]System.Boolean
-			IL_1af9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1afe: dup
-			IL_1aff: ldc.i4.0
-			IL_1b00: box [System.Runtime]System.Boolean
-			IL_1b05: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1b0a: stloc.s 9
-			IL_1b0c: ldloc.s 6
-			IL_1b0e: ldstr "Line"
-			IL_1b13: ldloc.s 9
-			IL_1b15: ldc.i4.1
-			IL_1b16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_1b1b: pop
-			IL_1b1c: ldarg.0
-			IL_1b1d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1b22: stloc.s 6
-			IL_1b24: ldloc.s 6
-			IL_1b26: ldstr "LastPx"
-			IL_1b2b: ldc.r8 0.0
-			IL_1b34: ldc.i4.1
-			IL_1b35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_1b3a: pop
-			IL_1b3b: ldnull
-			IL_1b3c: ret
+			IL_187d: ldarg.0
+			IL_187e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1883: stloc.s 5
+			IL_1885: ldc.i4.s 12
+			IL_1887: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_188c: dup
+			IL_188d: ldc.i4.0
+			IL_188e: box [System.Runtime]System.Boolean
+			IL_1893: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1898: dup
+			IL_1899: ldc.i4.0
+			IL_189a: box [System.Runtime]System.Boolean
+			IL_189f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_18a4: dup
+			IL_18a5: ldc.i4.0
+			IL_18a6: box [System.Runtime]System.Boolean
+			IL_18ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_18b0: dup
+			IL_18b1: ldc.i4.0
+			IL_18b2: box [System.Runtime]System.Boolean
+			IL_18b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_18bc: dup
+			IL_18bd: ldc.i4.0
+			IL_18be: box [System.Runtime]System.Boolean
+			IL_18c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_18c8: dup
+			IL_18c9: ldc.i4.0
+			IL_18ca: box [System.Runtime]System.Boolean
+			IL_18cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_18d4: dup
+			IL_18d5: ldc.i4.0
+			IL_18d6: box [System.Runtime]System.Boolean
+			IL_18db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_18e0: dup
+			IL_18e1: ldc.i4.0
+			IL_18e2: box [System.Runtime]System.Boolean
+			IL_18e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_18ec: dup
+			IL_18ed: ldc.i4.0
+			IL_18ee: box [System.Runtime]System.Boolean
+			IL_18f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_18f8: dup
+			IL_18f9: ldc.i4.0
+			IL_18fa: box [System.Runtime]System.Boolean
+			IL_18ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1904: dup
+			IL_1905: ldc.i4.0
+			IL_1906: box [System.Runtime]System.Boolean
+			IL_190b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1910: dup
+			IL_1911: ldc.i4.0
+			IL_1912: box [System.Runtime]System.Boolean
+			IL_1917: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_191c: stloc.s 6
+			IL_191e: ldloc.s 5
+			IL_1920: ldstr "Line"
+			IL_1925: ldloc.s 6
+			IL_1927: ldc.i4.1
+			IL_1928: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_192d: pop
+			IL_192e: ldarg.0
+			IL_192f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1934: stloc.s 5
+			IL_1936: ldloc.s 5
+			IL_1938: ldstr "LastPx"
+			IL_193d: ldc.r8 0.0
+			IL_1946: ldc.i4.1
+			IL_1947: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_194c: pop
+			IL_194d: ldnull
+			IL_194e: ret
 		} // end of method DrawQube::__js_call__
 
 	} // end of class DrawQube
@@ -7496,7 +7262,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1478 (0x5c6)
+			// Code size: 1354 (0x54a)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -7505,10 +7271,10 @@
 				[3] object,
 				[4] bool,
 				[5] string,
-				[6] object[],
+				[6] object,
 				[7] object,
 				[8] object,
-				[9] object,
+				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[10] object,
 				[11] object,
 				[12] float64,
@@ -7594,415 +7360,347 @@
 			// end loop
 
 			IL_00e7: ldarg.0
-			IL_00e8: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
-			IL_00ed: ldc.i4.1
-			IL_00ee: newarr [System.Runtime]System.Object
-			IL_00f3: dup
-			IL_00f4: ldc.i4.0
-			IL_00f5: ldarg.0
-			IL_00f6: stelem.ref
-			IL_00f7: stloc.s 6
-			IL_00f9: ldarg.0
-			IL_00fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::I
-			IL_00ff: stloc.3
-			IL_0100: ldarg.0
-			IL_0101: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0106: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_010b: ldc.r8 8
-			IL_0114: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0119: volatile.
-			IL_011b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0120: brfalse IL_0134
+			IL_00e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::I
+			IL_00ed: stloc.3
+			IL_00ee: ldarg.0
+			IL_00ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_00f4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00f9: ldc.r8 8
+			IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0107: volatile.
+			IL_0109: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_010e: brfalse IL_0122
 
-			IL_0125: ldstr "V"
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_012f: br IL_0148
+			IL_0113: ldstr "V"
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_011d: br IL_0136
 
-			IL_0134: ldstr "V"
-			IL_0139: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:40"
-			IL_013e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0122: ldstr "V"
+			IL_0127: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:38"
+			IL_012c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0148: stloc.2
-			IL_0149: ldloc.2
-			IL_014a: ldc.r8 0.0
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0158: stloc.2
-			IL_0159: ldloc.2
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_015f: stloc.s 7
-			IL_0161: ldarg.0
-			IL_0162: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0167: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_016c: ldc.r8 8
-			IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_017a: volatile.
-			IL_017c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
-			IL_0181: brfalse IL_0195
+			IL_0136: stloc.2
+			IL_0137: ldloc.2
+			IL_0138: ldc.r8 0.0
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0146: stloc.2
+			IL_0147: ldloc.2
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+			IL_014d: stloc.s 6
+			IL_014f: ldarg.0
+			IL_0150: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0155: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_015a: ldc.r8 8
+			IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0168: volatile.
+			IL_016a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_016f: brfalse IL_0183
 
-			IL_0186: ldstr "V"
-			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0190: br IL_01a9
+			IL_0174: ldstr "V"
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017e: br IL_0197
 
-			IL_0195: ldstr "V"
-			IL_019a: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:48"
-			IL_019f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
-			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0183: ldstr "V"
+			IL_0188: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:46"
+			IL_018d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01a9: stloc.2
-			IL_01aa: ldloc.2
-			IL_01ab: ldc.r8 1
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_01b9: stloc.2
-			IL_01ba: ldloc.2
-			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_01c0: stloc.s 8
-			IL_01c2: ldarg.0
-			IL_01c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01c8: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01cd: ldc.r8 8
-			IL_01d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01db: volatile.
-			IL_01dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
-			IL_01e2: brfalse IL_01f6
+			IL_0197: stloc.2
+			IL_0198: ldloc.2
+			IL_0199: ldc.r8 1
+			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01a7: stloc.2
+			IL_01a8: ldloc.2
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+			IL_01ae: stloc.s 7
+			IL_01b0: ldarg.0
+			IL_01b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_01b6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01bb: ldc.r8 8
+			IL_01c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01c9: volatile.
+			IL_01cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+			IL_01d0: brfalse IL_01e4
 
-			IL_01e7: ldstr "V"
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f1: br IL_020a
+			IL_01d5: ldstr "V"
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01df: br IL_01f8
 
-			IL_01f6: ldstr "V"
-			IL_01fb: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:56"
-			IL_0200: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01e4: ldstr "V"
+			IL_01e9: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:54"
+			IL_01ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_93
+			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_020a: stloc.2
-			IL_020b: ldloc.2
-			IL_020c: ldc.r8 2
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_021a: stloc.2
-			IL_021b: ldloc.2
-			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_0221: stloc.s 9
-			IL_0223: ldloc.s 6
-			IL_0225: ldloc.3
-			IL_0226: ldloc.s 7
-			IL_0228: ldloc.s 8
-			IL_022a: ldloc.s 9
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0231: stloc.3
-			IL_0232: ldarg.0
-			IL_0233: ldloc.3
-			IL_0234: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0239: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_023e: ldarg.0
-			IL_023f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateX
-			IL_0244: ldc.i4.1
-			IL_0245: newarr [System.Runtime]System.Object
-			IL_024a: dup
-			IL_024b: ldc.i4.0
-			IL_024c: ldarg.0
-			IL_024d: stelem.ref
-			IL_024e: stloc.s 6
-			IL_0250: ldarg.0
-			IL_0251: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0256: stloc.3
-			IL_0257: ldloc.s 6
-			IL_0259: ldloc.3
-			IL_025a: ldc.r8 1
-			IL_0263: box [System.Runtime]System.Double
-			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_026d: stloc.3
-			IL_026e: ldarg.0
-			IL_026f: ldloc.3
-			IL_0270: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0275: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_027a: ldarg.0
-			IL_027b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateY
-			IL_0280: ldc.i4.1
-			IL_0281: newarr [System.Runtime]System.Object
-			IL_0286: dup
-			IL_0287: ldc.i4.0
-			IL_0288: ldarg.0
-			IL_0289: stelem.ref
-			IL_028a: stloc.s 6
-			IL_028c: ldarg.0
-			IL_028d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0292: stloc.3
-			IL_0293: ldloc.s 6
-			IL_0295: ldloc.3
-			IL_0296: ldc.r8 3
-			IL_029f: box [System.Runtime]System.Double
-			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02a9: stloc.3
-			IL_02aa: ldarg.0
-			IL_02ab: ldloc.3
-			IL_02ac: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_02b1: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_02b6: ldarg.0
-			IL_02b7: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateZ
-			IL_02bc: ldc.i4.1
-			IL_02bd: newarr [System.Runtime]System.Object
-			IL_02c2: dup
-			IL_02c3: ldc.i4.0
-			IL_02c4: ldarg.0
-			IL_02c5: stelem.ref
-			IL_02c6: stloc.s 6
-			IL_02c8: ldarg.0
-			IL_02c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_02ce: stloc.3
-			IL_02cf: ldloc.s 6
-			IL_02d1: ldloc.3
-			IL_02d2: ldc.r8 5
-			IL_02db: box [System.Runtime]System.Double
-			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_02e5: stloc.3
-			IL_02e6: ldarg.0
-			IL_02e7: ldloc.3
-			IL_02e8: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_02ed: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_02f2: ldarg.0
-			IL_02f3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
-			IL_02f8: ldc.i4.1
-			IL_02f9: newarr [System.Runtime]System.Object
-			IL_02fe: dup
-			IL_02ff: ldc.i4.0
-			IL_0300: ldarg.0
-			IL_0301: stelem.ref
-			IL_0302: stloc.s 6
-			IL_0304: ldarg.0
-			IL_0305: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_030a: stloc.3
-			IL_030b: ldarg.0
-			IL_030c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0311: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0316: ldc.r8 8
-			IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0324: volatile.
-			IL_0326: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
-			IL_032b: brfalse IL_033f
+			IL_01f8: stloc.2
+			IL_01f9: ldloc.2
+			IL_01fa: ldc.r8 2
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0208: stloc.2
+			IL_0209: ldloc.2
+			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+			IL_020f: stloc.s 8
+			IL_0211: ldarg.0
+			IL_0212: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0217: ldnull
+			IL_0218: ldloc.3
+			IL_0219: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_021e: ldloc.s 6
+			IL_0220: ldloc.s 7
+			IL_0222: ldloc.s 8
+			IL_0224: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
+			IL_0229: stloc.s 9
+			IL_022b: ldarg.0
+			IL_022c: ldloc.s 9
+			IL_022e: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0233: ldarg.0
+			IL_0234: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0239: stloc.3
+			IL_023a: ldarg.0
+			IL_023b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0240: ldnull
+			IL_0241: ldloc.3
+			IL_0242: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0247: ldc.r8 1
+			IL_0250: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+			IL_0255: stloc.s 9
+			IL_0257: ldarg.0
+			IL_0258: ldloc.s 9
+			IL_025a: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_025f: ldarg.0
+			IL_0260: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0265: stloc.3
+			IL_0266: ldarg.0
+			IL_0267: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_026c: ldnull
+			IL_026d: ldloc.3
+			IL_026e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0273: ldc.r8 3
+			IL_027c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+			IL_0281: stloc.s 9
+			IL_0283: ldarg.0
+			IL_0284: ldloc.s 9
+			IL_0286: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_028b: ldarg.0
+			IL_028c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0291: stloc.3
+			IL_0292: ldarg.0
+			IL_0293: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0298: ldnull
+			IL_0299: ldloc.3
+			IL_029a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_029f: ldc.r8 5
+			IL_02a8: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+			IL_02ad: stloc.s 9
+			IL_02af: ldarg.0
+			IL_02b0: ldloc.s 9
+			IL_02b2: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_02b7: ldarg.0
+			IL_02b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_02bd: stloc.3
+			IL_02be: ldarg.0
+			IL_02bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02c4: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02c9: ldc.r8 8
+			IL_02d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_02d7: volatile.
+			IL_02d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+			IL_02de: brfalse IL_02f2
 
-			IL_0330: ldstr "V"
-			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_033a: br IL_0353
+			IL_02e3: ldstr "V"
+			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ed: br IL_0306
 
-			IL_033f: ldstr "V"
-			IL_0344: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:94"
-			IL_0349: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
-			IL_034e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02f2: ldstr "V"
+			IL_02f7: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:88"
+			IL_02fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_94
+			IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0353: stloc.2
-			IL_0354: ldloc.2
-			IL_0355: ldc.r8 0.0
-			IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0363: stloc.2
-			IL_0364: ldarg.0
-			IL_0365: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_036a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_036f: ldc.r8 8
-			IL_0378: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_037d: volatile.
-			IL_037f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
-			IL_0384: brfalse IL_0398
+			IL_0306: stloc.2
+			IL_0307: ldloc.2
+			IL_0308: ldc.r8 0.0
+			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0316: stloc.2
+			IL_0317: ldarg.0
+			IL_0318: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_031d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0322: ldc.r8 8
+			IL_032b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0330: volatile.
+			IL_0332: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+			IL_0337: brfalse IL_034b
 
-			IL_0389: ldstr "V"
-			IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0393: br IL_03ac
+			IL_033c: ldstr "V"
+			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0346: br IL_035f
+
+			IL_034b: ldstr "V"
+			IL_0350: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:95"
+			IL_0355: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
+			IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_035f: stloc.s 10
+			IL_0361: ldloc.s 10
+			IL_0363: ldc.r8 1
+			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0371: stloc.s 10
+			IL_0373: ldarg.0
+			IL_0374: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0379: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_037e: ldc.r8 8
+			IL_0387: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_038c: volatile.
+			IL_038e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
+			IL_0393: brfalse IL_03a7
 
 			IL_0398: ldstr "V"
-			IL_039d: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:101"
-			IL_03a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_95
-			IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a2: br IL_03bb
 
-			IL_03ac: stloc.s 10
-			IL_03ae: ldloc.s 10
-			IL_03b0: ldc.r8 1
-			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_03be: stloc.s 10
-			IL_03c0: ldarg.0
-			IL_03c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03c6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_03cb: ldc.r8 8
-			IL_03d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_03d9: volatile.
-			IL_03db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
-			IL_03e0: brfalse IL_03f4
+			IL_03a7: ldstr "V"
+			IL_03ac: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:102"
+			IL_03b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
+			IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03e5: ldstr "V"
-			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ef: br IL_0408
+			IL_03bb: stloc.s 11
+			IL_03bd: ldloc.s 11
+			IL_03bf: ldc.r8 2
+			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03cd: stloc.s 11
+			IL_03cf: ldarg.0
+			IL_03d0: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_03d5: ldnull
+			IL_03d6: ldloc.3
+			IL_03d7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_03dc: ldloc.2
+			IL_03dd: ldloc.s 10
+			IL_03df: ldloc.s 11
+			IL_03e1: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
+			IL_03e6: stloc.s 9
+			IL_03e8: ldarg.0
+			IL_03e9: ldloc.s 9
+			IL_03eb: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_03f0: ldarg.0
+			IL_03f1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_03f6: stloc.s 11
+			IL_03f8: ldarg.0
+			IL_03f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_03fe: stloc.s 10
+			IL_0400: ldnull
+			IL_0401: ldloc.s 11
+			IL_0403: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0408: ldloc.s 10
+			IL_040a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_040f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0414: stloc.s 9
+			IL_0416: ldarg.0
+			IL_0417: ldloc.s 9
+			IL_0419: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_041e: ldc.r8 8
+			IL_0427: stloc.1
+			// loop start (head: IL_0428)
+				IL_0428: ldloc.1
+				IL_0429: stloc.s 12
+				IL_042b: ldc.r8 1
+				IL_0434: neg
+				IL_0435: stloc.s 13
+				IL_0437: ldloc.s 12
+				IL_0439: ldloc.s 13
+				IL_043b: cgt
+				IL_043d: brfalse IL_04cf
 
-			IL_03f4: ldstr "V"
-			IL_03f9: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:108"
-			IL_03fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_96
-			IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0442: ldarg.0
+				IL_0443: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0448: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_044d: ldloc.1
+				IL_044e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0453: stloc.s 10
+				IL_0455: ldarg.0
+				IL_0456: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+				IL_045b: stloc.s 11
+				IL_045d: ldarg.0
+				IL_045e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0463: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0468: ldloc.1
+				IL_0469: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_046e: volatile.
+				IL_0470: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
+				IL_0475: brfalse IL_0489
 
-			IL_0408: stloc.s 11
-			IL_040a: ldloc.s 11
-			IL_040c: ldc.r8 2
-			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_041a: stloc.s 11
-			IL_041c: ldloc.s 6
-			IL_041e: ldloc.3
-			IL_041f: ldloc.2
-			IL_0420: ldloc.s 10
-			IL_0422: ldloc.s 11
-			IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0429: stloc.s 11
-			IL_042b: ldarg.0
-			IL_042c: ldloc.s 11
-			IL_042e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0433: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0438: ldarg.0
-			IL_0439: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
-			IL_043e: ldc.i4.1
-			IL_043f: newarr [System.Runtime]System.Object
-			IL_0444: dup
-			IL_0445: ldc.i4.0
-			IL_0446: ldarg.0
-			IL_0447: stelem.ref
-			IL_0448: stloc.s 6
-			IL_044a: ldarg.0
-			IL_044b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0450: stloc.s 11
-			IL_0452: ldarg.0
-			IL_0453: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0458: stloc.s 10
-			IL_045a: ldloc.s 6
-			IL_045c: ldloc.s 11
-			IL_045e: ldloc.s 10
-			IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0465: stloc.s 10
-			IL_0467: ldarg.0
-			IL_0468: ldloc.s 10
-			IL_046a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_046f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0474: ldc.r8 8
-			IL_047d: stloc.1
-			// loop start (head: IL_047e)
-				IL_047e: ldloc.1
-				IL_047f: stloc.s 12
-				IL_0481: ldc.r8 1
-				IL_048a: neg
-				IL_048b: stloc.s 13
-				IL_048d: ldloc.s 12
-				IL_048f: ldloc.s 13
-				IL_0491: cgt
-				IL_0493: brfalse IL_0531
+				IL_047a: ldstr "V"
+				IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0484: br IL_049d
 
-				IL_0498: ldarg.0
-				IL_0499: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_049e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_04a3: ldloc.1
-				IL_04a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_04a9: stloc.s 10
-				IL_04ab: ldarg.0
-				IL_04ac: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
-				IL_04b1: ldc.i4.1
-				IL_04b2: newarr [System.Runtime]System.Object
-				IL_04b7: dup
-				IL_04b8: ldc.i4.0
-				IL_04b9: ldarg.0
-				IL_04ba: stelem.ref
-				IL_04bb: stloc.s 6
-				IL_04bd: ldarg.0
-				IL_04be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-				IL_04c3: stloc.s 11
-				IL_04c5: ldarg.0
-				IL_04c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_04cb: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_04d0: ldloc.1
-				IL_04d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_04d6: volatile.
-				IL_04d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
-				IL_04dd: brfalse IL_04f1
+				IL_0489: ldstr "V"
+				IL_048e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:131"
+				IL_0493: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
+				IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_04e2: ldstr "V"
-				IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_04ec: br IL_0505
-
-				IL_04f1: ldstr "V"
-				IL_04f6: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:139"
-				IL_04fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_97
-				IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-				IL_0505: stloc.2
-				IL_0506: ldloc.s 6
-				IL_0508: ldloc.s 11
-				IL_050a: ldloc.2
-				IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0510: stloc.2
-				IL_0511: ldloc.s 10
-				IL_0513: ldstr "V"
-				IL_0518: ldloc.2
-				IL_0519: ldc.i4.1
-				IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_051f: pop
-				IL_0520: ldloc.1
-				IL_0521: ldc.r8 1
-				IL_052a: sub
-				IL_052b: stloc.1
-				IL_052c: br IL_047e
+				IL_049d: stloc.2
+				IL_049e: ldnull
+				IL_049f: ldloc.s 11
+				IL_04a1: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_04a6: ldloc.2
+				IL_04a7: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+				IL_04ac: stloc.s 9
+				IL_04ae: ldloc.s 10
+				IL_04b0: ldstr "V"
+				IL_04b5: ldloc.s 9
+				IL_04b7: ldc.i4.1
+				IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_04bd: pop
+				IL_04be: ldloc.1
+				IL_04bf: ldc.r8 1
+				IL_04c8: sub
+				IL_04c9: stloc.1
+				IL_04ca: br IL_0428
 			// end loop
 
-			IL_0531: ldarg.0
-			IL_0532: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
-			IL_0537: stloc.2
-			IL_0538: ldloc.2
-			IL_0539: ldc.i4.1
-			IL_053a: newarr [System.Runtime]System.Object
-			IL_053f: dup
-			IL_0540: ldc.i4.0
-			IL_0541: ldarg.0
-			IL_0542: stelem.ref
-			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0548: pop
-			IL_0549: ldarg.0
-			IL_054a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_054f: stloc.2
-			IL_0550: volatile.
-			IL_0552: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
-			IL_0557: brfalse IL_056c
+			IL_04cf: ldarg.0
+			IL_04d0: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_04d5: ldnull
+			IL_04d6: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+			IL_04db: pop
+			IL_04dc: ldarg.0
+			IL_04dd: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_04e2: stloc.s 10
+			IL_04e4: volatile.
+			IL_04e6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+			IL_04eb: brfalse IL_0501
 
-			IL_055c: ldloc.2
-			IL_055d: ldstr "LoopCount"
-			IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0567: br IL_0581
+			IL_04f0: ldloc.s 10
+			IL_04f2: ldstr "LoopCount"
+			IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04fc: br IL_0517
 
-			IL_056c: ldloc.2
-			IL_056d: ldstr "LoopCount"
-			IL_0572: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:156"
-			IL_0577: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
-			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0501: ldloc.s 10
+			IL_0503: ldstr "LoopCount"
+			IL_0508: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M21>:__js_call__:148"
+			IL_050d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_98
+			IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0581: stloc.s 10
-			IL_0583: ldloc.s 10
-			IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
-			IL_058a: stloc.s 10
-			IL_058c: ldloc.s 10
-			IL_058e: ldc.i4.1
-			IL_058f: box [System.Runtime]System.Boolean
-			IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
-			IL_0599: stloc.s 10
-			IL_059b: ldloc.2
-			IL_059c: ldstr "LoopCount"
-			IL_05a1: ldloc.s 10
-			IL_05a3: ldc.i4.1
-			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_05a9: pop
-			IL_05aa: ldarg.0
-			IL_05ab: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
-			IL_05b0: stloc.s 10
-			IL_05b2: ldloc.s 10
-			IL_05b4: ldc.i4.1
-			IL_05b5: newarr [System.Runtime]System.Object
-			IL_05ba: dup
-			IL_05bb: ldc.i4.0
-			IL_05bc: ldarg.0
-			IL_05bd: stelem.ref
-			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_05c3: pop
-			IL_05c4: ldnull
-			IL_05c5: ret
+			IL_0517: stloc.2
+			IL_0518: ldloc.2
+			IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
+			IL_051e: stloc.2
+			IL_051f: ldloc.2
+			IL_0520: ldc.i4.1
+			IL_0521: box [System.Runtime]System.Boolean
+			IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
+			IL_052b: stloc.2
+			IL_052c: ldloc.s 10
+			IL_052e: ldstr "LoopCount"
+			IL_0533: ldloc.2
+			IL_0534: ldc.i4.1
+			IL_0535: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_053a: pop
+			IL_053b: ldarg.0
+			IL_053c: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0541: ldnull
+			IL_0542: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+			IL_0547: pop
+			IL_0548: ldnull
+			IL_0549: ret
 		} // end of method Loop::__js_call__
 
 	} // end of class Loop
@@ -8175,7 +7873,7 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 4063 (0xfdf)
+			// Code size: 3980 (0xf8c)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -8188,9 +7886,8 @@
 				[7] class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP,
 				[8] object,
 				[9] bool,
-				[10] object[],
-				[11] object,
-				[12] object
+				[10] object,
+				[11] object
 			)
 
 			IL_0000: ldarg.0
@@ -8933,7 +8630,7 @@
 				IL_09cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
 				IL_09d1: stloc.s 9
 				IL_09d3: ldloc.s 9
-				IL_09d5: brfalse IL_0c07
+				IL_09d5: brfalse IL_0bf8
 
 				IL_09da: ldarg.0
 				IL_09db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
@@ -8952,505 +8649,461 @@
 
 				IL_0a0f: stloc.3
 				IL_0a10: ldarg.0
-				IL_0a11: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcNormal
-				IL_0a16: ldc.i4.1
-				IL_0a17: newarr [System.Runtime]System.Object
-				IL_0a1c: dup
-				IL_0a1d: ldc.i4.0
-				IL_0a1e: ldarg.0
-				IL_0a1f: stelem.ref
-				IL_0a20: stloc.s 10
-				IL_0a22: ldarg.0
-				IL_0a23: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0a28: ldarg.0
-				IL_0a29: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0a2e: volatile.
-				IL_0a30: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-				IL_0a35: brfalse IL_0a49
+				IL_0a11: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0a16: ldarg.0
+				IL_0a17: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0a1c: volatile.
+				IL_0a1e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
+				IL_0a23: brfalse IL_0a37
 
-				IL_0a3a: ldstr "Edge"
-				IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0a44: br IL_0a5d
+				IL_0a28: ldstr "Edge"
+				IL_0a2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0a32: br IL_0a4b
 
-				IL_0a49: ldstr "Edge"
-				IL_0a4e: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:304"
-				IL_0a53: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
-				IL_0a58: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0a37: ldstr "Edge"
+				IL_0a3c: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:302"
+				IL_0a41: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_102
+				IL_0a46: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0a5d: stloc.1
-				IL_0a5e: ldloc.1
-				IL_0a5f: ldloc.0
-				IL_0a60: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0a65: stloc.1
-				IL_0a66: ldloc.1
-				IL_0a67: ldc.r8 0.0
-				IL_0a70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0a75: stloc.1
-				IL_0a76: ldloc.1
-				IL_0a77: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0a7c: stloc.1
-				IL_0a7d: volatile.
-				IL_0a7f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-				IL_0a84: brfalse IL_0a99
+				IL_0a4b: stloc.1
+				IL_0a4c: ldloc.1
+				IL_0a4d: ldloc.0
+				IL_0a4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0a53: stloc.1
+				IL_0a54: ldloc.1
+				IL_0a55: ldc.r8 0.0
+				IL_0a5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0a63: stloc.1
+				IL_0a64: ldloc.1
+				IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0a6a: stloc.1
+				IL_0a6b: volatile.
+				IL_0a6d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
+				IL_0a72: brfalse IL_0a87
 
-				IL_0a89: ldloc.1
-				IL_0a8a: ldstr "V"
-				IL_0a8f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0a94: br IL_0aae
+				IL_0a77: ldloc.1
+				IL_0a78: ldstr "V"
+				IL_0a7d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0a82: br IL_0a9c
 
-				IL_0a99: ldloc.1
-				IL_0a9a: ldstr "V"
-				IL_0a9f: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:310"
-				IL_0aa4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
-				IL_0aa9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0a87: ldloc.1
+				IL_0a88: ldstr "V"
+				IL_0a8d: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:308"
+				IL_0a92: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_103
+				IL_0a97: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0aae: stloc.1
-				IL_0aaf: ldarg.0
-				IL_0ab0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0ab5: ldarg.0
-				IL_0ab6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0abb: volatile.
-				IL_0abd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-				IL_0ac2: brfalse IL_0ad6
+				IL_0a9c: stloc.1
+				IL_0a9d: ldarg.0
+				IL_0a9e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0aa3: ldarg.0
+				IL_0aa4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0aa9: volatile.
+				IL_0aab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+				IL_0ab0: brfalse IL_0ac4
 
-				IL_0ac7: ldstr "Edge"
-				IL_0acc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0ad1: br IL_0aea
+				IL_0ab5: ldstr "Edge"
+				IL_0aba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0abf: br IL_0ad8
 
-				IL_0ad6: ldstr "Edge"
-				IL_0adb: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:314"
-				IL_0ae0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
-				IL_0ae5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0ac4: ldstr "Edge"
+				IL_0ac9: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:312"
+				IL_0ace: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_104
+				IL_0ad3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0aea: stloc.s 11
-				IL_0aec: ldloc.s 11
-				IL_0aee: ldloc.0
+				IL_0ad8: stloc.s 10
+				IL_0ada: ldloc.s 10
+				IL_0adc: ldloc.0
+				IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0ae2: stloc.s 10
+				IL_0ae4: ldloc.s 10
+				IL_0ae6: ldc.r8 1
 				IL_0aef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0af4: stloc.s 11
-				IL_0af6: ldloc.s 11
-				IL_0af8: ldc.r8 1
-				IL_0b01: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0b06: stloc.s 11
-				IL_0b08: ldloc.s 11
-				IL_0b0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0b0f: stloc.s 11
-				IL_0b11: volatile.
-				IL_0b13: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-				IL_0b18: brfalse IL_0b2e
+				IL_0af4: stloc.s 10
+				IL_0af6: ldloc.s 10
+				IL_0af8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0afd: stloc.s 10
+				IL_0aff: volatile.
+				IL_0b01: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+				IL_0b06: brfalse IL_0b1c
 
-				IL_0b1d: ldloc.s 11
-				IL_0b1f: ldstr "V"
-				IL_0b24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b29: br IL_0b44
+				IL_0b0b: ldloc.s 10
+				IL_0b0d: ldstr "V"
+				IL_0b12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b17: br IL_0b32
 
-				IL_0b2e: ldloc.s 11
-				IL_0b30: ldstr "V"
-				IL_0b35: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:320"
-				IL_0b3a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
-				IL_0b3f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0b1c: ldloc.s 10
+				IL_0b1e: ldstr "V"
+				IL_0b23: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:318"
+				IL_0b28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_105
+				IL_0b2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0b44: stloc.s 11
-				IL_0b46: ldarg.0
-				IL_0b47: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b4c: ldarg.0
-				IL_0b4d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b52: volatile.
-				IL_0b54: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-				IL_0b59: brfalse IL_0b6d
+				IL_0b32: stloc.s 10
+				IL_0b34: ldarg.0
+				IL_0b35: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b3a: ldarg.0
+				IL_0b3b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b40: volatile.
+				IL_0b42: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+				IL_0b47: brfalse IL_0b5b
 
-				IL_0b5e: ldstr "Edge"
-				IL_0b63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b68: br IL_0b81
+				IL_0b4c: ldstr "Edge"
+				IL_0b51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b56: br IL_0b6f
 
-				IL_0b6d: ldstr "Edge"
-				IL_0b72: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:324"
-				IL_0b77: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
-				IL_0b7c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0b5b: ldstr "Edge"
+				IL_0b60: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:322"
+				IL_0b65: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_106
+				IL_0b6a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0b81: stloc.s 12
-				IL_0b83: ldloc.s 12
-				IL_0b85: ldloc.0
+				IL_0b6f: stloc.s 11
+				IL_0b71: ldloc.s 11
+				IL_0b73: ldloc.0
+				IL_0b74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b79: stloc.s 11
+				IL_0b7b: ldloc.s 11
+				IL_0b7d: ldc.r8 2
 				IL_0b86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0b8b: stloc.s 12
-				IL_0b8d: ldloc.s 12
-				IL_0b8f: ldc.r8 2
-				IL_0b98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0b9d: stloc.s 12
-				IL_0b9f: ldloc.s 12
-				IL_0ba1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0ba6: stloc.s 12
-				IL_0ba8: volatile.
-				IL_0baa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-				IL_0baf: brfalse IL_0bc5
+				IL_0b8b: stloc.s 11
+				IL_0b8d: ldloc.s 11
+				IL_0b8f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0b94: stloc.s 11
+				IL_0b96: volatile.
+				IL_0b98: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+				IL_0b9d: brfalse IL_0bb3
 
-				IL_0bb4: ldloc.s 12
-				IL_0bb6: ldstr "V"
-				IL_0bbb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0bc0: br IL_0bdb
+				IL_0ba2: ldloc.s 11
+				IL_0ba4: ldstr "V"
+				IL_0ba9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bae: br IL_0bc9
 
-				IL_0bc5: ldloc.s 12
-				IL_0bc7: ldstr "V"
-				IL_0bcc: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:330"
-				IL_0bd1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
-				IL_0bd6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0bb3: ldloc.s 11
+				IL_0bb5: ldstr "V"
+				IL_0bba: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:328"
+				IL_0bbf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_107
+				IL_0bc4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0bdb: stloc.s 12
-				IL_0bdd: ldloc.s 10
-				IL_0bdf: ldloc.1
-				IL_0be0: ldloc.s 11
-				IL_0be2: ldloc.s 12
-				IL_0be4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_0be9: stloc.s 12
-				IL_0beb: ldloc.3
-				IL_0bec: ldloc.0
-				IL_0bed: ldloc.s 12
-				IL_0bef: ldc.i4.1
-				IL_0bf0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-				IL_0bf5: pop
-				IL_0bf6: ldloc.0
-				IL_0bf7: ldc.r8 1
-				IL_0c00: add
-				IL_0c01: stloc.0
-				IL_0c02: br IL_0955
+				IL_0bc9: stloc.s 11
+				IL_0bcb: ldarg.0
+				IL_0bcc: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+				IL_0bd1: ldnull
+				IL_0bd2: ldloc.1
+				IL_0bd3: ldloc.s 10
+				IL_0bd5: ldloc.s 11
+				IL_0bd7: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object)
+				IL_0bdc: stloc.2
+				IL_0bdd: ldloc.3
+				IL_0bde: ldloc.0
+				IL_0bdf: ldloc.2
+				IL_0be0: ldc.i4.1
+				IL_0be1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+				IL_0be6: pop
+				IL_0be7: ldloc.0
+				IL_0be8: ldc.r8 1
+				IL_0bf1: add
+				IL_0bf2: stloc.0
+				IL_0bf3: br IL_0955
 			// end loop
 
-			IL_0c07: ldarg.0
-			IL_0c08: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c0d: stloc.s 12
-			IL_0c0f: ldc.i4.s 12
-			IL_0c11: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0c16: dup
-			IL_0c17: ldc.i4.0
-			IL_0c18: box [System.Runtime]System.Boolean
-			IL_0c1d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c22: dup
-			IL_0c23: ldc.i4.0
-			IL_0c24: box [System.Runtime]System.Boolean
-			IL_0c29: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c2e: dup
-			IL_0c2f: ldc.i4.0
-			IL_0c30: box [System.Runtime]System.Boolean
-			IL_0c35: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c3a: dup
-			IL_0c3b: ldc.i4.0
-			IL_0c3c: box [System.Runtime]System.Boolean
-			IL_0c41: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c46: dup
-			IL_0c47: ldc.i4.0
-			IL_0c48: box [System.Runtime]System.Boolean
-			IL_0c4d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c52: dup
-			IL_0c53: ldc.i4.0
-			IL_0c54: box [System.Runtime]System.Boolean
-			IL_0c59: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c5e: dup
-			IL_0c5f: ldc.i4.0
-			IL_0c60: box [System.Runtime]System.Boolean
-			IL_0c65: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c6a: dup
-			IL_0c6b: ldc.i4.0
-			IL_0c6c: box [System.Runtime]System.Boolean
-			IL_0c71: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c76: dup
-			IL_0c77: ldc.i4.0
-			IL_0c78: box [System.Runtime]System.Boolean
-			IL_0c7d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c82: dup
-			IL_0c83: ldc.i4.0
-			IL_0c84: box [System.Runtime]System.Boolean
-			IL_0c89: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c8e: dup
-			IL_0c8f: ldc.i4.0
-			IL_0c90: box [System.Runtime]System.Boolean
-			IL_0c95: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c9a: dup
-			IL_0c9b: ldc.i4.0
-			IL_0c9c: box [System.Runtime]System.Boolean
-			IL_0ca1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ca6: stloc.2
-			IL_0ca7: ldloc.s 12
-			IL_0ca9: ldstr "Line"
-			IL_0cae: ldloc.2
-			IL_0caf: ldc.i4.1
-			IL_0cb0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0cb5: pop
-			IL_0cb6: ldarg.0
-			IL_0cb7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0cbc: stloc.s 12
-			IL_0cbe: ldc.r8 9
-			IL_0cc7: ldc.r8 2
-			IL_0cd0: mul
-			IL_0cd1: ldarg.2
-			IL_0cd2: mul
-			IL_0cd3: stloc.s 4
-			IL_0cd5: ldloc.s 12
-			IL_0cd7: ldstr "NumPx"
-			IL_0cdc: ldloc.s 4
-			IL_0cde: ldc.i4.1
-			IL_0cdf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0ce4: pop
-			IL_0ce5: ldc.r8 0.0
-			IL_0cee: stloc.0
-			// loop start (head: IL_0cef)
-				IL_0cef: ldloc.0
-				IL_0cf0: stloc.s 4
-				IL_0cf2: ldarg.0
-				IL_0cf3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0cf8: volatile.
-				IL_0cfa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-				IL_0cff: brfalse IL_0d13
+			IL_0bf8: ldarg.0
+			IL_0bf9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0bfe: stloc.3
+			IL_0bff: ldc.i4.s 12
+			IL_0c01: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0c06: dup
+			IL_0c07: ldc.i4.0
+			IL_0c08: box [System.Runtime]System.Boolean
+			IL_0c0d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c12: dup
+			IL_0c13: ldc.i4.0
+			IL_0c14: box [System.Runtime]System.Boolean
+			IL_0c19: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c1e: dup
+			IL_0c1f: ldc.i4.0
+			IL_0c20: box [System.Runtime]System.Boolean
+			IL_0c25: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c2a: dup
+			IL_0c2b: ldc.i4.0
+			IL_0c2c: box [System.Runtime]System.Boolean
+			IL_0c31: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c36: dup
+			IL_0c37: ldc.i4.0
+			IL_0c38: box [System.Runtime]System.Boolean
+			IL_0c3d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c42: dup
+			IL_0c43: ldc.i4.0
+			IL_0c44: box [System.Runtime]System.Boolean
+			IL_0c49: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c4e: dup
+			IL_0c4f: ldc.i4.0
+			IL_0c50: box [System.Runtime]System.Boolean
+			IL_0c55: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c5a: dup
+			IL_0c5b: ldc.i4.0
+			IL_0c5c: box [System.Runtime]System.Boolean
+			IL_0c61: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c66: dup
+			IL_0c67: ldc.i4.0
+			IL_0c68: box [System.Runtime]System.Boolean
+			IL_0c6d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c72: dup
+			IL_0c73: ldc.i4.0
+			IL_0c74: box [System.Runtime]System.Boolean
+			IL_0c79: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c7e: dup
+			IL_0c7f: ldc.i4.0
+			IL_0c80: box [System.Runtime]System.Boolean
+			IL_0c85: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c8a: dup
+			IL_0c8b: ldc.i4.0
+			IL_0c8c: box [System.Runtime]System.Boolean
+			IL_0c91: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c96: stloc.2
+			IL_0c97: ldloc.3
+			IL_0c98: ldstr "Line"
+			IL_0c9d: ldloc.2
+			IL_0c9e: ldc.i4.1
+			IL_0c9f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0ca4: pop
+			IL_0ca5: ldarg.0
+			IL_0ca6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0cab: stloc.3
+			IL_0cac: ldc.r8 9
+			IL_0cb5: ldc.r8 2
+			IL_0cbe: mul
+			IL_0cbf: ldarg.2
+			IL_0cc0: mul
+			IL_0cc1: stloc.s 4
+			IL_0cc3: ldloc.3
+			IL_0cc4: ldstr "NumPx"
+			IL_0cc9: ldloc.s 4
+			IL_0ccb: ldc.i4.1
+			IL_0ccc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0cd1: pop
+			IL_0cd2: ldc.r8 0.0
+			IL_0cdb: stloc.0
+			// loop start (head: IL_0cdc)
+				IL_0cdc: ldloc.0
+				IL_0cdd: stloc.s 4
+				IL_0cdf: ldarg.0
+				IL_0ce0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0ce5: volatile.
+				IL_0ce7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+				IL_0cec: brfalse IL_0d00
 
-				IL_0d04: ldstr "NumPx"
-				IL_0d09: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0d0e: br IL_0d27
+				IL_0cf1: ldstr "NumPx"
+				IL_0cf6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0cfb: br IL_0d14
 
-				IL_0d13: ldstr "NumPx"
-				IL_0d18: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:372"
-				IL_0d1d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
-				IL_0d22: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0d00: ldstr "NumPx"
+				IL_0d05: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:371"
+				IL_0d0a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_108
+				IL_0d0f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0d27: stloc.s 12
-				IL_0d29: ldloc.s 4
-				IL_0d2b: box [System.Runtime]System.Double
-				IL_0d30: stloc.s 8
-				IL_0d32: ldloc.s 8
-				IL_0d34: ldloc.s 12
-				IL_0d36: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-				IL_0d3b: stloc.s 9
-				IL_0d3d: ldloc.s 9
-				IL_0d3f: brfalse IL_0d9a
+				IL_0d14: stloc.3
+				IL_0d15: ldloc.s 4
+				IL_0d17: box [System.Runtime]System.Double
+				IL_0d1c: stloc.s 8
+				IL_0d1e: ldloc.s 8
+				IL_0d20: ldloc.3
+				IL_0d21: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+				IL_0d26: stloc.s 9
+				IL_0d28: ldloc.s 9
+				IL_0d2a: brfalse IL_0d82
 
-				IL_0d44: ldarg.0
-				IL_0d45: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-				IL_0d4a: stloc.s 12
-				IL_0d4c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
-				IL_0d51: stloc.s 7
-				IL_0d53: ldloc.s 12
-				IL_0d55: ldloc.s 7
-				IL_0d57: ldloc.s 12
-				IL_0d59: ldc.r8 0.0
-				IL_0d62: box [System.Runtime]System.Double
-				IL_0d67: ldc.r8 0.0
-				IL_0d70: box [System.Runtime]System.Double
-				IL_0d75: ldc.r8 0.0
-				IL_0d7e: box [System.Runtime]System.Double
-				IL_0d83: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
-				IL_0d88: pop
-				IL_0d89: ldloc.0
-				IL_0d8a: ldc.r8 1
-				IL_0d93: add
-				IL_0d94: stloc.0
-				IL_0d95: br IL_0cef
+				IL_0d2f: ldarg.0
+				IL_0d30: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+				IL_0d35: stloc.3
+				IL_0d36: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP::.ctor()
+				IL_0d3b: stloc.s 7
+				IL_0d3d: ldloc.3
+				IL_0d3e: ldloc.s 7
+				IL_0d40: ldloc.3
+				IL_0d41: ldc.r8 0.0
+				IL_0d4a: box [System.Runtime]System.Double
+				IL_0d4f: ldc.r8 0.0
+				IL_0d58: box [System.Runtime]System.Double
+				IL_0d5d: ldc.r8 0.0
+				IL_0d66: box [System.Runtime]System.Double
+				IL_0d6b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionWithReceiver3<class Modules.Compile_Resources_Dromaeo_3d_Cube/ObjectLiterals/Ctor_L97C1_CreateP>(object, object, object, object, object, object)
+				IL_0d70: pop
+				IL_0d71: ldloc.0
+				IL_0d72: ldc.r8 1
+				IL_0d7b: add
+				IL_0d7c: stloc.0
+				IL_0d7d: br IL_0cdc
 			// end loop
 
-			IL_0d9a: ldarg.0
-			IL_0d9b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
-			IL_0da0: ldc.i4.1
-			IL_0da1: newarr [System.Runtime]System.Object
-			IL_0da6: dup
-			IL_0da7: ldc.i4.0
-			IL_0da8: ldarg.0
-			IL_0da9: stelem.ref
-			IL_0daa: stloc.s 10
-			IL_0dac: ldarg.0
-			IL_0dad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0db2: stloc.s 12
-			IL_0db4: ldarg.0
-			IL_0db5: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0dba: volatile.
-			IL_0dbc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
-			IL_0dc1: brfalse IL_0dd5
+			IL_0d82: ldarg.0
+			IL_0d83: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0d88: stloc.3
+			IL_0d89: ldarg.0
+			IL_0d8a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0d8f: volatile.
+			IL_0d91: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_0d96: brfalse IL_0daa
 
-			IL_0dc6: ldstr "V"
-			IL_0dcb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0dd0: br IL_0de9
+			IL_0d9b: ldstr "V"
+			IL_0da0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0da5: br IL_0dbe
 
-			IL_0dd5: ldstr "V"
-			IL_0dda: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:398"
-			IL_0ddf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
-			IL_0de4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0daa: ldstr "V"
+			IL_0daf: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:395"
+			IL_0db4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_109
+			IL_0db9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0de9: stloc.3
-			IL_0dea: ldloc.3
-			IL_0deb: ldc.r8 0.0
-			IL_0df4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0df9: stloc.3
-			IL_0dfa: ldarg.0
-			IL_0dfb: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0e00: volatile.
-			IL_0e02: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
-			IL_0e07: brfalse IL_0e1b
+			IL_0dbe: stloc.s 11
+			IL_0dc0: ldloc.s 11
+			IL_0dc2: ldc.r8 0.0
+			IL_0dcb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0dd0: stloc.s 11
+			IL_0dd2: ldarg.0
+			IL_0dd3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0dd8: volatile.
+			IL_0dda: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_0ddf: brfalse IL_0df3
 
-			IL_0e0c: ldstr "V"
-			IL_0e11: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e16: br IL_0e2f
+			IL_0de4: ldstr "V"
+			IL_0de9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dee: br IL_0e07
 
-			IL_0e1b: ldstr "V"
-			IL_0e20: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:403"
-			IL_0e25: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
-			IL_0e2a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0df3: ldstr "V"
+			IL_0df8: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:400"
+			IL_0dfd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_110
+			IL_0e02: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e2f: stloc.s 11
-			IL_0e31: ldloc.s 11
-			IL_0e33: ldc.r8 1
-			IL_0e3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e41: stloc.s 11
-			IL_0e43: ldarg.0
-			IL_0e44: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0e49: volatile.
-			IL_0e4b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
-			IL_0e50: brfalse IL_0e64
+			IL_0e07: stloc.s 10
+			IL_0e09: ldloc.s 10
+			IL_0e0b: ldc.r8 1
+			IL_0e14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e19: stloc.s 10
+			IL_0e1b: ldarg.0
+			IL_0e1c: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0e21: volatile.
+			IL_0e23: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_0e28: brfalse IL_0e3c
 
-			IL_0e55: ldstr "V"
-			IL_0e5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e5f: br IL_0e78
+			IL_0e2d: ldstr "V"
+			IL_0e32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e37: br IL_0e50
 
-			IL_0e64: ldstr "V"
-			IL_0e69: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:408"
-			IL_0e6e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
-			IL_0e73: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0e3c: ldstr "V"
+			IL_0e41: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:405"
+			IL_0e46: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_111
+			IL_0e4b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e78: stloc.1
-			IL_0e79: ldloc.1
-			IL_0e7a: ldc.r8 2
-			IL_0e83: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e88: stloc.1
-			IL_0e89: ldloc.s 10
-			IL_0e8b: ldloc.s 12
-			IL_0e8d: ldloc.3
-			IL_0e8e: ldloc.s 11
+			IL_0e50: stloc.1
+			IL_0e51: ldloc.1
+			IL_0e52: ldc.r8 2
+			IL_0e5b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e60: stloc.1
+			IL_0e61: ldarg.0
+			IL_0e62: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0e67: ldnull
+			IL_0e68: ldloc.3
+			IL_0e69: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e6e: ldloc.s 11
+			IL_0e70: ldloc.s 10
+			IL_0e72: ldloc.1
+			IL_0e73: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
+			IL_0e78: stloc.2
+			IL_0e79: ldarg.0
+			IL_0e7a: ldloc.2
+			IL_0e7b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e80: ldarg.0
+			IL_0e81: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e86: stloc.1
+			IL_0e87: ldarg.0
+			IL_0e88: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0e8d: stloc.s 10
+			IL_0e8f: ldnull
 			IL_0e90: ldloc.1
-			IL_0e91: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0e96: stloc.1
-			IL_0e97: ldarg.0
-			IL_0e98: ldloc.1
-			IL_0e99: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0e9e: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e91: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e96: ldloc.s 10
+			IL_0e98: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e9d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0ea2: stloc.2
 			IL_0ea3: ldarg.0
-			IL_0ea4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
-			IL_0ea9: ldc.i4.1
-			IL_0eaa: newarr [System.Runtime]System.Object
-			IL_0eaf: dup
-			IL_0eb0: ldc.i4.0
-			IL_0eb1: ldarg.0
-			IL_0eb2: stelem.ref
-			IL_0eb3: stloc.s 10
-			IL_0eb5: ldarg.0
-			IL_0eb6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0ebb: stloc.1
-			IL_0ebc: ldarg.0
-			IL_0ebd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0ec2: stloc.s 11
-			IL_0ec4: ldloc.s 10
-			IL_0ec6: ldloc.1
-			IL_0ec7: ldloc.s 11
-			IL_0ec9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0ece: stloc.s 11
-			IL_0ed0: ldarg.0
-			IL_0ed1: ldloc.s 11
-			IL_0ed3: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0ed8: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0edd: ldc.r8 0.0
-			IL_0ee6: stloc.0
-			// loop start (head: IL_0ee7)
-				IL_0ee7: ldloc.0
-				IL_0ee8: stloc.s 4
-				IL_0eea: ldloc.s 4
-				IL_0eec: ldc.r8 9
-				IL_0ef5: clt
-				IL_0ef7: brfalse IL_0f93
+			IL_0ea4: ldloc.2
+			IL_0ea5: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0eaa: ldc.r8 0.0
+			IL_0eb3: stloc.0
+			// loop start (head: IL_0eb4)
+				IL_0eb4: ldloc.0
+				IL_0eb5: stloc.s 4
+				IL_0eb7: ldloc.s 4
+				IL_0eb9: ldc.r8 9
+				IL_0ec2: clt
+				IL_0ec4: brfalse IL_0f54
 
-				IL_0efc: ldarg.0
-				IL_0efd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0f02: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_0f07: ldloc.0
-				IL_0f08: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0f0d: stloc.s 11
-				IL_0f0f: ldarg.0
-				IL_0f10: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
-				IL_0f15: ldc.i4.1
-				IL_0f16: newarr [System.Runtime]System.Object
-				IL_0f1b: dup
-				IL_0f1c: ldc.i4.0
-				IL_0f1d: ldarg.0
-				IL_0f1e: stelem.ref
-				IL_0f1f: stloc.s 10
-				IL_0f21: ldarg.0
-				IL_0f22: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-				IL_0f27: stloc.1
-				IL_0f28: ldarg.0
-				IL_0f29: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0f2e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_0f33: ldloc.0
-				IL_0f34: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0f39: volatile.
-				IL_0f3b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
-				IL_0f40: brfalse IL_0f54
+				IL_0ec9: ldarg.0
+				IL_0eca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0ecf: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0ed4: ldloc.0
+				IL_0ed5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0eda: stloc.s 10
+				IL_0edc: ldarg.0
+				IL_0edd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+				IL_0ee2: stloc.1
+				IL_0ee3: ldarg.0
+				IL_0ee4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0ee9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0eee: ldloc.0
+				IL_0eef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0ef4: volatile.
+				IL_0ef6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+				IL_0efb: brfalse IL_0f0f
 
-				IL_0f45: ldstr "V"
-				IL_0f4a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0f4f: br IL_0f68
+				IL_0f00: ldstr "V"
+				IL_0f05: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0f0a: br IL_0f23
 
-				IL_0f54: ldstr "V"
-				IL_0f59: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:438"
-				IL_0f5e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
-				IL_0f63: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0f0f: ldstr "V"
+				IL_0f14: ldstr "Compile_Resources_Dromaeo_3d_Cube:<TwoPhaseDummy_M22>:__js_call__:433"
+				IL_0f19: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_112
+				IL_0f1e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0f68: stloc.3
-				IL_0f69: ldloc.s 10
-				IL_0f6b: ldloc.1
-				IL_0f6c: ldloc.3
-				IL_0f6d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_0f72: stloc.3
-				IL_0f73: ldloc.s 11
-				IL_0f75: ldstr "V"
-				IL_0f7a: ldloc.3
-				IL_0f7b: ldc.i4.1
-				IL_0f7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0f81: pop
-				IL_0f82: ldloc.0
-				IL_0f83: ldc.r8 1
-				IL_0f8c: add
-				IL_0f8d: stloc.0
-				IL_0f8e: br IL_0ee7
+				IL_0f23: stloc.s 11
+				IL_0f25: ldnull
+				IL_0f26: ldloc.1
+				IL_0f27: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0f2c: ldloc.s 11
+				IL_0f2e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+				IL_0f33: stloc.2
+				IL_0f34: ldloc.s 10
+				IL_0f36: ldstr "V"
+				IL_0f3b: ldloc.2
+				IL_0f3c: ldc.i4.1
+				IL_0f3d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0f42: pop
+				IL_0f43: ldloc.0
+				IL_0f44: ldc.r8 1
+				IL_0f4d: add
+				IL_0f4e: stloc.0
+				IL_0f4f: br IL_0eb4
 			// end loop
 
-			IL_0f93: ldarg.0
-			IL_0f94: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
-			IL_0f99: stloc.3
-			IL_0f9a: ldloc.3
-			IL_0f9b: ldc.i4.1
-			IL_0f9c: newarr [System.Runtime]System.Object
-			IL_0fa1: dup
-			IL_0fa2: ldc.i4.0
-			IL_0fa3: ldarg.0
-			IL_0fa4: stelem.ref
-			IL_0fa5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0faa: pop
-			IL_0fab: ldarg.0
-			IL_0fac: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0fb1: stloc.3
-			IL_0fb2: ldloc.3
-			IL_0fb3: ldstr "Init"
-			IL_0fb8: ldc.i4.1
-			IL_0fb9: box [System.Runtime]System.Boolean
-			IL_0fbe: ldc.i4.1
-			IL_0fbf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0fc4: pop
-			IL_0fc5: ldarg.0
-			IL_0fc6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
-			IL_0fcb: stloc.3
-			IL_0fcc: ldloc.3
-			IL_0fcd: ldc.i4.1
-			IL_0fce: newarr [System.Runtime]System.Object
-			IL_0fd3: dup
-			IL_0fd4: ldc.i4.0
-			IL_0fd5: ldarg.0
-			IL_0fd6: stelem.ref
-			IL_0fd7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0fdc: pop
-			IL_0fdd: ldnull
-			IL_0fde: ret
+			IL_0f54: ldarg.0
+			IL_0f55: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0f5a: ldnull
+			IL_0f5b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+			IL_0f60: pop
+			IL_0f61: ldarg.0
+			IL_0f62: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0f67: stloc.s 10
+			IL_0f69: ldloc.s 10
+			IL_0f6b: ldstr "Init"
+			IL_0f70: ldc.i4.1
+			IL_0f71: box [System.Runtime]System.Boolean
+			IL_0f76: ldc.i4.1
+			IL_0f77: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0f7c: pop
+			IL_0f7d: ldarg.0
+			IL_0f7e: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0f83: ldnull
+			IL_0f84: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+			IL_0f89: pop
+			IL_0f8a: ldnull
+			IL_0f8b: ret
 		} // end of method Init::__js_call__
 
 	} // end of class Init
@@ -9593,45 +9246,34 @@
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 70 (0x46)
+			// Code size: 52 (0x34)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
-				[2] object[],
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.Console
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.Console
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Init
-			IL_0006: stloc.1
-			IL_0007: ldc.i4.1
-			IL_0008: newarr [System.Runtime]System.Object
-			IL_000d: dup
-			IL_000e: ldc.i4.0
-			IL_000f: ldarg.0
-			IL_0010: stelem.ref
-			IL_0011: stloc.2
-			IL_0012: ldloc.1
-			IL_0013: ldloc.2
-			IL_0014: ldc.r8 20
-			IL_001d: box [System.Runtime]System.Double
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0027: pop
-			IL_0028: ldarg.0
-			IL_0029: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_002e: stloc.1
-			IL_002f: ldloc.1
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-			IL_0035: stloc.0
-			IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_003b: stloc.3
-			IL_003c: ldloc.3
-			IL_003d: ldloc.0
-			IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0043: pop
-			IL_0044: ldnull
-			IL_0045: ret
+			IL_0001: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 20
+			IL_0010: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Init::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, float64)
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_001c: stloc.1
+			IL_001d: ldloc.1
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+			IL_0023: stloc.0
+			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0029: stloc.2
+			IL_002a: ldloc.2
+			IL_002b: ldloc.0
+			IL_002c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0031: pop
+			IL_0032: ldnull
+			IL_0033: ret
 		} // end of method FunctionExpression_L334C23::__js_call__
 
 	} // end of class FunctionExpression_L334C23
@@ -9775,7 +9417,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1183 (0x49f)
+		// Code size: 1159 (0x487)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope,
@@ -9802,8 +9444,7 @@
 			[21] class Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject,
 			[22] class Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject,
 			[23] object,
-			[24] object[],
-			[25] class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject
+			[24] class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::.ctor()
@@ -10264,46 +9905,39 @@
 		IL_0433: nop
 		IL_0434: nop
 		IL_0435: nop
-		IL_0436: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_043b: stloc.s 8
-		IL_043d: ldloc.1
-		IL_043e: ldloc.s 8
-		IL_0440: ldstr "dromaeo-3d-cube"
-		IL_0445: ldstr "979cd0f1"
-		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_044f: pop
-		IL_0450: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0455: stloc.s 8
-		IL_0457: ldc.i4.1
-		IL_0458: newarr [System.Runtime]System.Object
-		IL_045d: dup
-		IL_045e: ldc.i4.0
-		IL_045f: ldloc.0
-		IL_0460: stelem.ref
-		IL_0461: stloc.s 24
-		IL_0463: ldloc.s 24
-		IL_0465: ldc.i4.0
-		IL_0466: ldelem.ref
-		IL_0467: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_046c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
-		IL_0471: ldc.i4.0
-		IL_0472: conv.r8
-		IL_0473: ldstr ""
-		IL_0478: ldc.i4.0
-		IL_0479: ldc.i4.0
-		IL_047a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_047f: stloc.s 25
-		IL_0481: ldloc.s 4
-		IL_0483: ldloc.s 8
-		IL_0485: ldstr "Rotate 3D Cube"
-		IL_048a: ldloc.s 25
-		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0491: pop
-		IL_0492: ldloc.2
-		IL_0493: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_049d: pop
-		IL_049e: ret
+		IL_0436: ldnull
+		IL_0437: ldstr "dromaeo-3d-cube"
+		IL_043c: ldstr "979cd0f1"
+		IL_0441: call object Modules.Compile_Resources_Dromaeo_3d_Cube/startTest::__js_call__(object, string, string)
+		IL_0446: pop
+		IL_0447: ldc.i4.1
+		IL_0448: newarr [System.Runtime]System.Object
+		IL_044d: dup
+		IL_044e: ldc.i4.0
+		IL_044f: ldloc.0
+		IL_0450: stelem.ref
+		IL_0451: stloc.s 8
+		IL_0453: ldloc.s 8
+		IL_0455: ldc.i4.0
+		IL_0456: ldelem.ref
+		IL_0457: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+		IL_045c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_0461: ldc.i4.0
+		IL_0462: conv.r8
+		IL_0463: ldstr ""
+		IL_0468: ldc.i4.0
+		IL_0469: ldc.i4.0
+		IL_046a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_046f: stloc.s 24
+		IL_0471: ldnull
+		IL_0472: ldstr "Rotate 3D Cube"
+		IL_0477: ldloc.s 24
+		IL_0479: call object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, string, object)
+		IL_047e: pop
+		IL_047f: ldnull
+		IL_0480: call object Modules.Compile_Resources_Dromaeo_3d_Cube/endTest::__js_call__(object)
+		IL_0485: pop
+		IL_0486: ret
 	} // end of method Compile_Resources_Dromaeo_3d_Cube::__js_module_init__
 
 } // end of class Modules.Compile_Resources_Dromaeo_3d_Cube

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -2983,13 +2983,12 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 222 (0xde)
+				// Code size: 190 (0xbe)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] bool,
-					[2] object,
-					[3] object[]
+					[2] object
 				)
 
 				IL_0000: ldarg.2
@@ -3050,43 +3049,23 @@
 				IL_0097: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_009c: stloc.1
 				IL_009d: ldloc.1
-				IL_009e: brfalse IL_00dc
+				IL_009e: brfalse IL_00bc
 
-				IL_00a3: ldarg.0
-				IL_00a4: ldc.i4.0
-				IL_00a5: ldelem.ref
-				IL_00a6: castclass Modules.Compile_Scripts_BumpVersion/Scope
-				IL_00ab: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
-				IL_00b0: ldc.i4.2
-				IL_00b1: newarr [System.Runtime]System.Object
-				IL_00b6: dup
-				IL_00b7: ldc.i4.0
-				IL_00b8: ldarg.0
-				IL_00b9: ldc.i4.0
-				IL_00ba: ldelem.ref
-				IL_00bb: stelem.ref
-				IL_00bc: dup
-				IL_00bd: ldc.i4.1
-				IL_00be: ldarg.0
-				IL_00bf: ldc.i4.1
-				IL_00c0: ldelem.ref
-				IL_00c1: stelem.ref
-				IL_00c2: stloc.3
-				IL_00c3: ldloc.3
-				IL_00c4: ldarg.2
-				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00ca: stloc.0
-				IL_00cb: ldloc.0
-				IL_00cc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_00d1: ldc.i4.0
-				IL_00d2: ceq
-				IL_00d4: stloc.1
-				IL_00d5: ldloc.1
-				IL_00d6: box [System.Runtime]System.Boolean
-				IL_00db: ret
+				IL_00a3: ldnull
+				IL_00a4: ldarg.2
+				IL_00a5: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
+				IL_00aa: stloc.0
+				IL_00ab: ldloc.0
+				IL_00ac: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_00b1: ldc.i4.0
+				IL_00b2: ceq
+				IL_00b4: stloc.1
+				IL_00b5: ldloc.1
+				IL_00b6: box [System.Runtime]System.Boolean
+				IL_00bb: ret
 
-				IL_00dc: ldloc.2
-				IL_00dd: ret
+				IL_00bc: ldloc.2
+				IL_00bd: ret
 			} // end of method ArrowFunction_L113C44::__js_call__
 
 		} // end of class ArrowFunction_L113C44
@@ -3563,13 +3542,12 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 194 (0xc2)
+				// Code size: 162 (0xa2)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] bool,
-					[2] object[],
-					[3] object
+					[2] object
 				)
 
 				IL_0000: ldarg.2
@@ -3622,43 +3600,23 @@
 				IL_007b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_0080: stloc.1
 				IL_0081: ldloc.1
-				IL_0082: brfalse IL_00c0
+				IL_0082: brfalse IL_00a0
 
-				IL_0087: ldarg.0
-				IL_0088: ldc.i4.0
-				IL_0089: ldelem.ref
-				IL_008a: castclass Modules.Compile_Scripts_BumpVersion/Scope
-				IL_008f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
-				IL_0094: ldc.i4.2
-				IL_0095: newarr [System.Runtime]System.Object
-				IL_009a: dup
-				IL_009b: ldc.i4.0
-				IL_009c: ldarg.0
-				IL_009d: ldc.i4.0
-				IL_009e: ldelem.ref
-				IL_009f: stelem.ref
-				IL_00a0: dup
-				IL_00a1: ldc.i4.1
-				IL_00a2: ldarg.0
-				IL_00a3: ldc.i4.1
-				IL_00a4: ldelem.ref
-				IL_00a5: stelem.ref
-				IL_00a6: stloc.2
-				IL_00a7: ldloc.2
-				IL_00a8: ldarg.2
-				IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00ae: stloc.3
-				IL_00af: ldloc.3
-				IL_00b0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_00b5: ldc.i4.0
-				IL_00b6: ceq
-				IL_00b8: stloc.1
-				IL_00b9: ldloc.1
-				IL_00ba: box [System.Runtime]System.Boolean
-				IL_00bf: ret
+				IL_0087: ldnull
+				IL_0088: ldarg.2
+				IL_0089: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
+				IL_008e: stloc.2
+				IL_008f: ldloc.2
+				IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0095: ldc.i4.0
+				IL_0096: ceq
+				IL_0098: stloc.1
+				IL_0099: ldloc.1
+				IL_009a: box [System.Runtime]System.Boolean
+				IL_009f: ret
 
-				IL_00c0: ldloc.0
-				IL_00c1: ret
+				IL_00a0: ldloc.0
+				IL_00a1: ret
 			} // end of method ArrowFunction_L136C51::__js_call__
 
 		} // end of class ArrowFunction_L136C51
@@ -3837,7 +3795,7 @@
 				74 61 54 6f 6b 65 6e 15 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2493 (0x9bd)
+			// Code size: 2036 (0x7f4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/perform/Scope,
@@ -3871,16 +3829,15 @@
 				[28] object,
 				[29] object,
 				[30] object,
-				[31] object[],
-				[32] bool,
-				[33] string,
-				[34] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[31] bool,
+				[32] string,
+				[33] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[34] object[],
 				[35] class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject,
 				[36] object,
 				[37] object,
 				[38] object,
-				[39] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-				[40] object
+				[39] class [JavaScriptRuntime]JavaScriptRuntime.Console
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope::.ctor()
@@ -3955,868 +3912,635 @@
 			IL_00e8: stloc.2
 
 			IL_00e9: ldarg.0
-			IL_00ea: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00ef: ldc.i4.1
-			IL_00f0: newarr [System.Runtime]System.Object
-			IL_00f5: dup
-			IL_00f6: ldc.i4.0
-			IL_00f7: ldarg.0
-			IL_00f8: stelem.ref
-			IL_00f9: stloc.s 31
-			IL_00fb: ldarg.0
-			IL_00fc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_0101: stloc.s 30
-			IL_0103: ldloc.s 31
-			IL_0105: ldloc.s 30
-			IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_010c: stloc.3
-			IL_010d: ldarg.0
-			IL_010e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0113: ldc.i4.1
-			IL_0114: newarr [System.Runtime]System.Object
-			IL_0119: dup
-			IL_011a: ldc.i4.0
-			IL_011b: ldarg.0
-			IL_011c: stelem.ref
-			IL_011d: stloc.s 31
-			IL_011f: ldarg.0
-			IL_0120: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0125: stloc.s 30
-			IL_0127: ldloc.s 31
-			IL_0129: ldloc.s 30
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0130: stloc.s 4
-			IL_0132: ldarg.0
-			IL_0133: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0138: ldc.i4.1
-			IL_0139: newarr [System.Runtime]System.Object
-			IL_013e: dup
-			IL_013f: ldc.i4.0
-			IL_0140: ldarg.0
-			IL_0141: stelem.ref
-			IL_0142: stloc.s 31
-			IL_0144: ldarg.0
-			IL_0145: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_014a: stloc.s 30
-			IL_014c: ldloc.s 31
-			IL_014e: ldloc.s 30
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0155: stloc.s 5
-			IL_0157: ldarg.0
-			IL_0158: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_015d: ldc.i4.1
-			IL_015e: newarr [System.Runtime]System.Object
-			IL_0163: dup
-			IL_0164: ldc.i4.0
-			IL_0165: ldarg.0
-			IL_0166: stelem.ref
-			IL_0167: stloc.s 31
-			IL_0169: ldarg.0
-			IL_016a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_016f: stloc.s 30
-			IL_0171: ldloc.s 31
-			IL_0173: ldloc.s 30
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_017a: stloc.s 6
-			IL_017c: ldarg.0
-			IL_017d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0182: ldc.i4.1
-			IL_0183: newarr [System.Runtime]System.Object
-			IL_0188: dup
-			IL_0189: ldc.i4.0
-			IL_018a: ldarg.0
-			IL_018b: stelem.ref
-			IL_018c: stloc.s 31
-			IL_018e: ldarg.0
-			IL_018f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_0194: stloc.s 30
-			IL_0196: ldloc.s 31
-			IL_0198: ldloc.s 30
-			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_019f: stloc.s 7
-			IL_01a1: ldarg.0
-			IL_01a2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_01a7: ldc.i4.1
-			IL_01a8: newarr [System.Runtime]System.Object
-			IL_01ad: dup
-			IL_01ae: ldc.i4.0
-			IL_01af: ldarg.0
-			IL_01b0: stelem.ref
-			IL_01b1: stloc.s 31
-			IL_01b3: ldarg.0
-			IL_01b4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_01b9: stloc.s 30
-			IL_01bb: ldloc.s 31
-			IL_01bd: ldloc.s 30
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01c4: stloc.s 8
-			IL_01c6: ldarg.0
-			IL_01c7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
-			IL_01cc: ldc.i4.1
-			IL_01cd: newarr [System.Runtime]System.Object
-			IL_01d2: dup
-			IL_01d3: ldc.i4.0
-			IL_01d4: ldarg.0
-			IL_01d5: stelem.ref
-			IL_01d6: ldloc.3
-			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01dc: stloc.s 9
-			IL_01de: ldarg.0
-			IL_01df: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
-			IL_01e4: ldc.i4.1
-			IL_01e5: newarr [System.Runtime]System.Object
-			IL_01ea: dup
-			IL_01eb: ldc.i4.0
-			IL_01ec: ldarg.0
-			IL_01ed: stelem.ref
-			IL_01ee: ldloc.1
-			IL_01ef: ldloc.s 9
-			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01f6: stloc.s 10
-			IL_01f8: ldloc.s 9
-			IL_01fa: ldloc.s 10
-			IL_01fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0201: stloc.s 32
-			IL_0203: ldloc.s 32
-			IL_0205: brfalse IL_02cf
+			IL_00ea: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_00ef: stloc.s 30
+			IL_00f1: ldarg.0
+			IL_00f2: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_00f7: ldnull
+			IL_00f8: ldloc.s 30
+			IL_00fa: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_00ff: stloc.3
+			IL_0100: ldarg.0
+			IL_0101: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0106: stloc.s 30
+			IL_0108: ldarg.0
+			IL_0109: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_010e: ldnull
+			IL_010f: ldloc.s 30
+			IL_0111: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_0116: stloc.s 4
+			IL_0118: ldarg.0
+			IL_0119: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_011e: stloc.s 30
+			IL_0120: ldarg.0
+			IL_0121: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0126: ldnull
+			IL_0127: ldloc.s 30
+			IL_0129: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_012e: stloc.s 5
+			IL_0130: ldarg.0
+			IL_0131: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_0136: stloc.s 30
+			IL_0138: ldarg.0
+			IL_0139: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_013e: ldnull
+			IL_013f: ldloc.s 30
+			IL_0141: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_0146: stloc.s 6
+			IL_0148: ldarg.0
+			IL_0149: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_014e: stloc.s 30
+			IL_0150: ldarg.0
+			IL_0151: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0156: ldnull
+			IL_0157: ldloc.s 30
+			IL_0159: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_015e: stloc.s 7
+			IL_0160: ldarg.0
+			IL_0161: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_0166: stloc.s 30
+			IL_0168: ldarg.0
+			IL_0169: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_016e: ldnull
+			IL_016f: ldloc.s 30
+			IL_0171: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_0176: stloc.s 8
+			IL_0178: ldnull
+			IL_0179: ldloc.3
+			IL_017a: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
+			IL_017f: stloc.s 9
+			IL_0181: ldarg.0
+			IL_0182: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0187: ldnull
+			IL_0188: ldloc.1
+			IL_0189: ldloc.s 9
+			IL_018b: call object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0190: stloc.s 10
+			IL_0192: ldloc.s 9
+			IL_0194: ldloc.s 10
+			IL_0196: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_019b: stloc.s 31
+			IL_019d: ldloc.s 31
+			IL_019f: brfalse IL_0269
 
-			IL_020a: ldstr "console"
-			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0219: stloc.s 30
-			IL_021b: ldloc.s 9
-			IL_021d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0222: stloc.s 33
-			IL_0224: ldstr "Version unchanged ("
-			IL_0229: ldloc.s 33
-			IL_022b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0230: ldstr "); aborting."
-			IL_0235: call string [System.Runtime]System.String::Concat(string, string)
-			IL_023a: stloc.s 33
-			IL_023c: volatile.
-			IL_023e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_0243: brfalse IL_025b
+			IL_01a4: ldstr "console"
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b3: stloc.s 30
+			IL_01b5: ldloc.s 9
+			IL_01b7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01bc: stloc.s 32
+			IL_01be: ldstr "Version unchanged ("
+			IL_01c3: ldloc.s 32
+			IL_01c5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ca: ldstr "); aborting."
+			IL_01cf: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01d4: stloc.s 32
+			IL_01d6: volatile.
+			IL_01d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_01dd: brfalse IL_01f5
 
-			IL_0248: ldloc.s 30
-			IL_024a: ldstr "error"
-			IL_024f: ldloc.s 33
-			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0256: br IL_0273
+			IL_01e2: ldloc.s 30
+			IL_01e4: ldstr "error"
+			IL_01e9: ldloc.s 32
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01f0: br IL_020d
 
-			IL_025b: ldloc.s 30
-			IL_025d: ldstr "error"
-			IL_0262: ldloc.s 33
-			IL_0264: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:76"
-			IL_0269: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
-			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_01f5: ldloc.s 30
+			IL_01f7: ldstr "error"
+			IL_01fc: ldloc.s 32
+			IL_01fe: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:68"
+			IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_48
+			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0273: pop
-			IL_0274: ldstr "process"
-			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0283: volatile.
-			IL_0285: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-			IL_028a: brfalse IL_02ac
+			IL_020d: pop
+			IL_020e: ldstr "process"
+			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021d: volatile.
+			IL_021f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_0224: brfalse IL_0246
 
-			IL_028f: ldstr "exit"
-			IL_0294: ldc.r8 1
-			IL_029d: box [System.Runtime]System.Double
-			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02a7: br IL_02ce
+			IL_0229: ldstr "exit"
+			IL_022e: ldc.r8 1
+			IL_0237: box [System.Runtime]System.Double
+			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0241: br IL_0268
 
-			IL_02ac: ldstr "exit"
-			IL_02b1: ldc.r8 1
-			IL_02ba: box [System.Runtime]System.Double
-			IL_02bf: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:83"
-			IL_02c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0246: ldstr "exit"
+			IL_024b: ldc.r8 1
+			IL_0254: box [System.Runtime]System.Double
+			IL_0259: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:75"
+			IL_025e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_49
+			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_02ce: pop
+			IL_0268: pop
 
-			IL_02cf: ldarg.0
-			IL_02d0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
-			IL_02d5: ldc.i4.1
-			IL_02d6: newarr [System.Runtime]System.Object
-			IL_02db: dup
-			IL_02dc: ldc.i4.0
-			IL_02dd: ldarg.0
-			IL_02de: stelem.ref
-			IL_02df: ldloc.s 8
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_02e6: stloc.s 30
-			IL_02e8: ldloc.s 30
-			IL_02ea: brfalse IL_02fb
+			IL_0269: ldarg.0
+			IL_026a: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_026f: ldnull
+			IL_0270: ldloc.s 8
+			IL_0272: call object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_0277: stloc.s 30
+			IL_0279: ldloc.s 30
+			IL_027b: brfalse IL_028c
+
+			IL_0280: ldloc.s 30
+			IL_0282: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0287: brfalse IL_029d
+
+			IL_028c: ldloc.s 30
+			IL_028e: ldstr ""
+			IL_0293: ldstr "body"
+			IL_0298: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+
+			IL_029d: volatile.
+			IL_029f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_02a4: brfalse IL_02ba
+
+			IL_02a9: ldloc.s 30
+			IL_02ab: ldstr "body"
+			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02b5: br IL_02d0
+
+			IL_02ba: ldloc.s 30
+			IL_02bc: ldstr "body"
+			IL_02c1: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:89"
+			IL_02c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+			IL_02d0: stloc.s 11
+			IL_02d2: volatile.
+			IL_02d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_02d9: brfalse IL_02ef
+
+			IL_02de: ldloc.s 30
+			IL_02e0: ldstr "start"
+			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ea: br IL_0305
 
 			IL_02ef: ldloc.s 30
-			IL_02f1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_02f6: brfalse IL_030c
+			IL_02f1: ldstr "start"
+			IL_02f6: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:91"
+			IL_02fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02fb: ldloc.s 30
-			IL_02fd: ldstr ""
-			IL_0302: ldstr "body"
-			IL_0307: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0305: stloc.s 12
+			IL_0307: volatile.
+			IL_0309: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_030e: brfalse IL_0324
 
-			IL_030c: volatile.
-			IL_030e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-			IL_0313: brfalse IL_0329
+			IL_0313: ldloc.s 30
+			IL_0315: ldstr "end"
+			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_031f: br IL_033a
 
-			IL_0318: ldloc.s 30
-			IL_031a: ldstr "body"
-			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0324: br IL_033f
+			IL_0324: ldloc.s 30
+			IL_0326: ldstr "end"
+			IL_032b: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:93"
+			IL_0330: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0329: ldloc.s 30
-			IL_032b: ldstr "body"
-			IL_0330: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:98"
-			IL_0335: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_50
-			IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_033a: stloc.s 13
+			IL_033c: ldloc.s 11
+			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0343: stloc.s 30
+			IL_0345: ldstr "\\r?\\n"
+			IL_034a: ldstr ""
+			IL_034f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0354: stloc.s 33
+			IL_0356: volatile.
+			IL_0358: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_035d: brfalse IL_0375
 
-			IL_033f: stloc.s 11
-			IL_0341: volatile.
-			IL_0343: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-			IL_0348: brfalse IL_035e
+			IL_0362: ldloc.s 30
+			IL_0364: ldstr "split"
+			IL_0369: ldloc.s 33
+			IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0370: br IL_038d
 
-			IL_034d: ldloc.s 30
-			IL_034f: ldstr "start"
-			IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0359: br IL_0374
+			IL_0375: ldloc.s 30
+			IL_0377: ldstr "split"
+			IL_037c: ldloc.s 33
+			IL_037e: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:99"
+			IL_0383: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+			IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_035e: ldloc.s 30
-			IL_0360: ldstr "start"
-			IL_0365: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:100"
-			IL_036a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_51
-			IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_038d: stloc.s 30
+			IL_038f: ldloc.s 30
+			IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0396: stloc.s 30
+			IL_0398: ldc.i4.2
+			IL_0399: newarr [System.Runtime]System.Object
+			IL_039e: dup
+			IL_039f: ldc.i4.0
+			IL_03a0: ldarg.0
+			IL_03a1: stelem.ref
+			IL_03a2: dup
+			IL_03a3: ldc.i4.1
+			IL_03a4: ldloc.0
+			IL_03a5: stelem.ref
+			IL_03a6: stloc.s 34
+			IL_03a8: ldloc.s 34
+			IL_03aa: ldc.i4.0
+			IL_03ab: ldelem.ref
+			IL_03ac: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_03b1: ldloc.s 34
+			IL_03b3: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
+			IL_03b8: ldc.i4.1
+			IL_03b9: conv.r8
+			IL_03ba: ldstr ""
+			IL_03bf: ldc.i4.0
+			IL_03c0: ldc.i4.0
+			IL_03c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_03c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0)
+			IL_03cb: stloc.s 35
+			IL_03cd: volatile.
+			IL_03cf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_03d4: brfalse IL_03ec
 
-			IL_0374: stloc.s 12
-			IL_0376: volatile.
-			IL_0378: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-			IL_037d: brfalse IL_0393
+			IL_03d9: ldloc.s 30
+			IL_03db: ldstr "some"
+			IL_03e0: ldloc.s 35
+			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03e7: br IL_0404
 
-			IL_0382: ldloc.s 30
-			IL_0384: ldstr "end"
-			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_038e: br IL_03a9
+			IL_03ec: ldloc.s 30
+			IL_03ee: ldstr "some"
+			IL_03f3: ldloc.s 35
+			IL_03f5: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:103"
+			IL_03fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+			IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0393: ldloc.s 30
-			IL_0395: ldstr "end"
-			IL_039a: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:102"
-			IL_039f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-			IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0404: stloc.s 14
+			IL_0406: ldloc.s 14
+			IL_0408: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_040d: ldc.i4.0
+			IL_040e: ceq
+			IL_0410: stloc.s 31
+			IL_0412: ldloc.s 31
+			IL_0414: box [System.Runtime]System.Boolean
+			IL_0419: stloc.s 36
+			IL_041b: ldloc.s 36
+			IL_041d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0422: stloc.s 31
+			IL_0424: ldloc.s 31
+			IL_0426: brfalse IL_0433
 
-			IL_03a9: stloc.s 13
-			IL_03ab: ldloc.s 11
-			IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b2: stloc.s 30
-			IL_03b4: ldstr "\\r?\\n"
-			IL_03b9: ldstr ""
-			IL_03be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_03c3: stloc.s 34
-			IL_03c5: volatile.
-			IL_03c7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-			IL_03cc: brfalse IL_03e4
+			IL_042b: ldloc.2
+			IL_042c: stloc.s 38
+			IL_042e: br IL_0437
 
-			IL_03d1: ldloc.s 30
-			IL_03d3: ldstr "split"
-			IL_03d8: ldloc.s 34
-			IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03df: br IL_03fc
+			IL_0433: ldloc.s 36
+			IL_0435: stloc.s 38
 
-			IL_03e4: ldloc.s 30
-			IL_03e6: ldstr "split"
-			IL_03eb: ldloc.s 34
-			IL_03ed: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:108"
-			IL_03f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-			IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0437: ldloc.s 38
+			IL_0439: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_043e: stloc.s 31
+			IL_0440: ldloc.s 31
+			IL_0442: brfalse IL_0515
 
-			IL_03fc: stloc.s 30
-			IL_03fe: ldloc.s 30
-			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0405: stloc.s 30
-			IL_0407: ldc.i4.2
-			IL_0408: newarr [System.Runtime]System.Object
-			IL_040d: dup
-			IL_040e: ldc.i4.0
-			IL_040f: ldarg.0
-			IL_0410: stelem.ref
-			IL_0411: dup
-			IL_0412: ldc.i4.1
-			IL_0413: ldloc.0
-			IL_0414: stelem.ref
-			IL_0415: stloc.s 31
-			IL_0417: ldloc.s 31
-			IL_0419: ldc.i4.0
-			IL_041a: ldelem.ref
-			IL_041b: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0420: ldloc.s 31
-			IL_0422: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
-			IL_0427: ldc.i4.1
-			IL_0428: conv.r8
-			IL_0429: ldstr ""
-			IL_042e: ldc.i4.0
-			IL_042f: ldc.i4.0
-			IL_0430: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0435: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0)
-			IL_043a: stloc.s 35
-			IL_043c: volatile.
-			IL_043e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-			IL_0443: brfalse IL_045b
+			IL_0447: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_044c: stloc.s 39
+			IL_044e: ldloc.s 39
+			IL_0450: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
+			IL_0455: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_045a: pop
+			IL_045b: ldnull
+			IL_045c: ldloc.3
+			IL_045d: ldloc.s 10
+			IL_045f: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0464: stloc.s 15
+			IL_0466: ldnull
+			IL_0467: ldloc.s 4
+			IL_0469: ldloc.s 10
+			IL_046b: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0470: stloc.s 16
+			IL_0472: ldnull
+			IL_0473: ldloc.s 5
+			IL_0475: ldloc.s 10
+			IL_0477: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_047c: stloc.s 17
+			IL_047e: ldnull
+			IL_047f: ldloc.s 6
+			IL_0481: ldloc.s 10
+			IL_0483: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0488: stloc.s 18
+			IL_048a: ldnull
+			IL_048b: ldloc.s 7
+			IL_048d: ldloc.s 10
+			IL_048f: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
+			IL_0494: stloc.s 19
+			IL_0496: ldarg.0
+			IL_0497: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_049c: stloc.s 30
+			IL_049e: ldarg.0
+			IL_049f: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_04a4: ldnull
+			IL_04a5: ldloc.s 30
+			IL_04a7: ldloc.s 15
+			IL_04a9: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_04ae: pop
+			IL_04af: ldarg.0
+			IL_04b0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_04b5: stloc.s 30
+			IL_04b7: ldarg.0
+			IL_04b8: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_04bd: ldnull
+			IL_04be: ldloc.s 30
+			IL_04c0: ldloc.s 16
+			IL_04c2: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_04c7: pop
+			IL_04c8: ldarg.0
+			IL_04c9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_04ce: stloc.s 30
+			IL_04d0: ldarg.0
+			IL_04d1: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_04d6: ldnull
+			IL_04d7: ldloc.s 30
+			IL_04d9: ldloc.s 17
+			IL_04db: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_04e0: pop
+			IL_04e1: ldarg.0
+			IL_04e2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_04e7: stloc.s 30
+			IL_04e9: ldarg.0
+			IL_04ea: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_04ef: ldnull
+			IL_04f0: ldloc.s 30
+			IL_04f2: ldloc.s 18
+			IL_04f4: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_04f9: pop
+			IL_04fa: ldarg.0
+			IL_04fb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_0500: stloc.s 30
+			IL_0502: ldarg.0
+			IL_0503: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0508: ldnull
+			IL_0509: ldloc.s 30
+			IL_050b: ldloc.s 19
+			IL_050d: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0512: pop
+			IL_0513: ldnull
+			IL_0514: ret
 
-			IL_0448: ldloc.s 30
-			IL_044a: ldstr "some"
-			IL_044f: ldloc.s 35
-			IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0456: br IL_0473
+			IL_0515: ldarg.0
+			IL_0516: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_051b: ldnull
+			IL_051c: ldloc.s 10
+			IL_051e: ldloc.s 11
+			IL_0520: call object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0525: stloc.s 20
+			IL_0527: ldloc.s 8
+			IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_052e: stloc.s 30
+			IL_0530: ldc.i4.0
+			IL_0531: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0536: brfalse IL_0578
 
-			IL_045b: ldloc.s 30
-			IL_045d: ldstr "some"
-			IL_0462: ldloc.s 35
-			IL_0464: ldstr "Compile_Scripts_BumpVersion:<TwoPhaseDummy_M14>:__js_call__:112"
-			IL_0469: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_053b: ldloc.s 30
+			IL_053d: isinst [System.Runtime]System.String
+			IL_0542: dup
+			IL_0543: brtrue IL_055b
 
-			IL_0473: stloc.s 14
-			IL_0475: ldloc.s 14
-			IL_0477: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_047c: ldc.i4.0
-			IL_047d: ceq
-			IL_047f: stloc.s 32
-			IL_0481: ldloc.s 32
-			IL_0483: box [System.Runtime]System.Boolean
-			IL_0488: stloc.s 36
-			IL_048a: ldloc.s 36
-			IL_048c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0491: stloc.s 32
-			IL_0493: ldloc.s 32
-			IL_0495: brfalse IL_04a2
+			IL_0548: pop
+			IL_0549: ldloc.s 30
+			IL_054b: ldstr "slice"
+			IL_0550: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0555: dup
+			IL_0556: brfalse IL_0577
 
-			IL_049a: ldloc.2
-			IL_049b: stloc.s 38
-			IL_049d: br IL_04a6
+			IL_055b: ldc.r8 0.0
+			IL_0564: box [System.Runtime]System.Double
+			IL_0569: ldloc.s 12
+			IL_056b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_0570: stloc.s 21
+			IL_0572: br IL_0596
 
-			IL_04a2: ldloc.s 36
-			IL_04a4: stloc.s 38
+			IL_0577: pop
 
-			IL_04a6: ldloc.s 38
-			IL_04a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04ad: stloc.s 32
-			IL_04af: ldloc.s 32
-			IL_04b1: brfalse IL_0624
+			IL_0578: ldloc.s 30
+			IL_057a: ldstr "slice"
+			IL_057f: ldc.r8 0.0
+			IL_0588: box [System.Runtime]System.Double
+			IL_058d: ldloc.s 12
+			IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0594: stloc.s 21
 
-			IL_04b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04bb: stloc.s 39
-			IL_04bd: ldloc.s 39
-			IL_04bf: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
-			IL_04c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04c9: pop
-			IL_04ca: ldarg.0
-			IL_04cb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_04d0: ldc.i4.1
-			IL_04d1: newarr [System.Runtime]System.Object
-			IL_04d6: dup
-			IL_04d7: ldc.i4.0
-			IL_04d8: ldarg.0
-			IL_04d9: stelem.ref
-			IL_04da: ldloc.3
-			IL_04db: ldloc.s 10
-			IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04e2: stloc.s 15
-			IL_04e4: ldarg.0
-			IL_04e5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_04ea: ldc.i4.1
-			IL_04eb: newarr [System.Runtime]System.Object
-			IL_04f0: dup
-			IL_04f1: ldc.i4.0
-			IL_04f2: ldarg.0
-			IL_04f3: stelem.ref
-			IL_04f4: ldloc.s 4
-			IL_04f6: ldloc.s 10
-			IL_04f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04fd: stloc.s 16
-			IL_04ff: ldarg.0
-			IL_0500: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0505: ldc.i4.1
-			IL_0506: newarr [System.Runtime]System.Object
-			IL_050b: dup
-			IL_050c: ldc.i4.0
-			IL_050d: ldarg.0
-			IL_050e: stelem.ref
-			IL_050f: ldloc.s 5
-			IL_0511: ldloc.s 10
-			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0518: stloc.s 17
-			IL_051a: ldarg.0
-			IL_051b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0520: ldc.i4.1
-			IL_0521: newarr [System.Runtime]System.Object
-			IL_0526: dup
-			IL_0527: ldc.i4.0
-			IL_0528: ldarg.0
-			IL_0529: stelem.ref
-			IL_052a: ldloc.s 6
-			IL_052c: ldloc.s 10
-			IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0533: stloc.s 18
-			IL_0535: ldarg.0
-			IL_0536: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_053b: ldc.i4.1
-			IL_053c: newarr [System.Runtime]System.Object
-			IL_0541: dup
-			IL_0542: ldc.i4.0
-			IL_0543: ldarg.0
-			IL_0544: stelem.ref
-			IL_0545: ldloc.s 7
-			IL_0547: ldloc.s 10
-			IL_0549: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_054e: stloc.s 19
-			IL_0550: ldarg.0
-			IL_0551: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0556: stloc.s 30
-			IL_0558: ldc.i4.1
-			IL_0559: newarr [System.Runtime]System.Object
-			IL_055e: dup
-			IL_055f: ldc.i4.0
-			IL_0560: ldarg.0
-			IL_0561: stelem.ref
-			IL_0562: stloc.s 31
-			IL_0564: ldarg.0
-			IL_0565: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_056a: stloc.s 40
-			IL_056c: ldloc.s 30
-			IL_056e: ldloc.s 31
-			IL_0570: ldloc.s 40
-			IL_0572: ldloc.s 15
-			IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0579: pop
-			IL_057a: ldarg.0
-			IL_057b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0580: stloc.s 40
-			IL_0582: ldc.i4.1
-			IL_0583: newarr [System.Runtime]System.Object
-			IL_0588: dup
-			IL_0589: ldc.i4.0
-			IL_058a: ldarg.0
-			IL_058b: stelem.ref
-			IL_058c: stloc.s 31
-			IL_058e: ldarg.0
-			IL_058f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0594: stloc.s 30
-			IL_0596: ldloc.s 40
-			IL_0598: ldloc.s 31
-			IL_059a: ldloc.s 30
-			IL_059c: ldloc.s 16
-			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05a3: pop
-			IL_05a4: ldarg.0
-			IL_05a5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_05aa: stloc.s 30
-			IL_05ac: ldc.i4.1
-			IL_05ad: newarr [System.Runtime]System.Object
-			IL_05b2: dup
-			IL_05b3: ldc.i4.0
-			IL_05b4: ldarg.0
-			IL_05b5: stelem.ref
-			IL_05b6: stloc.s 31
-			IL_05b8: ldarg.0
-			IL_05b9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_05be: stloc.s 40
-			IL_05c0: ldloc.s 30
-			IL_05c2: ldloc.s 31
-			IL_05c4: ldloc.s 40
-			IL_05c6: ldloc.s 17
-			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05cd: pop
-			IL_05ce: ldarg.0
-			IL_05cf: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_05d4: stloc.s 40
-			IL_05d6: ldc.i4.1
-			IL_05d7: newarr [System.Runtime]System.Object
-			IL_05dc: dup
-			IL_05dd: ldc.i4.0
-			IL_05de: ldarg.0
-			IL_05df: stelem.ref
-			IL_05e0: stloc.s 31
-			IL_05e2: ldarg.0
-			IL_05e3: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_05e8: stloc.s 30
-			IL_05ea: ldloc.s 40
-			IL_05ec: ldloc.s 31
-			IL_05ee: ldloc.s 30
-			IL_05f0: ldloc.s 18
-			IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05f7: pop
-			IL_05f8: ldarg.0
-			IL_05f9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_05fe: stloc.s 30
-			IL_0600: ldc.i4.1
-			IL_0601: newarr [System.Runtime]System.Object
-			IL_0606: dup
-			IL_0607: ldc.i4.0
-			IL_0608: ldarg.0
-			IL_0609: stelem.ref
-			IL_060a: stloc.s 31
-			IL_060c: ldarg.0
-			IL_060d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_0612: stloc.s 40
-			IL_0614: ldloc.s 30
-			IL_0616: ldloc.s 31
-			IL_0618: ldloc.s 40
-			IL_061a: ldloc.s 19
-			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0621: pop
-			IL_0622: ldnull
-			IL_0623: ret
+			IL_0596: ldloc.s 8
+			IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_059d: stloc.s 30
+			IL_059f: ldc.i4.0
+			IL_05a0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_05a5: brfalse IL_05d9
 
-			IL_0624: ldarg.0
-			IL_0625: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
-			IL_062a: ldc.i4.1
-			IL_062b: newarr [System.Runtime]System.Object
-			IL_0630: dup
-			IL_0631: ldc.i4.0
-			IL_0632: ldarg.0
-			IL_0633: stelem.ref
-			IL_0634: ldloc.s 10
-			IL_0636: ldloc.s 11
-			IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_063d: stloc.s 20
-			IL_063f: ldloc.s 8
-			IL_0641: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0646: stloc.s 40
-			IL_0648: ldc.i4.0
-			IL_0649: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_064e: brfalse IL_0690
+			IL_05aa: ldloc.s 30
+			IL_05ac: isinst [System.Runtime]System.String
+			IL_05b1: dup
+			IL_05b2: brtrue IL_05ca
 
-			IL_0653: ldloc.s 40
-			IL_0655: isinst [System.Runtime]System.String
-			IL_065a: dup
-			IL_065b: brtrue IL_0673
+			IL_05b7: pop
+			IL_05b8: ldloc.s 30
+			IL_05ba: ldstr "slice"
+			IL_05bf: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_05c4: dup
+			IL_05c5: brfalse IL_05d8
 
-			IL_0660: pop
-			IL_0661: ldloc.s 40
-			IL_0663: ldstr "slice"
-			IL_0668: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_066d: dup
-			IL_066e: brfalse IL_068f
+			IL_05ca: ldloc.s 13
+			IL_05cc: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_05d1: stloc.s 22
+			IL_05d3: br IL_05e9
 
-			IL_0673: ldc.r8 0.0
-			IL_067c: box [System.Runtime]System.Double
-			IL_0681: ldloc.s 12
-			IL_0683: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-			IL_0688: stloc.s 21
-			IL_068a: br IL_06ae
+			IL_05d8: pop
 
-			IL_068f: pop
+			IL_05d9: ldloc.s 30
+			IL_05db: ldstr "slice"
+			IL_05e0: ldloc.s 13
+			IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05e7: stloc.s 22
 
-			IL_0690: ldloc.s 40
-			IL_0692: ldstr "slice"
-			IL_0697: ldc.r8 0.0
-			IL_06a0: box [System.Runtime]System.Double
-			IL_06a5: ldloc.s 12
-			IL_06a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_06ac: stloc.s 21
-
-			IL_06ae: ldloc.s 8
-			IL_06b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06b5: stloc.s 40
-			IL_06b7: ldc.i4.0
-			IL_06b8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_06bd: brfalse IL_06f1
-
-			IL_06c2: ldloc.s 40
-			IL_06c4: isinst [System.Runtime]System.String
-			IL_06c9: dup
-			IL_06ca: brtrue IL_06e2
-
-			IL_06cf: pop
-			IL_06d0: ldloc.s 40
-			IL_06d2: ldstr "slice"
-			IL_06d7: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_06dc: dup
-			IL_06dd: brfalse IL_06f0
-
-			IL_06e2: ldloc.s 13
-			IL_06e4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
-			IL_06e9: stloc.s 22
-			IL_06eb: br IL_0701
-
-			IL_06f0: pop
-
-			IL_06f1: ldloc.s 40
-			IL_06f3: ldstr "slice"
-			IL_06f8: ldloc.s 13
-			IL_06fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06ff: stloc.s 22
-
-			IL_0701: ldstr "\n_Nothing yet._\n\n"
-			IL_0706: stloc.s 23
-			IL_0708: ldloc.s 21
-			IL_070a: ldloc.s 23
-			IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0711: stloc.s 38
-			IL_0713: ldloc.s 38
-			IL_0715: ldloc.s 20
-			IL_0717: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_071c: stloc.s 38
-			IL_071e: ldloc.s 38
-			IL_0720: ldloc.s 22
-			IL_0722: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0727: stloc.s 24
-			IL_0729: ldarg.0
-			IL_072a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_072f: ldc.i4.1
-			IL_0730: newarr [System.Runtime]System.Object
-			IL_0735: dup
-			IL_0736: ldc.i4.0
-			IL_0737: ldarg.0
-			IL_0738: stelem.ref
-			IL_0739: ldloc.3
-			IL_073a: ldloc.s 10
-			IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0741: stloc.s 25
-			IL_0743: ldarg.0
-			IL_0744: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0749: ldc.i4.1
-			IL_074a: newarr [System.Runtime]System.Object
-			IL_074f: dup
-			IL_0750: ldc.i4.0
-			IL_0751: ldarg.0
-			IL_0752: stelem.ref
-			IL_0753: ldloc.s 4
-			IL_0755: ldloc.s 10
-			IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_075c: stloc.s 26
-			IL_075e: ldarg.0
-			IL_075f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0764: ldc.i4.1
-			IL_0765: newarr [System.Runtime]System.Object
-			IL_076a: dup
-			IL_076b: ldc.i4.0
-			IL_076c: ldarg.0
-			IL_076d: stelem.ref
-			IL_076e: ldloc.s 5
-			IL_0770: ldloc.s 10
-			IL_0772: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0777: stloc.s 27
-			IL_0779: ldarg.0
-			IL_077a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_077f: ldc.i4.1
-			IL_0780: newarr [System.Runtime]System.Object
-			IL_0785: dup
-			IL_0786: ldc.i4.0
-			IL_0787: ldarg.0
-			IL_0788: stelem.ref
-			IL_0789: ldloc.s 6
-			IL_078b: ldloc.s 10
-			IL_078d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0792: stloc.s 28
-			IL_0794: ldarg.0
-			IL_0795: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_079a: ldc.i4.1
-			IL_079b: newarr [System.Runtime]System.Object
-			IL_07a0: dup
-			IL_07a1: ldc.i4.0
-			IL_07a2: ldarg.0
-			IL_07a3: stelem.ref
-			IL_07a4: ldloc.s 7
-			IL_07a6: ldloc.s 10
-			IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07ad: stloc.s 29
-			IL_07af: ldarg.0
-			IL_07b0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_07b5: stloc.s 40
-			IL_07b7: ldc.i4.1
-			IL_07b8: newarr [System.Runtime]System.Object
-			IL_07bd: dup
-			IL_07be: ldc.i4.0
-			IL_07bf: ldarg.0
-			IL_07c0: stelem.ref
-			IL_07c1: stloc.s 31
-			IL_07c3: ldarg.0
-			IL_07c4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_07c9: stloc.s 30
-			IL_07cb: ldloc.s 40
-			IL_07cd: ldloc.s 31
-			IL_07cf: ldloc.s 30
-			IL_07d1: ldloc.s 24
-			IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_07d8: pop
-			IL_07d9: ldarg.0
-			IL_07da: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_07df: stloc.s 30
-			IL_07e1: ldc.i4.1
-			IL_07e2: newarr [System.Runtime]System.Object
-			IL_07e7: dup
-			IL_07e8: ldc.i4.0
-			IL_07e9: ldarg.0
-			IL_07ea: stelem.ref
-			IL_07eb: stloc.s 31
-			IL_07ed: ldarg.0
-			IL_07ee: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_07f3: stloc.s 40
-			IL_07f5: ldloc.s 30
-			IL_07f7: ldloc.s 31
-			IL_07f9: ldloc.s 40
-			IL_07fb: ldloc.s 25
-			IL_07fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0802: pop
-			IL_0803: ldarg.0
-			IL_0804: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0809: stloc.s 40
-			IL_080b: ldc.i4.1
-			IL_080c: newarr [System.Runtime]System.Object
-			IL_0811: dup
-			IL_0812: ldc.i4.0
-			IL_0813: ldarg.0
-			IL_0814: stelem.ref
-			IL_0815: stloc.s 31
-			IL_0817: ldarg.0
-			IL_0818: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_081d: stloc.s 30
-			IL_081f: ldloc.s 40
-			IL_0821: ldloc.s 31
-			IL_0823: ldloc.s 30
-			IL_0825: ldloc.s 26
-			IL_0827: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_082c: pop
-			IL_082d: ldarg.0
-			IL_082e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0833: stloc.s 30
-			IL_0835: ldc.i4.1
-			IL_0836: newarr [System.Runtime]System.Object
-			IL_083b: dup
-			IL_083c: ldc.i4.0
-			IL_083d: ldarg.0
-			IL_083e: stelem.ref
-			IL_083f: stloc.s 31
-			IL_0841: ldarg.0
-			IL_0842: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0847: stloc.s 40
-			IL_0849: ldloc.s 30
-			IL_084b: ldloc.s 31
-			IL_084d: ldloc.s 40
-			IL_084f: ldloc.s 27
-			IL_0851: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0856: pop
-			IL_0857: ldarg.0
-			IL_0858: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_085d: stloc.s 40
-			IL_085f: ldc.i4.1
-			IL_0860: newarr [System.Runtime]System.Object
-			IL_0865: dup
-			IL_0866: ldc.i4.0
-			IL_0867: ldarg.0
-			IL_0868: stelem.ref
-			IL_0869: stloc.s 31
-			IL_086b: ldarg.0
-			IL_086c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0871: stloc.s 30
-			IL_0873: ldloc.s 40
-			IL_0875: ldloc.s 31
-			IL_0877: ldloc.s 30
-			IL_0879: ldloc.s 28
-			IL_087b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0880: pop
-			IL_0881: ldarg.0
-			IL_0882: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0887: stloc.s 30
-			IL_0889: ldc.i4.1
-			IL_088a: newarr [System.Runtime]System.Object
-			IL_088f: dup
-			IL_0890: ldc.i4.0
-			IL_0891: ldarg.0
-			IL_0892: stelem.ref
-			IL_0893: stloc.s 31
-			IL_0895: ldarg.0
-			IL_0896: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_089b: stloc.s 40
-			IL_089d: ldloc.s 30
-			IL_089f: ldloc.s 31
-			IL_08a1: ldloc.s 40
-			IL_08a3: ldloc.s 29
-			IL_08a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_08aa: pop
-			IL_08ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08b0: stloc.s 39
-			IL_08b2: ldloc.s 9
-			IL_08b4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08b9: stloc.s 33
-			IL_08bb: ldstr "Bumped version: "
-			IL_08c0: ldloc.s 33
-			IL_08c2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08c7: ldstr " -> "
-			IL_08cc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08d1: ldloc.s 10
-			IL_08d3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08d8: stloc.s 33
-			IL_08da: ldloc.s 33
-			IL_08dc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08e1: stloc.s 33
-			IL_08e3: ldloc.s 39
-			IL_08e5: ldloc.s 33
-			IL_08e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08ec: pop
-			IL_08ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08f2: stloc.s 39
-			IL_08f4: ldloc.s 39
-			IL_08f6: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_08fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0900: pop
-			IL_0901: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0906: stloc.s 39
-			IL_0908: ldloc.s 39
-			IL_090a: ldstr "\nNext steps:"
-			IL_090f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0914: pop
-			IL_0915: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_091a: stloc.s 39
-			IL_091c: ldloc.s 39
-			IL_091e: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0923: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0928: pop
-			IL_0929: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_092e: stloc.s 39
-			IL_0930: ldloc.s 10
-			IL_0932: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0937: stloc.s 33
-			IL_0939: ldstr "  git commit -m \"chore(release): cut "
-			IL_093e: ldloc.s 33
-			IL_0940: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0945: ldstr "\""
-			IL_094a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_094f: stloc.s 33
-			IL_0951: ldloc.s 39
-			IL_0953: ldloc.s 33
-			IL_0955: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_095a: pop
-			IL_095b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0960: stloc.s 39
-			IL_0962: ldloc.s 10
-			IL_0964: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0969: stloc.s 33
-			IL_096b: ldstr "  git tag -a v"
-			IL_0970: ldloc.s 33
-			IL_0972: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0977: ldstr " -m \"Release "
-			IL_097c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0981: ldloc.s 10
-			IL_0983: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0988: stloc.s 33
-			IL_098a: ldloc.s 33
-			IL_098c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0991: ldstr "\""
-			IL_0996: call string [System.Runtime]System.String::Concat(string, string)
-			IL_099b: stloc.s 33
-			IL_099d: ldloc.s 39
-			IL_099f: ldloc.s 33
-			IL_09a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_09a6: pop
-			IL_09a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09ac: stloc.s 39
-			IL_09ae: ldloc.s 39
-			IL_09b0: ldstr "  git push && git push --tags"
-			IL_09b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_09ba: pop
-			IL_09bb: ldnull
-			IL_09bc: ret
+			IL_05e9: ldstr "\n_Nothing yet._\n\n"
+			IL_05ee: stloc.s 23
+			IL_05f0: ldloc.s 21
+			IL_05f2: ldloc.s 23
+			IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05f9: stloc.s 38
+			IL_05fb: ldloc.s 38
+			IL_05fd: ldloc.s 20
+			IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0604: stloc.s 38
+			IL_0606: ldloc.s 38
+			IL_0608: ldloc.s 22
+			IL_060a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_060f: stloc.s 24
+			IL_0611: ldnull
+			IL_0612: ldloc.3
+			IL_0613: ldloc.s 10
+			IL_0615: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_061a: stloc.s 25
+			IL_061c: ldnull
+			IL_061d: ldloc.s 4
+			IL_061f: ldloc.s 10
+			IL_0621: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0626: stloc.s 26
+			IL_0628: ldnull
+			IL_0629: ldloc.s 5
+			IL_062b: ldloc.s 10
+			IL_062d: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0632: stloc.s 27
+			IL_0634: ldnull
+			IL_0635: ldloc.s 6
+			IL_0637: ldloc.s 10
+			IL_0639: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_063e: stloc.s 28
+			IL_0640: ldnull
+			IL_0641: ldloc.s 7
+			IL_0643: ldloc.s 10
+			IL_0645: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
+			IL_064a: stloc.s 29
+			IL_064c: ldarg.0
+			IL_064d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_0652: stloc.s 30
+			IL_0654: ldarg.0
+			IL_0655: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_065a: ldnull
+			IL_065b: ldloc.s 30
+			IL_065d: ldloc.s 24
+			IL_065f: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0664: pop
+			IL_0665: ldarg.0
+			IL_0666: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_066b: stloc.s 30
+			IL_066d: ldarg.0
+			IL_066e: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0673: ldnull
+			IL_0674: ldloc.s 30
+			IL_0676: ldloc.s 25
+			IL_0678: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_067d: pop
+			IL_067e: ldarg.0
+			IL_067f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0684: stloc.s 30
+			IL_0686: ldarg.0
+			IL_0687: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_068c: ldnull
+			IL_068d: ldloc.s 30
+			IL_068f: ldloc.s 26
+			IL_0691: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0696: pop
+			IL_0697: ldarg.0
+			IL_0698: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_069d: stloc.s 30
+			IL_069f: ldarg.0
+			IL_06a0: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_06a5: ldnull
+			IL_06a6: ldloc.s 30
+			IL_06a8: ldloc.s 27
+			IL_06aa: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_06af: pop
+			IL_06b0: ldarg.0
+			IL_06b1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_06b6: stloc.s 30
+			IL_06b8: ldarg.0
+			IL_06b9: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_06be: ldnull
+			IL_06bf: ldloc.s 30
+			IL_06c1: ldloc.s 28
+			IL_06c3: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_06c8: pop
+			IL_06c9: ldarg.0
+			IL_06ca: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_06cf: stloc.s 30
+			IL_06d1: ldarg.0
+			IL_06d2: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_06d7: ldnull
+			IL_06d8: ldloc.s 30
+			IL_06da: ldloc.s 29
+			IL_06dc: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_06e1: pop
+			IL_06e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06e7: stloc.s 39
+			IL_06e9: ldloc.s 9
+			IL_06eb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06f0: stloc.s 32
+			IL_06f2: ldstr "Bumped version: "
+			IL_06f7: ldloc.s 32
+			IL_06f9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06fe: ldstr " -> "
+			IL_0703: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0708: ldloc.s 10
+			IL_070a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_070f: stloc.s 32
+			IL_0711: ldloc.s 32
+			IL_0713: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0718: stloc.s 32
+			IL_071a: ldloc.s 39
+			IL_071c: ldloc.s 32
+			IL_071e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0723: pop
+			IL_0724: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0729: stloc.s 39
+			IL_072b: ldloc.s 39
+			IL_072d: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_0732: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0737: pop
+			IL_0738: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_073d: stloc.s 39
+			IL_073f: ldloc.s 39
+			IL_0741: ldstr "\nNext steps:"
+			IL_0746: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_074b: pop
+			IL_074c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0751: stloc.s 39
+			IL_0753: ldloc.s 39
+			IL_0755: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_075a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_075f: pop
+			IL_0760: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0765: stloc.s 39
+			IL_0767: ldloc.s 10
+			IL_0769: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_076e: stloc.s 32
+			IL_0770: ldstr "  git commit -m \"chore(release): cut "
+			IL_0775: ldloc.s 32
+			IL_0777: call string [System.Runtime]System.String::Concat(string, string)
+			IL_077c: ldstr "\""
+			IL_0781: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0786: stloc.s 32
+			IL_0788: ldloc.s 39
+			IL_078a: ldloc.s 32
+			IL_078c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0791: pop
+			IL_0792: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0797: stloc.s 39
+			IL_0799: ldloc.s 10
+			IL_079b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07a0: stloc.s 32
+			IL_07a2: ldstr "  git tag -a v"
+			IL_07a7: ldloc.s 32
+			IL_07a9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07ae: ldstr " -m \"Release "
+			IL_07b3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07b8: ldloc.s 10
+			IL_07ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07bf: stloc.s 32
+			IL_07c1: ldloc.s 32
+			IL_07c3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07c8: ldstr "\""
+			IL_07cd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07d2: stloc.s 32
+			IL_07d4: ldloc.s 39
+			IL_07d6: ldloc.s 32
+			IL_07d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07dd: pop
+			IL_07de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07e3: stloc.s 39
+			IL_07e5: ldloc.s 39
+			IL_07e7: ldstr "  git push && git push --tags"
+			IL_07ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07f1: pop
+			IL_07f2: ldnull
+			IL_07f3: ret
 		} // end of method perform::__js_call__
 
 	} // end of class perform
@@ -4931,7 +4655,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1107 (0x453)
+		// Code size: 1108 (0x454)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_BumpVersion/Scope,
@@ -5350,90 +5074,91 @@
 		.try
 		{
 			IL_0351: nop
-			IL_0352: ldloc.1
-			IL_0353: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_035d: pop
-			IL_035e: leave IL_044f
+			IL_0352: ldloc.0
+			IL_0353: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0358: ldnull
+			IL_0359: call object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
+			IL_035e: pop
+			IL_035f: leave IL_0450
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0363: stloc.s 4
-			IL_0365: ldloc.s 4
-			IL_0367: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_036c: dup
-			IL_036d: brtrue IL_0383
+			IL_0364: stloc.s 4
+			IL_0366: ldloc.s 4
+			IL_0368: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_036d: dup
+			IL_036e: brtrue IL_0384
 
-			IL_0372: pop
-			IL_0373: ldloc.s 4
-			IL_0375: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_037a: dup
-			IL_037b: brtrue IL_038f
+			IL_0373: pop
+			IL_0374: ldloc.s 4
+			IL_0376: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_037b: dup
+			IL_037c: brtrue IL_0390
 
-			IL_0380: pop
-			IL_0381: rethrow
+			IL_0381: pop
+			IL_0382: rethrow
 
-			IL_0383: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0388: stloc.s 5
-			IL_038a: br IL_0391
+			IL_0384: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0389: stloc.s 5
+			IL_038b: br IL_0392
 
-			IL_038f: stloc.s 5
+			IL_0390: stloc.s 5
 
-			IL_0391: ldloc.s 5
-			IL_0393: stloc.s 6
-			IL_0395: ldstr "console"
-			IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03a4: stloc.s 20
-			IL_03a6: volatile.
-			IL_03a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-			IL_03ad: brfalse IL_03c3
+			IL_0392: ldloc.s 5
+			IL_0394: stloc.s 6
+			IL_0396: ldstr "console"
+			IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03a5: stloc.s 20
+			IL_03a7: volatile.
+			IL_03a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_03ae: brfalse IL_03c4
 
-			IL_03b2: ldloc.s 6
-			IL_03b4: ldstr "message"
-			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03be: br IL_03d9
+			IL_03b3: ldloc.s 6
+			IL_03b5: ldstr "message"
+			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03bf: br IL_03da
 
-			IL_03c3: ldloc.s 6
-			IL_03c5: ldstr "message"
-			IL_03ca: ldstr "Compile_Scripts_BumpVersion:Modules.Compile_Scripts_BumpVersion:__js_module_init__:114"
-			IL_03cf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-			IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03c4: ldloc.s 6
+			IL_03c6: ldstr "message"
+			IL_03cb: ldstr "Compile_Scripts_BumpVersion:Modules.Compile_Scripts_BumpVersion:__js_module_init__:114"
+			IL_03d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03d9: stloc.s 21
-			IL_03db: ldloc.s 20
-			IL_03dd: ldstr "error"
-			IL_03e2: ldstr "ERROR:"
-			IL_03e7: ldloc.s 21
-			IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_03ee: pop
-			IL_03ef: ldstr "process"
-			IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03fe: volatile.
-			IL_0400: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_0405: brfalse IL_0427
+			IL_03da: stloc.s 21
+			IL_03dc: ldloc.s 20
+			IL_03de: ldstr "error"
+			IL_03e3: ldstr "ERROR:"
+			IL_03e8: ldloc.s 21
+			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_03ef: pop
+			IL_03f0: ldstr "process"
+			IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ff: volatile.
+			IL_0401: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0406: brfalse IL_0428
 
-			IL_040a: ldstr "exit"
-			IL_040f: ldc.r8 1
-			IL_0418: box [System.Runtime]System.Double
-			IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0422: br IL_0449
+			IL_040b: ldstr "exit"
+			IL_0410: ldc.r8 1
+			IL_0419: box [System.Runtime]System.Double
+			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0423: br IL_044a
 
-			IL_0427: ldstr "exit"
-			IL_042c: ldc.r8 1
-			IL_0435: box [System.Runtime]System.Double
-			IL_043a: ldstr "Compile_Scripts_BumpVersion:Modules.Compile_Scripts_BumpVersion:__js_module_init__:122"
-			IL_043f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0428: ldstr "exit"
+			IL_042d: ldc.r8 1
+			IL_0436: box [System.Runtime]System.Double
+			IL_043b: ldstr "Compile_Scripts_BumpVersion:Modules.Compile_Scripts_BumpVersion:__js_module_init__:122"
+			IL_0440: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0449: pop
-			IL_044a: leave IL_044f
+			IL_044a: pop
+			IL_044b: leave IL_0450
 		} // end handler
 
-		IL_044f: ldnull
-		IL_0450: stloc.s 7
-		IL_0452: ret
+		IL_0450: ldnull
+		IL_0451: stloc.s 7
+		IL_0453: ret
 	} // end of method Compile_Scripts_BumpVersion::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_BumpVersion

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -2733,7 +2733,7 @@
 				74 61 54 6f 6b 65 6e 1d 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1365 (0x555)
+			// Code size: 1343 (0x53f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2743,500 +2743,487 @@
 				[4] object,
 				[5] object,
 				[6] object,
-				[7] object[],
-				[8] object,
-				[9] bool,
-				[10] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
-				[11] object,
-				[12] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
-				[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[14] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-				[15] string,
-				[16] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[7] object,
+				[8] bool,
+				[9] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
+				[10] object,
+				[11] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
+				[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[13] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[14] string,
+				[15] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::parseArgs
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.s 7
-			IL_0012: ldstr "process"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_001c: volatile.
-			IL_001e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0023: brfalse IL_0037
+			IL_0000: ldstr "process"
+			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_000a: volatile.
+			IL_000c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0011: brfalse IL_0025
 
-			IL_0028: ldstr "argv"
-			IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0032: br IL_004b
+			IL_0016: ldstr "argv"
+			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0020: br IL_0039
 
-			IL_0037: ldstr "argv"
-			IL_003c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:6"
-			IL_0041: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0025: ldstr "argv"
+			IL_002a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:4"
+			IL_002f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_004b: stloc.s 8
-			IL_004d: ldloc.s 7
-			IL_004f: ldloc.s 8
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0056: stloc.0
-			IL_0057: volatile.
-			IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_005e: brfalse IL_0073
+			IL_0039: stloc.s 7
+			IL_003b: ldarg.0
+			IL_003c: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
+			IL_0041: ldnull
+			IL_0042: ldloc.s 7
+			IL_0044: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
+			IL_0049: stloc.0
+			IL_004a: volatile.
+			IL_004c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0051: brfalse IL_0066
 
-			IL_0063: ldloc.0
-			IL_0064: ldstr "inFile"
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006e: br IL_0088
+			IL_0056: ldloc.0
+			IL_0057: ldstr "inFile"
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0061: br IL_007b
 
-			IL_0073: ldloc.0
-			IL_0074: ldstr "inFile"
-			IL_0079: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:11"
-			IL_007e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0066: ldloc.0
+			IL_0067: ldstr "inFile"
+			IL_006c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:10"
+			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0088: stloc.s 8
-			IL_008a: ldloc.s 8
-			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0091: ldc.i4.0
-			IL_0092: ceq
-			IL_0094: stloc.s 9
-			IL_0096: ldloc.s 9
-			IL_0098: brfalse IL_00bd
+			IL_007b: stloc.s 7
+			IL_007d: ldloc.s 7
+			IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0084: ldc.i4.0
+			IL_0085: ceq
+			IL_0087: stloc.s 8
+			IL_0089: ldloc.s 8
+			IL_008b: brfalse IL_00b0
 
-			IL_009d: ldstr "Missing --in <input.html>"
-			IL_00a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00a7: stloc.1
+			IL_0090: ldstr "Missing --in <input.html>"
+			IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_009a: stloc.1
+			IL_009b: ldloc.1
+			IL_009c: isinst [System.Runtime]System.Exception
+			IL_00a1: dup
+			IL_00a2: brtrue IL_00af
+
+			IL_00a7: pop
 			IL_00a8: ldloc.1
-			IL_00a9: isinst [System.Runtime]System.Exception
-			IL_00ae: dup
-			IL_00af: brtrue IL_00bc
+			IL_00a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00ae: throw
 
-			IL_00b4: pop
-			IL_00b5: ldloc.1
-			IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00bb: throw
+			IL_00af: throw
 
-			IL_00bc: throw
+			IL_00b0: volatile.
+			IL_00b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_00b7: brfalse IL_00cc
 
-			IL_00bd: volatile.
-			IL_00bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-			IL_00c4: brfalse IL_00d9
+			IL_00bc: ldloc.0
+			IL_00bd: ldstr "outFile"
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c7: br IL_00e1
 
-			IL_00c9: ldloc.0
-			IL_00ca: ldstr "outFile"
-			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d4: br IL_00ee
+			IL_00cc: ldloc.0
+			IL_00cd: ldstr "outFile"
+			IL_00d2: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:21"
+			IL_00d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_00d9: ldloc.0
-			IL_00da: ldstr "outFile"
-			IL_00df: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:22"
-			IL_00e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00e1: stloc.s 7
+			IL_00e3: ldloc.s 7
+			IL_00e5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00ea: ldc.i4.0
+			IL_00eb: ceq
+			IL_00ed: stloc.s 8
+			IL_00ef: ldloc.s 8
+			IL_00f1: brfalse IL_0116
 
-			IL_00ee: stloc.s 8
-			IL_00f0: ldloc.s 8
-			IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00f7: ldc.i4.0
-			IL_00f8: ceq
-			IL_00fa: stloc.s 9
-			IL_00fc: ldloc.s 9
-			IL_00fe: brfalse IL_0123
+			IL_00f6: ldstr "Missing --out <output.md>"
+			IL_00fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0100: stloc.2
+			IL_0101: ldloc.2
+			IL_0102: isinst [System.Runtime]System.Exception
+			IL_0107: dup
+			IL_0108: brtrue IL_0115
 
-			IL_0103: ldstr "Missing --out <output.md>"
-			IL_0108: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_010d: stloc.2
+			IL_010d: pop
 			IL_010e: ldloc.2
-			IL_010f: isinst [System.Runtime]System.Exception
-			IL_0114: dup
-			IL_0115: brtrue IL_0122
+			IL_010f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0114: throw
 
-			IL_011a: pop
-			IL_011b: ldloc.2
-			IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0121: throw
+			IL_0115: throw
 
-			IL_0122: throw
+			IL_0116: ldarg.0
+			IL_0117: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_011c: stloc.s 9
+			IL_011e: ldstr "process"
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012d: volatile.
+			IL_012f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0134: brfalse IL_0148
 
-			IL_0123: ldarg.0
-			IL_0124: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_0129: stloc.s 10
-			IL_012b: ldstr "process"
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013a: volatile.
-			IL_013c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_0141: brfalse IL_0155
+			IL_0139: ldstr "cwd"
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0143: br IL_015c
 
-			IL_0146: ldstr "cwd"
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0150: br IL_0169
+			IL_0148: ldstr "cwd"
+			IL_014d: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:35"
+			IL_0152: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0155: ldstr "cwd"
-			IL_015a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:36"
-			IL_015f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_015c: stloc.s 7
+			IL_015e: volatile.
+			IL_0160: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_0165: brfalse IL_017a
 
-			IL_0169: stloc.s 8
-			IL_016b: volatile.
-			IL_016d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_0172: brfalse IL_0187
+			IL_016a: ldloc.0
+			IL_016b: ldstr "inFile"
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0175: br IL_018f
 
-			IL_0177: ldloc.0
-			IL_0178: ldstr "inFile"
-			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0182: br IL_019c
+			IL_017a: ldloc.0
+			IL_017b: ldstr "inFile"
+			IL_0180: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:37"
+			IL_0185: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0187: ldloc.0
-			IL_0188: ldstr "inFile"
-			IL_018d: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:38"
-			IL_0192: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_018f: stloc.s 10
+			IL_0191: ldloc.s 9
+			IL_0193: ldstr "resolve"
+			IL_0198: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_019d: brtrue IL_01bf
 
-			IL_019c: stloc.s 11
-			IL_019e: ldloc.s 10
-			IL_01a0: ldstr "resolve"
-			IL_01a5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_01aa: brtrue IL_01cc
+			IL_01a2: ldloc.s 9
+			IL_01a4: ldc.i4.2
+			IL_01a5: newarr [System.Runtime]System.Object
+			IL_01aa: dup
+			IL_01ab: ldc.i4.0
+			IL_01ac: ldloc.s 7
+			IL_01ae: stelem.ref
+			IL_01af: dup
+			IL_01b0: ldc.i4.1
+			IL_01b1: ldloc.s 10
+			IL_01b3: stelem.ref
+			IL_01b4: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_01b9: stloc.3
+			IL_01ba: br IL_01dc
 
-			IL_01af: ldloc.s 10
-			IL_01b1: ldc.i4.2
-			IL_01b2: newarr [System.Runtime]System.Object
-			IL_01b7: dup
-			IL_01b8: ldc.i4.0
-			IL_01b9: ldloc.s 8
-			IL_01bb: stelem.ref
-			IL_01bc: dup
-			IL_01bd: ldc.i4.1
-			IL_01be: ldloc.s 11
-			IL_01c0: stelem.ref
-			IL_01c1: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_01c6: stloc.3
-			IL_01c7: br IL_01e9
+			IL_01bf: ldloc.s 9
+			IL_01c1: ldstr "resolve"
+			IL_01c6: ldc.i4.2
+			IL_01c7: newarr [System.Runtime]System.Object
+			IL_01cc: dup
+			IL_01cd: ldc.i4.0
+			IL_01ce: ldloc.s 7
+			IL_01d0: stelem.ref
+			IL_01d1: dup
+			IL_01d2: ldc.i4.1
+			IL_01d3: ldloc.s 10
+			IL_01d5: stelem.ref
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_01db: stloc.3
 
-			IL_01cc: ldloc.s 10
-			IL_01ce: ldstr "resolve"
-			IL_01d3: ldc.i4.2
-			IL_01d4: newarr [System.Runtime]System.Object
-			IL_01d9: dup
-			IL_01da: ldc.i4.0
-			IL_01db: ldloc.s 8
-			IL_01dd: stelem.ref
-			IL_01de: dup
-			IL_01df: ldc.i4.1
-			IL_01e0: ldloc.s 11
-			IL_01e2: stelem.ref
-			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_01e8: stloc.3
+			IL_01dc: ldarg.0
+			IL_01dd: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_01e2: stloc.s 9
+			IL_01e4: ldstr "process"
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f3: volatile.
+			IL_01f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_01fa: brfalse IL_020e
 
-			IL_01e9: ldarg.0
-			IL_01ea: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_01ef: stloc.s 10
-			IL_01f1: ldstr "process"
-			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0200: volatile.
-			IL_0202: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-			IL_0207: brfalse IL_021b
+			IL_01ff: ldstr "cwd"
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0209: br IL_0222
 
-			IL_020c: ldstr "cwd"
-			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0216: br IL_022f
+			IL_020e: ldstr "cwd"
+			IL_0213: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:45"
+			IL_0218: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_021b: ldstr "cwd"
-			IL_0220: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:46"
-			IL_0225: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0222: stloc.s 10
+			IL_0224: volatile.
+			IL_0226: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_022b: brfalse IL_0240
 
-			IL_022f: stloc.s 11
-			IL_0231: volatile.
-			IL_0233: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-			IL_0238: brfalse IL_024d
+			IL_0230: ldloc.0
+			IL_0231: ldstr "outFile"
+			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023b: br IL_0255
 
-			IL_023d: ldloc.0
-			IL_023e: ldstr "outFile"
-			IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0248: br IL_0262
+			IL_0240: ldloc.0
+			IL_0241: ldstr "outFile"
+			IL_0246: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:47"
+			IL_024b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_024d: ldloc.0
-			IL_024e: ldstr "outFile"
-			IL_0253: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:48"
-			IL_0258: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0255: stloc.s 7
+			IL_0257: ldloc.s 9
+			IL_0259: ldstr "resolve"
+			IL_025e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0263: brtrue IL_0286
 
-			IL_0262: stloc.s 8
-			IL_0264: ldloc.s 10
-			IL_0266: ldstr "resolve"
-			IL_026b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0270: brtrue IL_0293
+			IL_0268: ldloc.s 9
+			IL_026a: ldc.i4.2
+			IL_026b: newarr [System.Runtime]System.Object
+			IL_0270: dup
+			IL_0271: ldc.i4.0
+			IL_0272: ldloc.s 10
+			IL_0274: stelem.ref
+			IL_0275: dup
+			IL_0276: ldc.i4.1
+			IL_0277: ldloc.s 7
+			IL_0279: stelem.ref
+			IL_027a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
+			IL_027f: stloc.s 4
+			IL_0281: br IL_02a4
 
-			IL_0275: ldloc.s 10
-			IL_0277: ldc.i4.2
-			IL_0278: newarr [System.Runtime]System.Object
-			IL_027d: dup
-			IL_027e: ldc.i4.0
-			IL_027f: ldloc.s 11
-			IL_0281: stelem.ref
-			IL_0282: dup
-			IL_0283: ldc.i4.1
-			IL_0284: ldloc.s 8
-			IL_0286: stelem.ref
-			IL_0287: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::resolve(object[])
-			IL_028c: stloc.s 4
-			IL_028e: br IL_02b1
+			IL_0286: ldloc.s 9
+			IL_0288: ldstr "resolve"
+			IL_028d: ldc.i4.2
+			IL_028e: newarr [System.Runtime]System.Object
+			IL_0293: dup
+			IL_0294: ldc.i4.0
+			IL_0295: ldloc.s 10
+			IL_0297: stelem.ref
+			IL_0298: dup
+			IL_0299: ldc.i4.1
+			IL_029a: ldloc.s 7
+			IL_029c: stelem.ref
+			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_02a2: stloc.s 4
 
-			IL_0293: ldloc.s 10
-			IL_0295: ldstr "resolve"
-			IL_029a: ldc.i4.2
-			IL_029b: newarr [System.Runtime]System.Object
-			IL_02a0: dup
-			IL_02a1: ldc.i4.0
-			IL_02a2: ldloc.s 11
-			IL_02a4: stelem.ref
-			IL_02a5: dup
-			IL_02a6: ldc.i4.1
-			IL_02a7: ldloc.s 8
-			IL_02a9: stelem.ref
-			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_02af: stloc.s 4
+			IL_02a4: ldarg.0
+			IL_02a5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_02aa: stloc.s 11
+			IL_02ac: ldloc.s 11
+			IL_02ae: ldstr "readFileSync"
+			IL_02b3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_02b8: brtrue IL_02d1
 
-			IL_02b1: ldarg.0
-			IL_02b2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_02b7: stloc.s 12
-			IL_02b9: ldloc.s 12
-			IL_02bb: ldstr "readFileSync"
-			IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_02c5: brtrue IL_02de
+			IL_02bd: ldloc.s 11
+			IL_02bf: ldloc.3
+			IL_02c0: ldstr "utf8"
+			IL_02c5: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_02ca: stloc.s 5
+			IL_02cc: br IL_02f1
 
-			IL_02ca: ldloc.s 12
-			IL_02cc: ldloc.3
-			IL_02cd: ldstr "utf8"
-			IL_02d2: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_02d7: stloc.s 5
-			IL_02d9: br IL_02fe
+			IL_02d1: ldloc.s 11
+			IL_02d3: ldstr "readFileSync"
+			IL_02d8: ldc.i4.2
+			IL_02d9: newarr [System.Runtime]System.Object
+			IL_02de: dup
+			IL_02df: ldc.i4.0
+			IL_02e0: ldloc.3
+			IL_02e1: stelem.ref
+			IL_02e2: dup
+			IL_02e3: ldc.i4.1
+			IL_02e4: ldstr "utf8"
+			IL_02e9: stelem.ref
+			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_02ef: stloc.s 5
 
-			IL_02de: ldloc.s 12
-			IL_02e0: ldstr "readFileSync"
-			IL_02e5: ldc.i4.2
-			IL_02e6: newarr [System.Runtime]System.Object
-			IL_02eb: dup
-			IL_02ec: ldc.i4.0
-			IL_02ed: ldloc.3
-			IL_02ee: stelem.ref
-			IL_02ef: dup
-			IL_02f0: ldc.i4.1
-			IL_02f1: ldstr "utf8"
-			IL_02f6: stelem.ref
-			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_02fc: stloc.s 5
+			IL_02f1: ldarg.0
+			IL_02f2: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
+			IL_02f7: ldnull
+			IL_02f8: ldloc.s 5
+			IL_02fa: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
+			IL_02ff: stloc.s 6
+			IL_0301: ldarg.0
+			IL_0302: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_0307: stloc.s 11
+			IL_0309: ldarg.0
+			IL_030a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_030f: volatile.
+			IL_0311: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0316: brfalse IL_032c
 
-			IL_02fe: ldarg.0
-			IL_02ff: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::convertHtmlToMarkdown
-			IL_0304: ldc.i4.1
-			IL_0305: newarr [System.Runtime]System.Object
-			IL_030a: dup
-			IL_030b: ldc.i4.0
-			IL_030c: ldarg.0
-			IL_030d: stelem.ref
-			IL_030e: ldloc.s 5
-			IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0315: stloc.s 6
-			IL_0317: ldarg.0
-			IL_0318: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_031d: stloc.s 12
-			IL_031f: ldarg.0
-			IL_0320: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_0325: volatile.
-			IL_0327: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-			IL_032c: brfalse IL_0342
+			IL_031b: ldstr "dirname"
+			IL_0320: ldloc.s 4
+			IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0327: br IL_0342
 
-			IL_0331: ldstr "dirname"
-			IL_0336: ldloc.s 4
-			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_033d: br IL_0358
+			IL_032c: ldstr "dirname"
+			IL_0331: ldloc.s 4
+			IL_0333: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:62"
+			IL_0338: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0342: ldstr "dirname"
-			IL_0347: ldloc.s 4
-			IL_0349: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:64"
-			IL_034e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-			IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0342: stloc.s 7
+			IL_0344: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0349: dup
+			IL_034a: ldstr "recursive"
+			IL_034f: ldc.i4.1
+			IL_0350: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0355: stloc.s 12
+			IL_0357: ldloc.s 11
+			IL_0359: ldstr "mkdirSync"
+			IL_035e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_0363: brtrue IL_0379
 
-			IL_0358: stloc.s 8
-			IL_035a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_035f: dup
-			IL_0360: ldstr "recursive"
-			IL_0365: ldc.i4.1
-			IL_0366: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_036b: stloc.s 13
-			IL_036d: ldloc.s 12
-			IL_036f: ldstr "mkdirSync"
-			IL_0374: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0379: brtrue IL_038f
+			IL_0368: ldloc.s 11
+			IL_036a: ldloc.s 7
+			IL_036c: ldloc.s 12
+			IL_036e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
+			IL_0373: pop
+			IL_0374: br IL_0396
 
-			IL_037e: ldloc.s 12
-			IL_0380: ldloc.s 8
-			IL_0382: ldloc.s 13
-			IL_0384: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::mkdirSync(object, object)
-			IL_0389: pop
-			IL_038a: br IL_03ac
+			IL_0379: ldloc.s 11
+			IL_037b: ldstr "mkdirSync"
+			IL_0380: ldc.i4.2
+			IL_0381: newarr [System.Runtime]System.Object
+			IL_0386: dup
+			IL_0387: ldc.i4.0
+			IL_0388: ldloc.s 7
+			IL_038a: stelem.ref
+			IL_038b: dup
+			IL_038c: ldc.i4.1
+			IL_038d: ldloc.s 12
+			IL_038f: stelem.ref
+			IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0395: pop
 
-			IL_038f: ldloc.s 12
-			IL_0391: ldstr "mkdirSync"
-			IL_0396: ldc.i4.2
-			IL_0397: newarr [System.Runtime]System.Object
-			IL_039c: dup
-			IL_039d: ldc.i4.0
-			IL_039e: ldloc.s 8
-			IL_03a0: stelem.ref
-			IL_03a1: dup
-			IL_03a2: ldc.i4.1
-			IL_03a3: ldloc.s 13
-			IL_03a5: stelem.ref
-			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_03ab: pop
+			IL_0396: ldarg.0
+			IL_0397: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_039c: stloc.s 11
+			IL_039e: ldloc.s 11
+			IL_03a0: ldstr "writeFileSync"
+			IL_03a5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_03aa: brtrue IL_03c4
 
-			IL_03ac: ldarg.0
-			IL_03ad: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_03b2: stloc.s 12
-			IL_03b4: ldloc.s 12
-			IL_03b6: ldstr "writeFileSync"
-			IL_03bb: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_03c0: brtrue IL_03da
+			IL_03af: ldloc.s 11
+			IL_03b1: ldloc.s 4
+			IL_03b3: ldloc.s 6
+			IL_03b5: ldstr "utf8"
+			IL_03ba: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_03bf: br IL_03e9
 
-			IL_03c5: ldloc.s 12
-			IL_03c7: ldloc.s 4
-			IL_03c9: ldloc.s 6
-			IL_03cb: ldstr "utf8"
-			IL_03d0: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_03d5: br IL_03ff
+			IL_03c4: ldloc.s 11
+			IL_03c6: ldstr "writeFileSync"
+			IL_03cb: ldc.i4.3
+			IL_03cc: newarr [System.Runtime]System.Object
+			IL_03d1: dup
+			IL_03d2: ldc.i4.0
+			IL_03d3: ldloc.s 4
+			IL_03d5: stelem.ref
+			IL_03d6: dup
+			IL_03d7: ldc.i4.1
+			IL_03d8: ldloc.s 6
+			IL_03da: stelem.ref
+			IL_03db: dup
+			IL_03dc: ldc.i4.2
+			IL_03dd: ldstr "utf8"
+			IL_03e2: stelem.ref
+			IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_03e8: pop
 
-			IL_03da: ldloc.s 12
-			IL_03dc: ldstr "writeFileSync"
-			IL_03e1: ldc.i4.3
-			IL_03e2: newarr [System.Runtime]System.Object
-			IL_03e7: dup
-			IL_03e8: ldc.i4.0
-			IL_03e9: ldloc.s 4
-			IL_03eb: stelem.ref
-			IL_03ec: dup
-			IL_03ed: ldc.i4.1
-			IL_03ee: ldloc.s 6
-			IL_03f0: stelem.ref
-			IL_03f1: dup
-			IL_03f2: ldc.i4.2
-			IL_03f3: ldstr "utf8"
-			IL_03f8: stelem.ref
-			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_03fe: pop
+			IL_03e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ee: stloc.s 13
+			IL_03f0: volatile.
+			IL_03f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_03f7: brfalse IL_040c
 
-			IL_03ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0404: stloc.s 14
-			IL_0406: volatile.
-			IL_0408: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-			IL_040d: brfalse IL_0422
+			IL_03fc: ldloc.0
+			IL_03fd: ldstr "inFile"
+			IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0407: br IL_0421
 
-			IL_0412: ldloc.0
-			IL_0413: ldstr "inFile"
-			IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_041d: br IL_0437
+			IL_040c: ldloc.0
+			IL_040d: ldstr "inFile"
+			IL_0412: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:74"
+			IL_0417: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0422: ldloc.0
-			IL_0423: ldstr "inFile"
-			IL_0428: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:76"
-			IL_042d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-			IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0421: stloc.s 7
+			IL_0423: ldloc.s 7
+			IL_0425: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_042a: stloc.s 14
+			IL_042c: ldstr "Converted "
+			IL_0431: ldloc.s 14
+			IL_0433: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0438: ldstr " -> "
+			IL_043d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0442: volatile.
+			IL_0444: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_0449: brfalse IL_045e
 
-			IL_0437: stloc.s 8
-			IL_0439: ldloc.s 8
-			IL_043b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0440: stloc.s 15
-			IL_0442: ldstr "Converted "
-			IL_0447: ldloc.s 15
-			IL_0449: call string [System.Runtime]System.String::Concat(string, string)
-			IL_044e: ldstr " -> "
-			IL_0453: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0458: volatile.
-			IL_045a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-			IL_045f: brfalse IL_0474
+			IL_044e: ldloc.0
+			IL_044f: ldstr "outFile"
+			IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0459: br IL_0473
 
-			IL_0464: ldloc.0
-			IL_0465: ldstr "outFile"
-			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_046f: br IL_0489
+			IL_045e: ldloc.0
+			IL_045f: ldstr "outFile"
+			IL_0464: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:80"
+			IL_0469: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0474: ldloc.0
-			IL_0475: ldstr "outFile"
-			IL_047a: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:82"
-			IL_047f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0473: stloc.s 7
+			IL_0475: ldloc.s 7
+			IL_0477: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_047c: stloc.s 14
+			IL_047e: ldloc.s 14
+			IL_0480: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0485: ldstr " ("
+			IL_048a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_048f: ldloc.s 6
+			IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0496: stloc.s 7
+			IL_0498: ldstr "\\n"
+			IL_049d: ldstr ""
+			IL_04a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_04a7: stloc.s 15
+			IL_04a9: volatile.
+			IL_04ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_04b0: brfalse IL_04c8
 
-			IL_0489: stloc.s 8
-			IL_048b: ldloc.s 8
-			IL_048d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0492: stloc.s 15
-			IL_0494: ldloc.s 15
-			IL_0496: call string [System.Runtime]System.String::Concat(string, string)
-			IL_049b: ldstr " ("
-			IL_04a0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04a5: ldloc.s 6
-			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04ac: stloc.s 8
-			IL_04ae: ldstr "\\n"
-			IL_04b3: ldstr ""
-			IL_04b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_04bd: stloc.s 16
-			IL_04bf: volatile.
-			IL_04c1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_04c6: brfalse IL_04de
+			IL_04b5: ldloc.s 7
+			IL_04b7: ldstr "split"
+			IL_04bc: ldloc.s 15
+			IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04c3: br IL_04e0
 
-			IL_04cb: ldloc.s 8
-			IL_04cd: ldstr "split"
-			IL_04d2: ldloc.s 16
-			IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04d9: br IL_04f6
+			IL_04c8: ldloc.s 7
+			IL_04ca: ldstr "split"
+			IL_04cf: ldloc.s 15
+			IL_04d1: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:89"
+			IL_04d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_04de: ldloc.s 8
-			IL_04e0: ldstr "split"
-			IL_04e5: ldloc.s 16
-			IL_04e7: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:91"
-			IL_04ec: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_04e0: stloc.s 7
+			IL_04e2: volatile.
+			IL_04e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_04e9: brfalse IL_04ff
 
-			IL_04f6: stloc.s 8
-			IL_04f8: volatile.
-			IL_04fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_04ff: brfalse IL_0515
+			IL_04ee: ldloc.s 7
+			IL_04f0: ldstr "length"
+			IL_04f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04fa: br IL_0515
 
-			IL_0504: ldloc.s 8
-			IL_0506: ldstr "length"
-			IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0510: br IL_052b
+			IL_04ff: ldloc.s 7
+			IL_0501: ldstr "length"
+			IL_0506: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:91"
+			IL_050b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0515: ldloc.s 8
-			IL_0517: ldstr "length"
-			IL_051c: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:<TwoPhaseDummy_M20>:__js_call__:93"
-			IL_0521: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-			IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-			IL_052b: stloc.s 8
-			IL_052d: ldloc.s 8
-			IL_052f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0534: stloc.s 15
-			IL_0536: ldloc.s 15
-			IL_0538: call string [System.Runtime]System.String::Concat(string, string)
-			IL_053d: ldstr " lines)"
-			IL_0542: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0547: stloc.s 15
-			IL_0549: ldloc.s 14
-			IL_054b: ldloc.s 15
-			IL_054d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0552: pop
-			IL_0553: ldnull
-			IL_0554: ret
+			IL_0515: stloc.s 7
+			IL_0517: ldloc.s 7
+			IL_0519: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_051e: stloc.s 14
+			IL_0520: ldloc.s 14
+			IL_0522: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0527: ldstr " lines)"
+			IL_052c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0531: stloc.s 14
+			IL_0533: ldloc.s 13
+			IL_0535: ldloc.s 14
+			IL_0537: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_053c: pop
+			IL_053d: ldnull
+			IL_053e: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -3353,7 +3340,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 631 (0x277)
+		// Code size: 632 (0x278)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope,
@@ -3488,134 +3475,135 @@
 		IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_011b: stloc.s 13
 		IL_011d: ldloc.s 13
-		IL_011f: brfalse IL_0273
+		IL_011f: brfalse IL_0274
 		.try
 		{
 			IL_0124: nop
-			IL_0125: ldloc.1
-			IL_0126: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0130: pop
-			IL_0131: leave IL_0273
+			IL_0125: ldloc.0
+			IL_0126: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
+			IL_012b: ldnull
+			IL_012c: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
+			IL_0131: pop
+			IL_0132: leave IL_0274
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0136: stloc.2
-			IL_0137: ldloc.2
-			IL_0138: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_013d: dup
-			IL_013e: brtrue IL_0153
+			IL_0137: stloc.2
+			IL_0138: ldloc.2
+			IL_0139: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_013e: dup
+			IL_013f: brtrue IL_0154
 
-			IL_0143: pop
-			IL_0144: ldloc.2
-			IL_0145: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_014a: dup
-			IL_014b: brtrue IL_015e
+			IL_0144: pop
+			IL_0145: ldloc.2
+			IL_0146: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_014b: dup
+			IL_014c: brtrue IL_015f
 
-			IL_0150: pop
-			IL_0151: rethrow
+			IL_0151: pop
+			IL_0152: rethrow
 
-			IL_0153: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0158: stloc.3
-			IL_0159: br IL_015f
+			IL_0154: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0159: stloc.3
+			IL_015a: br IL_0160
 
-			IL_015e: stloc.3
+			IL_015f: stloc.3
 
-			IL_015f: ldloc.3
-			IL_0160: stloc.s 4
-			IL_0162: ldstr "console"
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0171: stloc.s 12
-			IL_0173: ldloc.s 4
-			IL_0175: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_017a: stloc.s 13
-			IL_017c: ldloc.s 13
-			IL_017e: brfalse IL_01c1
+			IL_0160: ldloc.3
+			IL_0161: stloc.s 4
+			IL_0163: ldstr "console"
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0172: stloc.s 12
+			IL_0174: ldloc.s 4
+			IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_017b: stloc.s 13
+			IL_017d: ldloc.s 13
+			IL_017f: brfalse IL_01c2
 
-			IL_0183: volatile.
-			IL_0185: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_018a: brfalse IL_01a0
+			IL_0184: volatile.
+			IL_0186: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_018b: brfalse IL_01a1
 
-			IL_018f: ldloc.s 4
-			IL_0191: ldstr "message"
-			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_019b: br IL_01b6
+			IL_0190: ldloc.s 4
+			IL_0192: ldstr "message"
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_019c: br IL_01b7
 
-			IL_01a0: ldloc.s 4
-			IL_01a2: ldstr "message"
-			IL_01a7: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:__js_module_init__:57"
-			IL_01ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01a1: ldloc.s 4
+			IL_01a3: ldstr "message"
+			IL_01a8: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:__js_module_init__:57"
+			IL_01ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01b6: stloc.s 14
-			IL_01b8: ldloc.s 14
-			IL_01ba: stloc.s 16
-			IL_01bc: br IL_01c5
+			IL_01b7: stloc.s 14
+			IL_01b9: ldloc.s 14
+			IL_01bb: stloc.s 16
+			IL_01bd: br IL_01c6
 
-			IL_01c1: ldloc.s 4
-			IL_01c3: stloc.s 16
+			IL_01c2: ldloc.s 4
+			IL_01c4: stloc.s 16
 
-			IL_01c5: ldloc.s 16
-			IL_01c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01cc: stloc.s 13
-			IL_01ce: ldloc.s 13
-			IL_01d0: brfalse IL_0213
+			IL_01c6: ldloc.s 16
+			IL_01c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01cd: stloc.s 13
+			IL_01cf: ldloc.s 13
+			IL_01d1: brfalse IL_0214
 
-			IL_01d5: volatile.
-			IL_01d7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_01dc: brfalse IL_01f2
+			IL_01d6: volatile.
+			IL_01d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_01dd: brfalse IL_01f3
 
-			IL_01e1: ldloc.s 4
-			IL_01e3: ldstr "message"
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ed: br IL_0208
+			IL_01e2: ldloc.s 4
+			IL_01e4: ldstr "message"
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ee: br IL_0209
 
-			IL_01f2: ldloc.s 4
-			IL_01f4: ldstr "message"
-			IL_01f9: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:__js_module_init__:66"
-			IL_01fe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01f3: ldloc.s 4
+			IL_01f5: ldstr "message"
+			IL_01fa: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:__js_module_init__:66"
+			IL_01ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0208: stloc.s 14
-			IL_020a: ldloc.s 14
-			IL_020c: stloc.s 5
-			IL_020e: br IL_0217
+			IL_0209: stloc.s 14
+			IL_020b: ldloc.s 14
+			IL_020d: stloc.s 5
+			IL_020f: br IL_0218
 
-			IL_0213: ldloc.s 4
-			IL_0215: stloc.s 5
+			IL_0214: ldloc.s 4
+			IL_0216: stloc.s 5
 
-			IL_0217: volatile.
-			IL_0219: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_021e: brfalse IL_0236
+			IL_0218: volatile.
+			IL_021a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_021f: brfalse IL_0237
 
-			IL_0223: ldloc.s 12
-			IL_0225: ldstr "error"
-			IL_022a: ldloc.s 5
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0231: br IL_024e
+			IL_0224: ldloc.s 12
+			IL_0226: ldstr "error"
+			IL_022b: ldloc.s 5
+			IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0232: br IL_024f
 
-			IL_0236: ldloc.s 12
-			IL_0238: ldstr "error"
-			IL_023d: ldloc.s 5
-			IL_023f: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:__js_module_init__:72"
-			IL_0244: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0237: ldloc.s 12
+			IL_0239: ldstr "error"
+			IL_023e: ldloc.s 5
+			IL_0240: ldstr "Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown:__js_module_init__:72"
+			IL_0245: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_024e: pop
-			IL_024f: ldstr "process"
-			IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0259: ldstr "exitCode"
-			IL_025e: ldc.r8 1
-			IL_0267: ldc.i4.1
-			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_026d: pop
-			IL_026e: leave IL_0273
+			IL_024f: pop
+			IL_0250: ldstr "process"
+			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_025a: ldstr "exitCode"
+			IL_025f: ldc.r8 1
+			IL_0268: ldc.i4.1
+			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_026e: pop
+			IL_026f: leave IL_0274
 		} // end handler
 
-		IL_0273: ldnull
-		IL_0274: stloc.s 6
-		IL_0276: ret
+		IL_0274: ldnull
+		IL_0275: stloc.s 6
+		IL_0277: ret
 	} // end of method Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -2234,7 +2234,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 220 (0xdc)
+			// Code size: 198 (0xc6)
 			.maxstack 10
 			.locals init (
 				[0] string,
@@ -2245,7 +2245,7 @@
 				[5] object,
 				[6] object,
 				[7] string,
-				[8] object[],
+				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[9] object,
 				[10] bool
 			)
@@ -2260,102 +2260,90 @@
 			IL_0019: call string [System.Runtime]System.String::Concat(string, string)
 			IL_001e: stloc.0
 			IL_001f: ldarg.0
-			IL_0020: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_0025: ldc.i4.1
-			IL_0026: newarr [System.Runtime]System.Object
-			IL_002b: dup
-			IL_002c: ldc.i4.0
-			IL_002d: ldarg.0
-			IL_002e: stelem.ref
-			IL_002f: stloc.s 8
-			IL_0031: ldloc.s 8
-			IL_0033: ldarg.2
-			IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0039: stloc.s 9
-			IL_003b: ldloc.s 9
-			IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_0042: stloc.1
-			IL_0043: ldc.i4.0
-			IL_0044: stloc.2
-			IL_0045: ldc.i4.0
-			IL_0046: stloc.3
+			IL_0020: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_0025: ldnull
+			IL_0026: ldarg.2
+			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+			IL_002c: stloc.s 8
+			IL_002e: ldloc.s 8
+			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0035: stloc.1
+			IL_0036: ldc.i4.0
+			IL_0037: stloc.2
+			IL_0038: ldc.i4.0
+			IL_0039: stloc.3
 			.try
 			{
-				// loop start (head: IL_0047)
-					IL_0047: ldc.i4.1
-					IL_0048: stloc.2
-					IL_0049: ldloc.1
-					IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_004f: stloc.s 9
-					IL_0051: ldloc.s 9
-					IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_0058: stloc.s 10
-					IL_005a: ldloc.s 10
-					IL_005c: brtrue IL_00b8
+				// loop start (head: IL_003a)
+					IL_003a: ldc.i4.1
+					IL_003b: stloc.2
+					IL_003c: ldloc.1
+					IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_0042: stloc.s 9
+					IL_0044: ldloc.s 9
+					IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_004b: stloc.s 10
+					IL_004d: ldloc.s 10
+					IL_004f: brtrue IL_00a2
 
-					IL_0061: ldloc.s 9
-					IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_0068: stloc.s 9
-					IL_006a: ldc.i4.0
-					IL_006b: stloc.2
-					IL_006c: ldloc.s 9
-					IL_006e: stloc.s 4
-					IL_0070: ldarg.0
-					IL_0071: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssemblyInRoot
-					IL_0076: ldc.i4.1
-					IL_0077: newarr [System.Runtime]System.Object
-					IL_007c: dup
-					IL_007d: ldc.i4.0
-					IL_007e: ldarg.0
-					IL_007f: stelem.ref
-					IL_0080: ldloc.s 4
-					IL_0082: ldloc.0
-					IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_0088: stloc.s 5
-					IL_008a: ldloc.s 5
-					IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0091: stloc.s 10
-					IL_0093: ldloc.s 10
-					IL_0095: brfalse IL_00a6
+					IL_0054: ldloc.s 9
+					IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_005b: stloc.s 9
+					IL_005d: ldc.i4.0
+					IL_005e: stloc.2
+					IL_005f: ldloc.s 9
+					IL_0061: stloc.s 4
+					IL_0063: ldarg.0
+					IL_0064: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+					IL_0069: ldnull
+					IL_006a: ldloc.s 4
+					IL_006c: ldloc.0
+					IL_006d: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+					IL_0072: stloc.s 5
+					IL_0074: ldloc.s 5
+					IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_007b: stloc.s 10
+					IL_007d: ldloc.s 10
+					IL_007f: brfalse IL_0090
 
-					IL_009a: ldnull
-					IL_009b: stloc.s 6
-					IL_009d: ldloc.s 5
-					IL_009f: stloc.s 6
-					IL_00a1: leave IL_00d9
+					IL_0084: ldnull
+					IL_0085: stloc.s 6
+					IL_0087: ldloc.s 5
+					IL_0089: stloc.s 6
+					IL_008b: leave IL_00c3
 
-					IL_00a6: br IL_0047
+					IL_0090: br IL_003a
 				// end loop
-				IL_00ab: ldloc.1
-				IL_00ac: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_00b1: ldc.i4.1
-				IL_00b2: stloc.3
-				IL_00b3: leave IL_00d2
+				IL_0095: ldloc.1
+				IL_0096: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_009b: ldc.i4.1
+				IL_009c: stloc.3
+				IL_009d: leave IL_00bc
 
-				IL_00b8: ldc.i4.1
-				IL_00b9: stloc.2
-				IL_00ba: leave IL_00d2
+				IL_00a2: ldc.i4.1
+				IL_00a3: stloc.2
+				IL_00a4: leave IL_00bc
 			} // end .try
 			finally
 			{
-				IL_00bf: ldloc.2
-				IL_00c0: brtrue IL_00d1
+				IL_00a9: ldloc.2
+				IL_00aa: brtrue IL_00bb
 
-				IL_00c5: ldloc.3
-				IL_00c6: brtrue IL_00d1
+				IL_00af: ldloc.3
+				IL_00b0: brtrue IL_00bb
 
-				IL_00cb: ldloc.1
-				IL_00cc: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_00b5: ldloc.1
+				IL_00b6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_00d1: endfinally
+				IL_00bb: endfinally
 			} // end handler
 
-			IL_00d2: ldc.i4.0
-			IL_00d3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00d8: ret
+			IL_00bc: ldc.i4.0
+			IL_00bd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00c2: ret
 
-			IL_00d9: ldloc.s 6
-			IL_00db: ret
+			IL_00c3: ldloc.s 6
+			IL_00c5: ret
 		} // end of method tryFindLatestGeneratedAssembly::__js_call__
 
 	} // end of class tryFindLatestGeneratedAssembly
@@ -3487,7 +3475,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 3315 (0xcf3)
+			// Code size: 3234 (0xca2)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3502,7 +3490,7 @@
 				[9] object,
 				[10] object,
 				[11] object,
-				[12] object,
+				[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[13] float64,
 				[14] class [System.Runtime]System.Exception,
 				[15] object,
@@ -3510,17 +3498,16 @@
 				[17] object,
 				[18] object,
 				[19] bool,
-				[20] object[],
-				[21] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
-				[22] string,
-				[23] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
-				[24] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-				[25] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[26] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule,
-				[27] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[28] object,
-				[29] float64,
-				[30] float64
+				[20] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
+				[21] string,
+				[22] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
+				[23] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+				[24] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[25] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule,
+				[26] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[27] object,
+				[28] float64,
+				[29] float64
 			)
 
 			IL_0000: ldstr "process"
@@ -3714,834 +3701,791 @@
 
 			IL_02bc: pop
 
-			IL_02bd: ldarg.0
-			IL_02be: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::normalizeCategory
-			IL_02c3: ldc.i4.1
-			IL_02c4: newarr [System.Runtime]System.Object
-			IL_02c9: dup
-			IL_02ca: ldc.i4.0
-			IL_02cb: ldarg.0
-			IL_02cc: stelem.ref
-			IL_02cd: stloc.s 20
-			IL_02cf: ldloc.0
-			IL_02d0: ldc.r8 0.0
-			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_02de: stloc.s 18
-			IL_02e0: ldloc.s 20
-			IL_02e2: ldloc.s 18
-			IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_02e9: stloc.1
-			IL_02ea: ldloc.0
-			IL_02eb: ldc.r8 1
-			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_02f9: stloc.2
-			IL_02fa: ldarg.0
-			IL_02fb: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getGeneratorTestSnapshotPath
-			IL_0300: ldc.i4.1
-			IL_0301: newarr [System.Runtime]System.Object
-			IL_0306: dup
-			IL_0307: ldc.i4.0
-			IL_0308: ldarg.0
-			IL_0309: stelem.ref
-			IL_030a: stloc.s 20
-			IL_030c: volatile.
-			IL_030e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-			IL_0313: brfalse IL_0328
+			IL_02bd: ldloc.0
+			IL_02be: ldc.r8 0.0
+			IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02cc: stloc.s 18
+			IL_02ce: ldarg.0
+			IL_02cf: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_02d4: ldnull
+			IL_02d5: ldloc.s 18
+			IL_02d7: call object Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+			IL_02dc: stloc.1
+			IL_02dd: ldloc.0
+			IL_02de: ldc.r8 1
+			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02ec: stloc.2
+			IL_02ed: volatile.
+			IL_02ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_02f4: brfalse IL_0309
 
-			IL_0318: ldloc.1
-			IL_0319: ldstr "path"
-			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0323: br IL_033d
+			IL_02f9: ldloc.1
+			IL_02fa: ldstr "path"
+			IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0304: br IL_031e
 
-			IL_0328: ldloc.1
-			IL_0329: ldstr "path"
-			IL_032e: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:70"
-			IL_0333: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0309: ldloc.1
+			IL_030a: ldstr "path"
+			IL_030f: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:67"
+			IL_0314: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+			IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_033d: stloc.s 18
-			IL_033f: ldloc.s 20
-			IL_0341: ldloc.s 18
-			IL_0343: ldloc.2
-			IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0349: stloc.3
-			IL_034a: ldarg.0
-			IL_034b: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_0350: stloc.s 21
-			IL_0352: ldloc.s 21
-			IL_0354: ldloc.3
-			IL_0355: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_035a: box [System.Runtime]System.Boolean
-			IL_035f: stloc.s 18
-			IL_0361: ldloc.s 18
-			IL_0363: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0368: ldc.i4.0
-			IL_0369: ceq
-			IL_036b: stloc.s 19
-			IL_036d: ldloc.s 19
-			IL_036f: brfalse IL_0477
+			IL_031e: stloc.s 18
+			IL_0320: ldarg.0
+			IL_0321: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_0326: ldnull
+			IL_0327: ldloc.s 18
+			IL_0329: ldloc.2
+			IL_032a: call object Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+			IL_032f: stloc.3
+			IL_0330: ldarg.0
+			IL_0331: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_0336: stloc.s 20
+			IL_0338: ldloc.s 20
+			IL_033a: ldloc.3
+			IL_033b: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_0340: box [System.Runtime]System.Boolean
+			IL_0345: stloc.s 18
+			IL_0347: ldloc.s 18
+			IL_0349: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_034e: ldc.i4.0
+			IL_034f: ceq
+			IL_0351: stloc.s 19
+			IL_0353: ldloc.s 19
+			IL_0355: brfalse IL_045d
 
-			IL_0374: ldstr "console"
-			IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0383: stloc.s 18
-			IL_0385: ldloc.3
-			IL_0386: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_038b: stloc.s 22
-			IL_038d: ldstr "Generator test snapshot not found: "
-			IL_0392: ldloc.s 22
-			IL_0394: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0399: stloc.s 22
-			IL_039b: volatile.
-			IL_039d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-			IL_03a2: brfalse IL_03ba
+			IL_035a: ldstr "console"
+			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0369: stloc.s 18
+			IL_036b: ldloc.3
+			IL_036c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0371: stloc.s 21
+			IL_0373: ldstr "Generator test snapshot not found: "
+			IL_0378: ldloc.s 21
+			IL_037a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_037f: stloc.s 21
+			IL_0381: volatile.
+			IL_0383: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_0388: brfalse IL_03a0
 
-			IL_03a7: ldloc.s 18
-			IL_03a9: ldstr "error"
-			IL_03ae: ldloc.s 22
-			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03b5: br IL_03d2
+			IL_038d: ldloc.s 18
+			IL_038f: ldstr "error"
+			IL_0394: ldloc.s 21
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_039b: br IL_03b8
 
-			IL_03ba: ldloc.s 18
-			IL_03bc: ldstr "error"
-			IL_03c1: ldloc.s 22
-			IL_03c3: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:85"
-			IL_03c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-			IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_03a0: ldloc.s 18
+			IL_03a2: ldstr "error"
+			IL_03a7: ldloc.s 21
+			IL_03a9: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:83"
+			IL_03ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+			IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_03d2: pop
-			IL_03d3: ldstr "console"
-			IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03e2: volatile.
-			IL_03e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_03e9: brfalse IL_0402
+			IL_03b8: pop
+			IL_03b9: ldstr "console"
+			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03c8: volatile.
+			IL_03ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_03cf: brfalse IL_03e8
 
-			IL_03ee: ldstr "error"
-			IL_03f3: ldstr "Check the category and test name before running the helper."
-			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_03fd: br IL_041b
+			IL_03d4: ldstr "error"
+			IL_03d9: ldstr "Check the category and test name before running the helper."
+			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03e3: br IL_0401
 
-			IL_0402: ldstr "error"
-			IL_0407: ldstr "Check the category and test name before running the helper."
-			IL_040c: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:91"
-			IL_0411: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-			IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_03e8: ldstr "error"
+			IL_03ed: ldstr "Check the category and test name before running the helper."
+			IL_03f2: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:89"
+			IL_03f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_041b: pop
-			IL_041c: ldstr "process"
-			IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_042b: volatile.
-			IL_042d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_0432: brfalse IL_0454
+			IL_0401: pop
+			IL_0402: ldstr "process"
+			IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0411: volatile.
+			IL_0413: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0418: brfalse IL_043a
 
-			IL_0437: ldstr "exit"
-			IL_043c: ldc.r8 1
-			IL_0445: box [System.Runtime]System.Double
-			IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_044f: br IL_0476
+			IL_041d: ldstr "exit"
+			IL_0422: ldc.r8 1
+			IL_042b: box [System.Runtime]System.Double
+			IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0435: br IL_045c
 
-			IL_0454: ldstr "exit"
-			IL_0459: ldc.r8 1
-			IL_0462: box [System.Runtime]System.Double
-			IL_0467: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:98"
-			IL_046c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-			IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_043a: ldstr "exit"
+			IL_043f: ldc.r8 1
+			IL_0448: box [System.Runtime]System.Double
+			IL_044d: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:96"
+			IL_0452: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+			IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0476: pop
+			IL_045c: pop
 
-			IL_0477: volatile.
-			IL_0479: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-			IL_047e: brfalse IL_0493
+			IL_045d: volatile.
+			IL_045f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_0464: brfalse IL_0479
 
-			IL_0483: ldloc.1
-			IL_0484: ldstr "namespace"
-			IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_048e: br IL_04a8
+			IL_0469: ldloc.1
+			IL_046a: ldstr "namespace"
+			IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0474: br IL_048e
 
-			IL_0493: ldloc.1
-			IL_0494: ldstr "namespace"
-			IL_0499: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:103"
-			IL_049e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-			IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0479: ldloc.1
+			IL_047a: ldstr "namespace"
+			IL_047f: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:101"
+			IL_0484: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+			IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04a8: stloc.s 18
-			IL_04aa: ldloc.s 18
-			IL_04ac: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04b1: stloc.s 22
-			IL_04b3: ldstr "Jroc.Tests."
-			IL_04b8: ldloc.s 22
-			IL_04ba: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04bf: ldstr ".GeneratorTests."
-			IL_04c4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04c9: ldloc.2
-			IL_04ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_04cf: stloc.s 22
-			IL_04d1: ldloc.s 22
-			IL_04d3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04d8: stloc.s 4
-			IL_04da: ldarg.0
-			IL_04db: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_04e0: stloc.s 23
-			IL_04e2: ldarg.0
-			IL_04e3: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_04e8: stloc.s 18
-			IL_04ea: ldloc.s 23
-			IL_04ec: ldc.i4.4
-			IL_04ed: newarr [System.Runtime]System.Object
-			IL_04f2: dup
-			IL_04f3: ldc.i4.0
-			IL_04f4: ldloc.s 18
-			IL_04f6: stelem.ref
-			IL_04f7: dup
-			IL_04f8: ldc.i4.1
-			IL_04f9: ldstr "tests"
-			IL_04fe: stelem.ref
-			IL_04ff: dup
-			IL_0500: ldc.i4.2
-			IL_0501: ldstr "Jroc.Tests"
-			IL_0506: stelem.ref
-			IL_0507: dup
-			IL_0508: ldc.i4.3
-			IL_0509: ldstr "Jroc.Tests.csproj"
-			IL_050e: stelem.ref
-			IL_050f: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0514: stloc.s 5
-			IL_0516: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_051b: stloc.s 24
-			IL_051d: ldloc.s 4
-			IL_051f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0524: stloc.s 22
-			IL_0526: ldstr "Running test: "
-			IL_052b: ldloc.s 22
-			IL_052d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0532: stloc.s 22
-			IL_0534: ldloc.s 24
-			IL_0536: ldloc.s 22
-			IL_0538: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_053d: pop
-			IL_053e: ldstr "process"
-			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0548: volatile.
-			IL_054a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_054f: brfalse IL_0563
+			IL_048e: stloc.s 18
+			IL_0490: ldloc.s 18
+			IL_0492: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0497: stloc.s 21
+			IL_0499: ldstr "Jroc.Tests."
+			IL_049e: ldloc.s 21
+			IL_04a0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04a5: ldstr ".GeneratorTests."
+			IL_04aa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04af: ldloc.2
+			IL_04b0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04b5: stloc.s 21
+			IL_04b7: ldloc.s 21
+			IL_04b9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04be: stloc.s 4
+			IL_04c0: ldarg.0
+			IL_04c1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_04c6: stloc.s 22
+			IL_04c8: ldarg.0
+			IL_04c9: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_04ce: stloc.s 18
+			IL_04d0: ldloc.s 22
+			IL_04d2: ldc.i4.4
+			IL_04d3: newarr [System.Runtime]System.Object
+			IL_04d8: dup
+			IL_04d9: ldc.i4.0
+			IL_04da: ldloc.s 18
+			IL_04dc: stelem.ref
+			IL_04dd: dup
+			IL_04de: ldc.i4.1
+			IL_04df: ldstr "tests"
+			IL_04e4: stelem.ref
+			IL_04e5: dup
+			IL_04e6: ldc.i4.2
+			IL_04e7: ldstr "Jroc.Tests"
+			IL_04ec: stelem.ref
+			IL_04ed: dup
+			IL_04ee: ldc.i4.3
+			IL_04ef: ldstr "Jroc.Tests.csproj"
+			IL_04f4: stelem.ref
+			IL_04f5: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_04fa: stloc.s 5
+			IL_04fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0501: stloc.s 23
+			IL_0503: ldloc.s 4
+			IL_0505: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_050a: stloc.s 21
+			IL_050c: ldstr "Running test: "
+			IL_0511: ldloc.s 21
+			IL_0513: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0518: stloc.s 21
+			IL_051a: ldloc.s 23
+			IL_051c: ldloc.s 21
+			IL_051e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0523: pop
+			IL_0524: ldstr "process"
+			IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_052e: volatile.
+			IL_0530: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_0535: brfalse IL_0549
 
-			IL_0554: ldstr "env"
-			IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_055e: br IL_0577
+			IL_053a: ldstr "env"
+			IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0544: br IL_055d
 
-			IL_0563: ldstr "env"
-			IL_0568: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:129"
-			IL_056d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0549: ldstr "env"
+			IL_054e: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:127"
+			IL_0553: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0577: stloc.s 18
-			IL_0579: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_057e: stloc.s 25
-			IL_0580: ldloc.s 25
-			IL_0582: ldloc.s 18
-			IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
-			IL_0589: pop
-			IL_058a: ldloc.s 25
-			IL_058c: ldstr "JROC_WRITE_TEST_ARTIFACTS"
-			IL_0591: ldstr "1"
-			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_059b: pop
-			IL_059c: ldloc.s 25
-			IL_059e: stloc.s 6
-			IL_05a0: ldarg.0
-			IL_05a1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_05a6: stloc.s 26
-			IL_05a8: ldloc.s 4
-			IL_05aa: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05af: stloc.s 22
-			IL_05b1: ldstr "FullyQualifiedName="
-			IL_05b6: ldloc.s 22
-			IL_05b8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05bd: stloc.s 22
-			IL_05bf: ldc.i4.5
-			IL_05c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_05c5: dup
-			IL_05c6: ldstr "test"
-			IL_05cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05d0: dup
-			IL_05d1: ldloc.s 5
-			IL_05d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05d8: dup
-			IL_05d9: ldstr "--filter"
-			IL_05de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05e3: dup
-			IL_05e4: ldloc.s 22
-			IL_05e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_055d: stloc.s 18
+			IL_055f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0564: stloc.s 24
+			IL_0566: ldloc.s 24
+			IL_0568: ldloc.s 18
+			IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
+			IL_056f: pop
+			IL_0570: ldloc.s 24
+			IL_0572: ldstr "JROC_WRITE_TEST_ARTIFACTS"
+			IL_0577: ldstr "1"
+			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0581: pop
+			IL_0582: ldloc.s 24
+			IL_0584: stloc.s 6
+			IL_0586: ldarg.0
+			IL_0587: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_058c: stloc.s 25
+			IL_058e: ldloc.s 4
+			IL_0590: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0595: stloc.s 21
+			IL_0597: ldstr "FullyQualifiedName="
+			IL_059c: ldloc.s 21
+			IL_059e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05a3: stloc.s 21
+			IL_05a5: ldc.i4.5
+			IL_05a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_05ab: dup
+			IL_05ac: ldstr "test"
+			IL_05b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05b6: dup
+			IL_05b7: ldloc.s 5
+			IL_05b9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05be: dup
+			IL_05bf: ldstr "--filter"
+			IL_05c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05c9: dup
+			IL_05ca: ldloc.s 21
+			IL_05cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05d1: dup
+			IL_05d2: ldstr "--no-build"
+			IL_05d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_05dc: stloc.s 26
+			IL_05de: ldarg.0
+			IL_05df: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_05e4: stloc.s 18
+			IL_05e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_05eb: dup
-			IL_05ec: ldstr "--no-build"
-			IL_05f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_05f6: stloc.s 27
-			IL_05f8: ldarg.0
-			IL_05f9: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_05fe: stloc.s 18
-			IL_0600: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0605: dup
-			IL_0606: ldstr "stdio"
-			IL_060b: ldstr "inherit"
-			IL_0610: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0615: dup
-			IL_0616: ldstr "shell"
-			IL_061b: ldc.i4.1
-			IL_061c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0621: dup
-			IL_0622: ldstr "cwd"
-			IL_0627: ldloc.s 18
-			IL_0629: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_062e: dup
-			IL_062f: ldstr "env"
-			IL_0634: ldloc.s 6
-			IL_0636: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_063b: stloc.s 25
-			IL_063d: ldloc.s 26
-			IL_063f: ldstr "dotnet"
-			IL_0644: ldloc.s 27
-			IL_0646: ldloc.s 25
-			IL_0648: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_064d: stloc.s 7
-			IL_064f: ldarg.0
-			IL_0650: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
-			IL_0655: ldc.i4.1
-			IL_0656: newarr [System.Runtime]System.Object
-			IL_065b: dup
-			IL_065c: ldc.i4.0
-			IL_065d: ldarg.0
-			IL_065e: stelem.ref
-			IL_065f: ldloc.2
-			IL_0660: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0665: stloc.s 8
-			IL_0667: volatile.
-			IL_0669: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_066e: brfalse IL_0684
+			IL_05ec: ldstr "stdio"
+			IL_05f1: ldstr "inherit"
+			IL_05f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05fb: dup
+			IL_05fc: ldstr "shell"
+			IL_0601: ldc.i4.1
+			IL_0602: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0607: dup
+			IL_0608: ldstr "cwd"
+			IL_060d: ldloc.s 18
+			IL_060f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0614: dup
+			IL_0615: ldstr "env"
+			IL_061a: ldloc.s 6
+			IL_061c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0621: stloc.s 24
+			IL_0623: ldloc.s 25
+			IL_0625: ldstr "dotnet"
+			IL_062a: ldloc.s 26
+			IL_062c: ldloc.s 24
+			IL_062e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_0633: stloc.s 7
+			IL_0635: ldnull
+			IL_0636: ldloc.2
+			IL_0637: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
+			IL_063c: stloc.s 8
+			IL_063e: volatile.
+			IL_0640: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0645: brfalse IL_065b
 
-			IL_0673: ldloc.s 7
-			IL_0675: ldstr "status"
-			IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_067f: br IL_069a
+			IL_064a: ldloc.s 7
+			IL_064c: ldstr "status"
+			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0656: br IL_0671
 
-			IL_0684: ldloc.s 7
-			IL_0686: ldstr "status"
-			IL_068b: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:159"
-			IL_0690: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_065b: ldloc.s 7
+			IL_065d: ldstr "status"
+			IL_0662: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:156"
+			IL_0667: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_069a: stloc.s 18
-			IL_069c: ldloc.s 18
-			IL_069e: ldc.r8 0.0
-			IL_06a7: box [System.Runtime]System.Double
-			IL_06ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_06b1: stloc.s 19
-			IL_06b3: ldloc.s 19
-			IL_06b5: brfalse IL_06dd
+			IL_0671: stloc.s 18
+			IL_0673: ldloc.s 18
+			IL_0675: ldc.r8 0.0
+			IL_067e: box [System.Runtime]System.Double
+			IL_0683: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0688: stloc.s 19
+			IL_068a: ldloc.s 19
+			IL_068c: brfalse IL_06ab
 
-			IL_06ba: ldarg.0
-			IL_06bb: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_06c0: ldc.i4.1
-			IL_06c1: newarr [System.Runtime]System.Object
-			IL_06c6: dup
-			IL_06c7: ldc.i4.0
-			IL_06c8: ldarg.0
-			IL_06c9: stelem.ref
-			IL_06ca: ldloc.1
-			IL_06cb: ldloc.s 8
-			IL_06cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06d2: stloc.s 18
-			IL_06d4: ldloc.s 18
-			IL_06d6: stloc.s 9
-			IL_06d8: br IL_06e5
+			IL_0691: ldarg.0
+			IL_0692: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_0697: ldnull
+			IL_0698: ldloc.1
+			IL_0699: ldloc.s 8
+			IL_069b: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+			IL_06a0: stloc.s 18
+			IL_06a2: ldloc.s 18
+			IL_06a4: stloc.s 9
+			IL_06a6: br IL_06b3
 
-			IL_06dd: ldc.i4.0
-			IL_06de: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_06e3: stloc.s 9
+			IL_06ab: ldc.i4.0
+			IL_06ac: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_06b1: stloc.s 9
 
-			IL_06e5: ldloc.s 9
-			IL_06e7: stloc.s 10
-			IL_06e9: ldloc.s 10
-			IL_06eb: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_06f0: ldc.i4.0
-			IL_06f1: ceq
-			IL_06f3: stloc.s 19
-			IL_06f5: ldloc.s 19
-			IL_06f7: brfalse IL_08ea
+			IL_06b3: ldloc.s 9
+			IL_06b5: stloc.s 10
+			IL_06b7: ldloc.s 10
+			IL_06b9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06be: ldc.i4.0
+			IL_06bf: ceq
+			IL_06c1: stloc.s 19
+			IL_06c3: ldloc.s 19
+			IL_06c5: brfalse IL_08af
 
-			IL_06fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0701: stloc.s 24
-			IL_0703: ldloc.s 24
-			IL_0705: ldstr "Test did not produce an assembly, retrying with build..."
-			IL_070a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_070f: pop
-			IL_0710: ldarg.0
-			IL_0711: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0716: stloc.s 26
-			IL_0718: ldloc.s 4
-			IL_071a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_071f: stloc.s 22
-			IL_0721: ldstr "FullyQualifiedName="
-			IL_0726: ldloc.s 22
-			IL_0728: call string [System.Runtime]System.String::Concat(string, string)
-			IL_072d: stloc.s 22
-			IL_072f: ldc.i4.4
-			IL_0730: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0735: dup
-			IL_0736: ldstr "test"
-			IL_073b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0740: dup
-			IL_0741: ldloc.s 5
-			IL_0743: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_06ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06cf: stloc.s 23
+			IL_06d1: ldloc.s 23
+			IL_06d3: ldstr "Test did not produce an assembly, retrying with build..."
+			IL_06d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06dd: pop
+			IL_06de: ldarg.0
+			IL_06df: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_06e4: stloc.s 25
+			IL_06e6: ldloc.s 4
+			IL_06e8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06ed: stloc.s 21
+			IL_06ef: ldstr "FullyQualifiedName="
+			IL_06f4: ldloc.s 21
+			IL_06f6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06fb: stloc.s 21
+			IL_06fd: ldc.i4.4
+			IL_06fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0703: dup
+			IL_0704: ldstr "test"
+			IL_0709: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_070e: dup
+			IL_070f: ldloc.s 5
+			IL_0711: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0716: dup
+			IL_0717: ldstr "--filter"
+			IL_071c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0721: dup
+			IL_0722: ldloc.s 21
+			IL_0724: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0729: stloc.s 26
+			IL_072b: ldarg.0
+			IL_072c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_0731: stloc.s 18
+			IL_0733: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0738: dup
+			IL_0739: ldstr "stdio"
+			IL_073e: ldstr "inherit"
+			IL_0743: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0748: dup
-			IL_0749: ldstr "--filter"
-			IL_074e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0753: dup
-			IL_0754: ldloc.s 22
-			IL_0756: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_075b: stloc.s 27
-			IL_075d: ldarg.0
-			IL_075e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0763: stloc.s 18
-			IL_0765: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_076a: dup
-			IL_076b: ldstr "stdio"
-			IL_0770: ldstr "inherit"
-			IL_0775: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_077a: dup
-			IL_077b: ldstr "shell"
-			IL_0780: ldc.i4.1
-			IL_0781: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0786: dup
-			IL_0787: ldstr "cwd"
-			IL_078c: ldloc.s 18
-			IL_078e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0793: dup
-			IL_0794: ldstr "env"
-			IL_0799: ldloc.s 6
-			IL_079b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_07a0: stloc.s 25
-			IL_07a2: ldloc.s 26
-			IL_07a4: ldstr "dotnet"
-			IL_07a9: ldloc.s 27
-			IL_07ab: ldloc.s 25
-			IL_07ad: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_07b2: stloc.s 11
-			IL_07b4: volatile.
-			IL_07b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_07bb: brfalse IL_07d1
+			IL_0749: ldstr "shell"
+			IL_074e: ldc.i4.1
+			IL_074f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0754: dup
+			IL_0755: ldstr "cwd"
+			IL_075a: ldloc.s 18
+			IL_075c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0761: dup
+			IL_0762: ldstr "env"
+			IL_0767: ldloc.s 6
+			IL_0769: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_076e: stloc.s 24
+			IL_0770: ldloc.s 25
+			IL_0772: ldstr "dotnet"
+			IL_0777: ldloc.s 26
+			IL_0779: ldloc.s 24
+			IL_077b: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_0780: stloc.s 11
+			IL_0782: volatile.
+			IL_0784: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_0789: brfalse IL_079f
 
-			IL_07c0: ldloc.s 11
-			IL_07c2: ldstr "status"
-			IL_07c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07cc: br IL_07e7
+			IL_078e: ldloc.s 11
+			IL_0790: ldstr "status"
+			IL_0795: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_079a: br IL_07b5
 
-			IL_07d1: ldloc.s 11
-			IL_07d3: ldstr "status"
-			IL_07d8: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:199"
-			IL_07dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-			IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_079f: ldloc.s 11
+			IL_07a1: ldstr "status"
+			IL_07a6: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:195"
+			IL_07ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+			IL_07b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07e7: stloc.s 18
-			IL_07e9: ldloc.s 18
-			IL_07eb: ldc.r8 0.0
-			IL_07f4: box [System.Runtime]System.Double
-			IL_07f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_07fe: stloc.s 19
-			IL_0800: ldloc.s 19
-			IL_0802: brfalse IL_08cc
+			IL_07b5: stloc.s 18
+			IL_07b7: ldloc.s 18
+			IL_07b9: ldc.r8 0.0
+			IL_07c2: box [System.Runtime]System.Double
+			IL_07c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_07cc: stloc.s 19
+			IL_07ce: ldloc.s 19
+			IL_07d0: brfalse IL_089a
 
-			IL_0807: ldstr "console"
-			IL_080c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0811: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0816: stloc.s 18
-			IL_0818: ldloc.s 4
-			IL_081a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_081f: stloc.s 22
-			IL_0821: ldstr "Test "
-			IL_0826: ldloc.s 22
-			IL_0828: call string [System.Runtime]System.String::Concat(string, string)
-			IL_082d: ldstr " failed or not found."
-			IL_0832: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0837: stloc.s 22
-			IL_0839: volatile.
-			IL_083b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_0840: brfalse IL_0858
+			IL_07d5: ldstr "console"
+			IL_07da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07e4: stloc.s 18
+			IL_07e6: ldloc.s 4
+			IL_07e8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07ed: stloc.s 21
+			IL_07ef: ldstr "Test "
+			IL_07f4: ldloc.s 21
+			IL_07f6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07fb: ldstr " failed or not found."
+			IL_0800: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0805: stloc.s 21
+			IL_0807: volatile.
+			IL_0809: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_080e: brfalse IL_0826
 
-			IL_0845: ldloc.s 18
-			IL_0847: ldstr "error"
-			IL_084c: ldloc.s 22
-			IL_084e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0853: br IL_0870
+			IL_0813: ldloc.s 18
+			IL_0815: ldstr "error"
+			IL_081a: ldloc.s 21
+			IL_081c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0821: br IL_083e
 
-			IL_0858: ldloc.s 18
-			IL_085a: ldstr "error"
-			IL_085f: ldloc.s 22
-			IL_0861: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:213"
-			IL_0866: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-			IL_086b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0826: ldloc.s 18
+			IL_0828: ldstr "error"
+			IL_082d: ldloc.s 21
+			IL_082f: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:209"
+			IL_0834: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+			IL_0839: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0870: pop
-			IL_0871: ldstr "process"
-			IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_087b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0880: volatile.
-			IL_0882: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_0887: brfalse IL_08a9
+			IL_083e: pop
+			IL_083f: ldstr "process"
+			IL_0844: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0849: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_084e: volatile.
+			IL_0850: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0855: brfalse IL_0877
 
-			IL_088c: ldstr "exit"
-			IL_0891: ldc.r8 1
-			IL_089a: box [System.Runtime]System.Double
-			IL_089f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_08a4: br IL_08cb
+			IL_085a: ldstr "exit"
+			IL_085f: ldc.r8 1
+			IL_0868: box [System.Runtime]System.Double
+			IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0872: br IL_0899
 
-			IL_08a9: ldstr "exit"
-			IL_08ae: ldc.r8 1
-			IL_08b7: box [System.Runtime]System.Double
-			IL_08bc: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:220"
-			IL_08c1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_08c6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0877: ldstr "exit"
+			IL_087c: ldc.r8 1
+			IL_0885: box [System.Runtime]System.Double
+			IL_088a: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:216"
+			IL_088f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0894: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_08cb: pop
+			IL_0899: pop
 
-			IL_08cc: ldarg.0
-			IL_08cd: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_08d2: ldc.i4.1
-			IL_08d3: newarr [System.Runtime]System.Object
-			IL_08d8: dup
-			IL_08d9: ldc.i4.0
-			IL_08da: ldarg.0
-			IL_08db: stelem.ref
-			IL_08dc: ldloc.1
-			IL_08dd: ldloc.s 8
-			IL_08df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_08e4: stloc.s 18
-			IL_08e6: ldloc.s 18
-			IL_08e8: stloc.s 10
+			IL_089a: ldarg.0
+			IL_089b: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_08a0: ldnull
+			IL_08a1: ldloc.1
+			IL_08a2: ldloc.s 8
+			IL_08a4: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+			IL_08a9: stloc.s 18
+			IL_08ab: ldloc.s 18
+			IL_08ad: stloc.s 10
 
-			IL_08ea: ldloc.s 10
-			IL_08ec: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_08f1: ldc.i4.0
-			IL_08f2: ceq
-			IL_08f4: stloc.s 19
-			IL_08f6: ldloc.s 19
-			IL_08f8: brfalse IL_0b5d
+			IL_08af: ldloc.s 10
+			IL_08b1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08b6: ldc.i4.0
+			IL_08b7: ceq
+			IL_08b9: stloc.s 19
+			IL_08bb: ldloc.s 19
+			IL_08bd: brfalse IL_0b19
 
-			IL_08fd: ldstr "console"
-			IL_0902: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0907: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_090c: stloc.s 18
-			IL_090e: volatile.
-			IL_0910: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_0915: brfalse IL_092a
+			IL_08c2: ldstr "console"
+			IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_08d1: stloc.s 18
+			IL_08d3: volatile.
+			IL_08d5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_08da: brfalse IL_08ef
 
-			IL_091a: ldloc.1
-			IL_091b: ldstr "path"
-			IL_0920: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0925: br IL_093f
+			IL_08df: ldloc.1
+			IL_08e0: ldstr "path"
+			IL_08e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08ea: br IL_0904
 
-			IL_092a: ldloc.1
-			IL_092b: ldstr "path"
-			IL_0930: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:238"
-			IL_0935: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_093a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_08ef: ldloc.1
+			IL_08f0: ldstr "path"
+			IL_08f5: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:233"
+			IL_08fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_08ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_093f: stloc.s 28
-			IL_0941: ldloc.s 28
-			IL_0943: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0948: stloc.s 22
-			IL_094a: ldstr "Assembly not found for category '"
-			IL_094f: ldloc.s 22
-			IL_0951: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0956: ldstr "' and test '"
-			IL_095b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0960: ldloc.2
-			IL_0961: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0966: stloc.s 22
-			IL_0968: ldloc.s 22
-			IL_096a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_096f: ldstr "'."
-			IL_0974: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0979: stloc.s 22
-			IL_097b: volatile.
-			IL_097d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_0982: brfalse IL_099a
+			IL_0904: stloc.s 27
+			IL_0906: ldloc.s 27
+			IL_0908: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_090d: stloc.s 21
+			IL_090f: ldstr "Assembly not found for category '"
+			IL_0914: ldloc.s 21
+			IL_0916: call string [System.Runtime]System.String::Concat(string, string)
+			IL_091b: ldstr "' and test '"
+			IL_0920: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0925: ldloc.2
+			IL_0926: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_092b: stloc.s 21
+			IL_092d: ldloc.s 21
+			IL_092f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0934: ldstr "'."
+			IL_0939: call string [System.Runtime]System.String::Concat(string, string)
+			IL_093e: stloc.s 21
+			IL_0940: volatile.
+			IL_0942: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_0947: brfalse IL_095f
 
-			IL_0987: ldloc.s 18
-			IL_0989: ldstr "error"
-			IL_098e: ldloc.s 22
-			IL_0990: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0995: br IL_09b2
+			IL_094c: ldloc.s 18
+			IL_094e: ldstr "error"
+			IL_0953: ldloc.s 21
+			IL_0955: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_095a: br IL_0977
 
-			IL_099a: ldloc.s 18
-			IL_099c: ldstr "error"
-			IL_09a1: ldloc.s 22
-			IL_09a3: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:247"
-			IL_09a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_09ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_095f: ldloc.s 18
+			IL_0961: ldstr "error"
+			IL_0966: ldloc.s 21
+			IL_0968: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:242"
+			IL_096d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_0972: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_09b2: pop
-			IL_09b3: ldstr "console"
-			IL_09b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09c2: volatile.
-			IL_09c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_09c9: brfalse IL_09e2
+			IL_0977: pop
+			IL_0978: ldstr "console"
+			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0982: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0987: volatile.
+			IL_0989: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_098e: brfalse IL_09a7
 
-			IL_09ce: ldstr "error"
-			IL_09d3: ldstr "Looked under:"
-			IL_09d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_09dd: br IL_09fb
+			IL_0993: ldstr "error"
+			IL_0998: ldstr "Looked under:"
+			IL_099d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09a2: br IL_09c0
 
-			IL_09e2: ldstr "error"
-			IL_09e7: ldstr "Looked under:"
-			IL_09ec: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:253"
-			IL_09f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_09f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_09a7: ldstr "error"
+			IL_09ac: ldstr "Looked under:"
+			IL_09b1: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:248"
+			IL_09b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_09bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_09fb: pop
-			IL_09fc: ldarg.0
-			IL_09fd: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_0a02: ldc.i4.1
-			IL_0a03: newarr [System.Runtime]System.Object
-			IL_0a08: dup
-			IL_0a09: ldc.i4.0
-			IL_0a0a: ldarg.0
-			IL_0a0b: stelem.ref
-			IL_0a0c: ldloc.1
-			IL_0a0d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0a12: stloc.s 12
-			IL_0a14: ldc.r8 0.0
-			IL_0a1d: stloc.s 13
-			// loop start (head: IL_0a1f)
-				IL_0a1f: ldloc.s 13
-				IL_0a21: stloc.s 29
-				IL_0a23: ldloc.s 12
-				IL_0a25: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-				IL_0a2a: stloc.s 30
-				IL_0a2c: ldloc.s 29
-				IL_0a2e: ldloc.s 30
-				IL_0a30: clt
-				IL_0a32: brfalse IL_0ab9
+			IL_09c0: pop
+			IL_09c1: ldarg.0
+			IL_09c2: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_09c7: ldnull
+			IL_09c8: ldloc.1
+			IL_09c9: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+			IL_09ce: stloc.s 12
+			IL_09d0: ldc.r8 0.0
+			IL_09d9: stloc.s 13
+			// loop start (head: IL_09db)
+				IL_09db: ldloc.s 13
+				IL_09dd: stloc.s 28
+				IL_09df: ldloc.s 12
+				IL_09e1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_09e6: stloc.s 29
+				IL_09e8: ldloc.s 28
+				IL_09ea: ldloc.s 29
+				IL_09ec: clt
+				IL_09ee: brfalse IL_0a75
 
-				IL_0a37: ldstr "console"
-				IL_0a3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0a41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0a46: stloc.s 18
-				IL_0a48: ldloc.s 12
-				IL_0a4a: ldloc.s 13
-				IL_0a4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0a51: stloc.s 28
-				IL_0a53: ldloc.s 28
-				IL_0a55: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0a5a: stloc.s 22
-				IL_0a5c: ldstr "  - "
-				IL_0a61: ldloc.s 22
-				IL_0a63: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0a68: stloc.s 22
-				IL_0a6a: volatile.
-				IL_0a6c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-				IL_0a71: brfalse IL_0a89
+				IL_09f3: ldstr "console"
+				IL_09f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_09fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0a02: stloc.s 18
+				IL_0a04: ldloc.s 12
+				IL_0a06: ldloc.s 13
+				IL_0a08: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0a0d: stloc.s 27
+				IL_0a0f: ldloc.s 27
+				IL_0a11: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0a16: stloc.s 21
+				IL_0a18: ldstr "  - "
+				IL_0a1d: ldloc.s 21
+				IL_0a1f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0a24: stloc.s 21
+				IL_0a26: volatile.
+				IL_0a28: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+				IL_0a2d: brfalse IL_0a45
 
-				IL_0a76: ldloc.s 18
-				IL_0a78: ldstr "error"
-				IL_0a7d: ldloc.s 22
-				IL_0a7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0a84: br IL_0aa1
+				IL_0a32: ldloc.s 18
+				IL_0a34: ldstr "error"
+				IL_0a39: ldloc.s 21
+				IL_0a3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0a40: br IL_0a5d
 
-				IL_0a89: ldloc.s 18
-				IL_0a8b: ldstr "error"
-				IL_0a90: ldloc.s 22
-				IL_0a92: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:275"
-				IL_0a97: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-				IL_0a9c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+				IL_0a45: ldloc.s 18
+				IL_0a47: ldstr "error"
+				IL_0a4c: ldloc.s 21
+				IL_0a4e: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:269"
+				IL_0a53: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+				IL_0a58: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0aa1: pop
-				IL_0aa2: ldloc.s 13
-				IL_0aa4: ldc.r8 1
-				IL_0aad: add
-				IL_0aae: stloc.s 30
-				IL_0ab0: ldloc.s 30
-				IL_0ab2: stloc.s 13
-				IL_0ab4: br IL_0a1f
+				IL_0a5d: pop
+				IL_0a5e: ldloc.s 13
+				IL_0a60: ldc.r8 1
+				IL_0a69: add
+				IL_0a6a: stloc.s 29
+				IL_0a6c: ldloc.s 29
+				IL_0a6e: stloc.s 13
+				IL_0a70: br IL_09db
 			// end loop
 
-			IL_0ab9: ldstr "console"
-			IL_0abe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0ac3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0ac8: volatile.
-			IL_0aca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_0acf: brfalse IL_0ae8
+			IL_0a75: ldstr "console"
+			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a84: volatile.
+			IL_0a86: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0a8b: brfalse IL_0aa4
 
-			IL_0ad4: ldstr "error"
-			IL_0ad9: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_0ade: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0ae3: br IL_0b01
+			IL_0a90: ldstr "error"
+			IL_0a95: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0a9f: br IL_0abd
 
-			IL_0ae8: ldstr "error"
-			IL_0aed: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_0af2: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:288"
-			IL_0af7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_0afc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0aa4: ldstr "error"
+			IL_0aa9: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_0aae: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:282"
+			IL_0ab3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0ab8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0b01: pop
-			IL_0b02: ldstr "process"
-			IL_0b07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b0c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0b11: volatile.
-			IL_0b13: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_0b18: brfalse IL_0b3a
+			IL_0abd: pop
+			IL_0abe: ldstr "process"
+			IL_0ac3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ac8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0acd: volatile.
+			IL_0acf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0ad4: brfalse IL_0af6
 
-			IL_0b1d: ldstr "exit"
-			IL_0b22: ldc.r8 1
-			IL_0b2b: box [System.Runtime]System.Double
-			IL_0b30: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0b35: br IL_0b5c
+			IL_0ad9: ldstr "exit"
+			IL_0ade: ldc.r8 1
+			IL_0ae7: box [System.Runtime]System.Double
+			IL_0aec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0af1: br IL_0b18
 
-			IL_0b3a: ldstr "exit"
-			IL_0b3f: ldc.r8 1
-			IL_0b48: box [System.Runtime]System.Double
-			IL_0b4d: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:295"
-			IL_0b52: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_0b57: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0af6: ldstr "exit"
+			IL_0afb: ldc.r8 1
+			IL_0b04: box [System.Runtime]System.Double
+			IL_0b09: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:289"
+			IL_0b0e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0b13: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0b5c: pop
+			IL_0b18: pop
 
-			IL_0b5d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b62: stloc.s 24
-			IL_0b64: ldloc.s 10
-			IL_0b66: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b6b: stloc.s 22
-			IL_0b6d: ldstr "Found assembly: "
-			IL_0b72: ldloc.s 22
-			IL_0b74: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b79: stloc.s 22
-			IL_0b7b: ldloc.s 24
-			IL_0b7d: ldloc.s 22
-			IL_0b7f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b84: pop
+			IL_0b19: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b1e: stloc.s 23
+			IL_0b20: ldloc.s 10
+			IL_0b22: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b27: stloc.s 21
+			IL_0b29: ldstr "Found assembly: "
+			IL_0b2e: ldloc.s 21
+			IL_0b30: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b35: stloc.s 21
+			IL_0b37: ldloc.s 23
+			IL_0b39: ldloc.s 21
+			IL_0b3b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b40: pop
 			.try
 			{
-				IL_0b85: nop
-				IL_0b86: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0b8b: stloc.s 24
-				IL_0b8d: ldloc.s 24
-				IL_0b8f: ldstr "Opening in ILSpy..."
-				IL_0b94: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0b99: pop
-				IL_0b9a: ldarg.0
-				IL_0b9b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-				IL_0ba0: stloc.s 18
-				IL_0ba2: ldloc.s 18
-				IL_0ba4: ldc.i4.1
-				IL_0ba5: newarr [System.Runtime]System.Object
-				IL_0baa: dup
-				IL_0bab: ldc.i4.0
-				IL_0bac: ldarg.0
-				IL_0bad: stelem.ref
-				IL_0bae: ldloc.s 10
-				IL_0bb0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0bb5: pop
-				IL_0bb6: leave IL_0cd9
+				IL_0b41: nop
+				IL_0b42: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0b47: stloc.s 23
+				IL_0b49: ldloc.s 23
+				IL_0b4b: ldstr "Opening in ILSpy..."
+				IL_0b50: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0b55: pop
+				IL_0b56: ldarg.0
+				IL_0b57: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+				IL_0b5c: ldnull
+				IL_0b5d: ldloc.s 10
+				IL_0b5f: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0b64: pop
+				IL_0b65: leave IL_0c88
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_0bbb: stloc.s 14
-				IL_0bbd: ldloc.s 14
-				IL_0bbf: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0bc4: dup
-				IL_0bc5: brtrue IL_0bdb
+				IL_0b6a: stloc.s 14
+				IL_0b6c: ldloc.s 14
+				IL_0b6e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0b73: dup
+				IL_0b74: brtrue IL_0b8a
 
-				IL_0bca: pop
-				IL_0bcb: ldloc.s 14
-				IL_0bcd: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0bd2: dup
-				IL_0bd3: brtrue IL_0be7
+				IL_0b79: pop
+				IL_0b7a: ldloc.s 14
+				IL_0b7c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0b81: dup
+				IL_0b82: brtrue IL_0b96
 
-				IL_0bd8: pop
-				IL_0bd9: rethrow
+				IL_0b87: pop
+				IL_0b88: rethrow
 
-				IL_0bdb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0be0: stloc.s 15
-				IL_0be2: br IL_0be9
+				IL_0b8a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0b8f: stloc.s 15
+				IL_0b91: br IL_0b98
 
-				IL_0be7: stloc.s 15
+				IL_0b96: stloc.s 15
 
-				IL_0be9: ldloc.s 15
-				IL_0beb: stloc.s 16
-				IL_0bed: ldstr "console"
-				IL_0bf2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0bf7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0bfc: volatile.
-				IL_0bfe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-				IL_0c03: brfalse IL_0c1c
+				IL_0b98: ldloc.s 15
+				IL_0b9a: stloc.s 16
+				IL_0b9c: ldstr "console"
+				IL_0ba1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0ba6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0bab: volatile.
+				IL_0bad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+				IL_0bb2: brfalse IL_0bcb
 
-				IL_0c08: ldstr "error"
-				IL_0c0d: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_0c12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0c17: br IL_0c35
+				IL_0bb7: ldstr "error"
+				IL_0bbc: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_0bc1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0bc6: br IL_0be4
 
-				IL_0c1c: ldstr "error"
-				IL_0c21: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_0c26: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:326"
-				IL_0c2b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-				IL_0c30: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+				IL_0bcb: ldstr "error"
+				IL_0bd0: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_0bd5: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:319"
+				IL_0bda: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+				IL_0bdf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0c35: pop
-				IL_0c36: ldstr "console"
-				IL_0c3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0c40: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0c45: volatile.
-				IL_0c47: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-				IL_0c4c: brfalse IL_0c62
+				IL_0be4: pop
+				IL_0be5: ldstr "console"
+				IL_0bea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0bef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0bf4: volatile.
+				IL_0bf6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+				IL_0bfb: brfalse IL_0c11
 
-				IL_0c51: ldstr "error"
-				IL_0c56: ldloc.s 16
-				IL_0c58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0c5d: br IL_0c78
+				IL_0c00: ldstr "error"
+				IL_0c05: ldloc.s 16
+				IL_0c07: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0c0c: br IL_0c27
 
-				IL_0c62: ldstr "error"
-				IL_0c67: ldloc.s 16
-				IL_0c69: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:331"
-				IL_0c6e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-				IL_0c73: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+				IL_0c11: ldstr "error"
+				IL_0c16: ldloc.s 16
+				IL_0c18: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:324"
+				IL_0c1d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+				IL_0c22: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0c78: pop
-				IL_0c79: ldstr "process"
-				IL_0c7e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0c83: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0c88: volatile.
-				IL_0c8a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-				IL_0c8f: brfalse IL_0cb1
+				IL_0c27: pop
+				IL_0c28: ldstr "process"
+				IL_0c2d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0c32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0c37: volatile.
+				IL_0c39: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+				IL_0c3e: brfalse IL_0c60
 
-				IL_0c94: ldstr "exit"
-				IL_0c99: ldc.r8 1
-				IL_0ca2: box [System.Runtime]System.Double
-				IL_0ca7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0cac: br IL_0cd3
+				IL_0c43: ldstr "exit"
+				IL_0c48: ldc.r8 1
+				IL_0c51: box [System.Runtime]System.Double
+				IL_0c56: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0c5b: br IL_0c82
 
-				IL_0cb1: ldstr "exit"
-				IL_0cb6: ldc.r8 1
-				IL_0cbf: box [System.Runtime]System.Double
-				IL_0cc4: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:338"
-				IL_0cc9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-				IL_0cce: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+				IL_0c60: ldstr "exit"
+				IL_0c65: ldc.r8 1
+				IL_0c6e: box [System.Runtime]System.Double
+				IL_0c73: ldstr "Compile_Scripts_DecompileGeneratorTest:<TwoPhaseDummy_M12>:__js_call__:331"
+				IL_0c78: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+				IL_0c7d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0cd3: pop
-				IL_0cd4: leave IL_0cd9
+				IL_0c82: pop
+				IL_0c83: leave IL_0c88
 			} // end handler
 
-			IL_0cd9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0cde: stloc.s 24
-			IL_0ce0: ldloc.s 24
-			IL_0ce2: ldstr "Done!"
-			IL_0ce7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0cec: pop
-			IL_0ced: ldnull
-			IL_0cee: stloc.s 17
-			IL_0cf0: ldloc.s 17
-			IL_0cf2: ret
+			IL_0c88: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c8d: stloc.s 23
+			IL_0c8f: ldloc.s 23
+			IL_0c91: ldstr "Done!"
+			IL_0c96: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c9b: pop
+			IL_0c9c: ldnull
+			IL_0c9d: stloc.s 17
+			IL_0c9f: ldloc.s 17
+			IL_0ca1: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -4860,22 +4804,22 @@
 		IL_01f4: nop
 		IL_01f5: nop
 		IL_01f6: nop
-		IL_01f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01fc: stloc.3
-		IL_01fd: ldloc.1
-		IL_01fe: ldloc.3
-		IL_01ff: ldarg.s __dirname
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0206: stloc.s 15
-		IL_0208: ldloc.0
-		IL_0209: ldloc.s 15
-		IL_020b: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+		IL_01f7: ldloc.0
+		IL_01f8: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+		IL_01fd: ldnull
+		IL_01fe: ldarg.s __dirname
+		IL_0200: call object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+		IL_0205: stloc.s 15
+		IL_0207: ldloc.0
+		IL_0208: ldloc.s 15
+		IL_020a: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+		IL_020f: nop
 		IL_0210: nop
 		IL_0211: nop
-		IL_0212: nop
-		IL_0213: ldloc.2
-		IL_0214: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0212: ldloc.0
+		IL_0213: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+		IL_0218: ldnull
+		IL_0219: call object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
 		IL_021e: pop
 		IL_021f: ret
 	} // end of method Compile_Scripts_DecompileGeneratorTest::__js_module_init__

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -2451,7 +2451,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 1445 (0x5a5)
+					// Code size: 1413 (0x585)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -2587,7 +2587,7 @@
 					IL_0141: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_0146: stloc.s 5
 					IL_0148: ldloc.s 5
-					IL_014a: brfalse IL_0344
+					IL_014a: brfalse IL_0324
 
 					IL_014f: ldarg.0
 					IL_0150: ldc.i4.1
@@ -2721,324 +2721,302 @@
 
 					IL_02af: pop
 					IL_02b0: ldarg.0
-					IL_02b1: ldc.i4.0
+					IL_02b1: ldc.i4.1
 					IL_02b2: ldelem.ref
-					IL_02b3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_02b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-					IL_02bd: ldc.i4.3
-					IL_02be: newarr [System.Runtime]System.Object
-					IL_02c3: dup
-					IL_02c4: ldc.i4.0
-					IL_02c5: ldarg.0
-					IL_02c6: ldc.i4.0
-					IL_02c7: ldelem.ref
-					IL_02c8: stelem.ref
-					IL_02c9: dup
-					IL_02ca: ldc.i4.1
-					IL_02cb: ldarg.0
-					IL_02cc: ldc.i4.1
-					IL_02cd: ldelem.ref
-					IL_02ce: stelem.ref
-					IL_02cf: dup
-					IL_02d0: ldc.i4.2
-					IL_02d1: ldarg.0
-					IL_02d2: ldc.i4.2
-					IL_02d3: ldelem.ref
-					IL_02d4: stelem.ref
-					IL_02d5: stloc.s 12
+					IL_02b3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_02b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_02bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_02c2: ldc.r8 1
+					IL_02cb: sub
+					IL_02cc: stloc.s 16
+					IL_02ce: ldloc.s 16
+					IL_02d0: box [System.Runtime]System.Double
+					IL_02d5: stloc.s 17
 					IL_02d7: ldarg.0
-					IL_02d8: ldc.i4.1
+					IL_02d8: ldc.i4.0
 					IL_02d9: ldelem.ref
-					IL_02da: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_02df: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_02e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_02e9: ldc.r8 1
-					IL_02f2: sub
-					IL_02f3: stloc.s 16
-					IL_02f5: ldloc.s 16
-					IL_02f7: box [System.Runtime]System.Double
-					IL_02fc: stloc.s 17
-					IL_02fe: ldloc.s 12
-					IL_0300: ldloc.3
-					IL_0301: ldloc.s 17
-					IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_0308: stloc.s 13
-					IL_030a: ldloc.s 13
-					IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0311: stloc.s 13
-					IL_0313: ldarg.0
-					IL_0314: ldc.i4.2
-					IL_0315: ldelem.ref
-					IL_0316: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_031b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_0320: stloc.s 4
-					IL_0322: ldarg.0
-					IL_0323: ldc.i4.2
-					IL_0324: ldelem.ref
-					IL_0325: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_032a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_032f: stloc.s 18
-					IL_0331: ldloc.s 13
-					IL_0333: ldstr "then"
-					IL_0338: ldloc.s 4
-					IL_033a: ldloc.s 18
-					IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_0341: pop
-					IL_0342: ldnull
-					IL_0343: ret
+					IL_02da: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_02df: ldnull
+					IL_02e0: ldloc.3
+					IL_02e1: ldloc.s 17
+					IL_02e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+					IL_02e8: stloc.s 13
+					IL_02ea: ldloc.s 13
+					IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02f1: stloc.s 13
+					IL_02f3: ldarg.0
+					IL_02f4: ldc.i4.2
+					IL_02f5: ldelem.ref
+					IL_02f6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02fb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0300: stloc.s 4
+					IL_0302: ldarg.0
+					IL_0303: ldc.i4.2
+					IL_0304: ldelem.ref
+					IL_0305: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_030a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_030f: stloc.s 18
+					IL_0311: ldloc.s 13
+					IL_0313: ldstr "then"
+					IL_0318: ldloc.s 4
+					IL_031a: ldloc.s 18
+					IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0321: pop
+					IL_0322: ldnull
+					IL_0323: ret
 
-					IL_0344: ldloc.1
-					IL_0345: ldc.r8 200
-					IL_034e: box [System.Runtime]System.Double
-					IL_0353: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-					IL_0358: stloc.s 5
-					IL_035a: ldloc.s 5
-					IL_035c: box [System.Runtime]System.Boolean
-					IL_0361: stloc.s 8
-					IL_0363: ldloc.s 8
-					IL_0365: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_036a: stloc.s 5
-					IL_036c: ldloc.s 5
-					IL_036e: brtrue IL_039b
+					IL_0324: ldloc.1
+					IL_0325: ldc.r8 200
+					IL_032e: box [System.Runtime]System.Double
+					IL_0333: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+					IL_0338: stloc.s 5
+					IL_033a: ldloc.s 5
+					IL_033c: box [System.Runtime]System.Boolean
+					IL_0341: stloc.s 8
+					IL_0343: ldloc.s 8
+					IL_0345: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_034a: stloc.s 5
+					IL_034c: ldloc.s 5
+					IL_034e: brtrue IL_037b
 
-					IL_0373: ldloc.1
-					IL_0374: ldc.r8 300
-					IL_037d: box [System.Runtime]System.Double
-					IL_0382: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
-					IL_0387: stloc.s 5
-					IL_0389: ldloc.s 5
-					IL_038b: box [System.Runtime]System.Boolean
-					IL_0390: stloc.s 9
-					IL_0392: ldloc.s 9
-					IL_0394: stloc.s 19
-					IL_0396: br IL_039f
+					IL_0353: ldloc.1
+					IL_0354: ldc.r8 300
+					IL_035d: box [System.Runtime]System.Double
+					IL_0362: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
+					IL_0367: stloc.s 5
+					IL_0369: ldloc.s 5
+					IL_036b: box [System.Runtime]System.Boolean
+					IL_0370: stloc.s 9
+					IL_0372: ldloc.s 9
+					IL_0374: stloc.s 19
+					IL_0376: br IL_037f
 
-					IL_039b: ldloc.s 8
-					IL_039d: stloc.s 19
+					IL_037b: ldloc.s 8
+					IL_037d: stloc.s 19
 
-					IL_039f: ldloc.s 19
-					IL_03a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_03a6: stloc.s 5
-					IL_03a8: ldloc.s 5
-					IL_03aa: brfalse IL_0464
+					IL_037f: ldloc.s 19
+					IL_0381: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0386: stloc.s 5
+					IL_0388: ldloc.s 5
+					IL_038a: brfalse IL_0444
 
-					IL_03af: ldarg.2
-					IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03b5: volatile.
-					IL_03b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
-					IL_03bc: brfalse IL_03d0
+					IL_038f: ldarg.2
+					IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0395: volatile.
+					IL_0397: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+					IL_039c: brfalse IL_03b0
 
-					IL_03c1: ldstr "resume"
-					IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_03cb: br IL_03e4
+					IL_03a1: ldstr "resume"
+					IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_03ab: br IL_03c4
 
-					IL_03d0: ldstr "resume"
-					IL_03d5: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:119"
-					IL_03da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
-					IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+					IL_03b0: ldstr "resume"
+					IL_03b5: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:118"
+					IL_03ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+					IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-					IL_03e4: pop
-					IL_03e5: ldarg.0
-					IL_03e6: ldc.i4.2
-					IL_03e7: ldelem.ref
-					IL_03e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_03ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_03f2: stloc.s 18
-					IL_03f4: ldc.i4.3
-					IL_03f5: newarr [System.Runtime]System.Object
-					IL_03fa: dup
-					IL_03fb: ldc.i4.0
-					IL_03fc: ldarg.0
-					IL_03fd: ldc.i4.0
-					IL_03fe: ldelem.ref
-					IL_03ff: stelem.ref
-					IL_0400: dup
-					IL_0401: ldc.i4.1
-					IL_0402: ldarg.0
-					IL_0403: ldc.i4.1
-					IL_0404: ldelem.ref
-					IL_0405: stelem.ref
-					IL_0406: dup
-					IL_0407: ldc.i4.2
-					IL_0408: ldarg.0
-					IL_0409: ldc.i4.2
-					IL_040a: ldelem.ref
-					IL_040b: stelem.ref
-					IL_040c: stloc.s 12
-					IL_040e: ldloc.1
-					IL_040f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0414: stloc.s 14
-					IL_0416: ldstr "HTTP "
-					IL_041b: ldloc.s 14
-					IL_041d: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0422: ldstr " fetching "
-					IL_0427: call string [System.Runtime]System.String::Concat(string, string)
-					IL_042c: ldarg.0
-					IL_042d: ldc.i4.1
-					IL_042e: ldelem.ref
-					IL_042f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0434: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0439: stloc.s 4
-					IL_043b: ldloc.s 4
-					IL_043d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0442: stloc.s 14
-					IL_0444: ldloc.s 14
-					IL_0446: call string [System.Runtime]System.String::Concat(string, string)
-					IL_044b: stloc.s 14
-					IL_044d: ldloc.s 14
-					IL_044f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0454: stloc.s 15
-					IL_0456: ldloc.s 18
-					IL_0458: ldloc.s 12
-					IL_045a: ldloc.s 15
-					IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0461: pop
-					IL_0462: ldnull
-					IL_0463: ret
+					IL_03c4: pop
+					IL_03c5: ldarg.0
+					IL_03c6: ldc.i4.2
+					IL_03c7: ldelem.ref
+					IL_03c8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_03cd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_03d2: stloc.s 18
+					IL_03d4: ldc.i4.3
+					IL_03d5: newarr [System.Runtime]System.Object
+					IL_03da: dup
+					IL_03db: ldc.i4.0
+					IL_03dc: ldarg.0
+					IL_03dd: ldc.i4.0
+					IL_03de: ldelem.ref
+					IL_03df: stelem.ref
+					IL_03e0: dup
+					IL_03e1: ldc.i4.1
+					IL_03e2: ldarg.0
+					IL_03e3: ldc.i4.1
+					IL_03e4: ldelem.ref
+					IL_03e5: stelem.ref
+					IL_03e6: dup
+					IL_03e7: ldc.i4.2
+					IL_03e8: ldarg.0
+					IL_03e9: ldc.i4.2
+					IL_03ea: ldelem.ref
+					IL_03eb: stelem.ref
+					IL_03ec: stloc.s 12
+					IL_03ee: ldloc.1
+					IL_03ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_03f4: stloc.s 14
+					IL_03f6: ldstr "HTTP "
+					IL_03fb: ldloc.s 14
+					IL_03fd: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0402: ldstr " fetching "
+					IL_0407: call string [System.Runtime]System.String::Concat(string, string)
+					IL_040c: ldarg.0
+					IL_040d: ldc.i4.1
+					IL_040e: ldelem.ref
+					IL_040f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0414: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0419: stloc.s 4
+					IL_041b: ldloc.s 4
+					IL_041d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0422: stloc.s 14
+					IL_0424: ldloc.s 14
+					IL_0426: call string [System.Runtime]System.String::Concat(string, string)
+					IL_042b: stloc.s 14
+					IL_042d: ldloc.s 14
+					IL_042f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0434: stloc.s 15
+					IL_0436: ldloc.s 18
+					IL_0438: ldloc.s 12
+					IL_043a: ldloc.s 15
+					IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0441: pop
+					IL_0442: ldnull
+					IL_0443: ret
 
-					IL_0464: ldarg.2
-					IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_046a: volatile.
-					IL_046c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-					IL_0471: brfalse IL_048a
+					IL_0444: ldarg.2
+					IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_044a: volatile.
+					IL_044c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+					IL_0451: brfalse IL_046a
 
-					IL_0476: ldstr "setEncoding"
-					IL_047b: ldstr "utf8"
-					IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0485: br IL_04a3
+					IL_0456: ldstr "setEncoding"
+					IL_045b: ldstr "utf8"
+					IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0465: br IL_0483
 
-					IL_048a: ldstr "setEncoding"
-					IL_048f: ldstr "utf8"
-					IL_0494: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:141"
-					IL_0499: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-					IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+					IL_046a: ldstr "setEncoding"
+					IL_046f: ldstr "utf8"
+					IL_0474: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:140"
+					IL_0479: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+					IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-					IL_04a3: pop
-					IL_04a4: ldloc.0
-					IL_04a5: ldstr ""
-					IL_04aa: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_04af: ldarg.2
-					IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_04b5: stloc.s 18
-					IL_04b7: ldc.i4.4
-					IL_04b8: newarr [System.Runtime]System.Object
-					IL_04bd: dup
-					IL_04be: ldc.i4.0
-					IL_04bf: ldarg.0
-					IL_04c0: ldc.i4.0
+					IL_0483: pop
+					IL_0484: ldloc.0
+					IL_0485: ldstr ""
+					IL_048a: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_048f: ldarg.2
+					IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0495: stloc.s 18
+					IL_0497: ldc.i4.4
+					IL_0498: newarr [System.Runtime]System.Object
+					IL_049d: dup
+					IL_049e: ldc.i4.0
+					IL_049f: ldarg.0
+					IL_04a0: ldc.i4.0
+					IL_04a1: ldelem.ref
+					IL_04a2: stelem.ref
+					IL_04a3: dup
+					IL_04a4: ldc.i4.1
+					IL_04a5: ldarg.0
+					IL_04a6: ldc.i4.1
+					IL_04a7: ldelem.ref
+					IL_04a8: stelem.ref
+					IL_04a9: dup
+					IL_04aa: ldc.i4.2
+					IL_04ab: ldarg.0
+					IL_04ac: ldc.i4.2
+					IL_04ad: ldelem.ref
+					IL_04ae: stelem.ref
+					IL_04af: dup
+					IL_04b0: ldc.i4.3
+					IL_04b1: ldloc.0
+					IL_04b2: stelem.ref
+					IL_04b3: stloc.s 12
+					IL_04b5: ldloc.s 12
+					IL_04b7: ldc.i4.0
+					IL_04b8: ldelem.ref
+					IL_04b9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_04be: ldloc.s 12
+					IL_04c0: ldc.i4.1
 					IL_04c1: ldelem.ref
-					IL_04c2: stelem.ref
-					IL_04c3: dup
-					IL_04c4: ldc.i4.1
-					IL_04c5: ldarg.0
-					IL_04c6: ldc.i4.1
-					IL_04c7: ldelem.ref
-					IL_04c8: stelem.ref
-					IL_04c9: dup
-					IL_04ca: ldc.i4.2
-					IL_04cb: ldarg.0
-					IL_04cc: ldc.i4.2
-					IL_04cd: ldelem.ref
-					IL_04ce: stelem.ref
-					IL_04cf: dup
-					IL_04d0: ldc.i4.3
-					IL_04d1: ldloc.0
-					IL_04d2: stelem.ref
-					IL_04d3: stloc.s 12
-					IL_04d5: ldloc.s 12
-					IL_04d7: ldc.i4.0
-					IL_04d8: ldelem.ref
-					IL_04d9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_04de: ldloc.s 12
+					IL_04c2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_04c7: ldloc.s 12
+					IL_04c9: ldc.i4.2
+					IL_04ca: ldelem.ref
+					IL_04cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_04d0: ldloc.s 12
+					IL_04d2: ldc.i4.3
+					IL_04d3: ldelem.ref
+					IL_04d4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+					IL_04d9: ldloc.s 12
+					IL_04db: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
 					IL_04e0: ldc.i4.1
-					IL_04e1: ldelem.ref
-					IL_04e2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_04e7: ldloc.s 12
-					IL_04e9: ldc.i4.2
-					IL_04ea: ldelem.ref
-					IL_04eb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_04f0: ldloc.s 12
-					IL_04f2: ldc.i4.3
-					IL_04f3: ldelem.ref
-					IL_04f4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-					IL_04f9: ldloc.s 12
-					IL_04fb: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
-					IL_0500: ldc.i4.1
-					IL_0501: conv.r8
-					IL_0502: ldstr ""
-					IL_0507: ldc.i4.0
-					IL_0508: ldc.i4.0
-					IL_0509: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0, float64, string, bool, bool)
-					IL_050e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0)
-					IL_0513: stloc.s 20
-					IL_0515: ldloc.s 18
-					IL_0517: ldstr "on"
-					IL_051c: ldstr "data"
-					IL_0521: ldloc.s 20
-					IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_0528: pop
-					IL_0529: ldarg.2
-					IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_052f: stloc.s 18
-					IL_0531: ldc.i4.4
-					IL_0532: newarr [System.Runtime]System.Object
-					IL_0537: dup
-					IL_0538: ldc.i4.0
-					IL_0539: ldarg.0
-					IL_053a: ldc.i4.0
+					IL_04e1: conv.r8
+					IL_04e2: ldstr ""
+					IL_04e7: ldc.i4.0
+					IL_04e8: ldc.i4.0
+					IL_04e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0, float64, string, bool, bool)
+					IL_04ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0)
+					IL_04f3: stloc.s 20
+					IL_04f5: ldloc.s 18
+					IL_04f7: ldstr "on"
+					IL_04fc: ldstr "data"
+					IL_0501: ldloc.s 20
+					IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0508: pop
+					IL_0509: ldarg.2
+					IL_050a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_050f: stloc.s 18
+					IL_0511: ldc.i4.4
+					IL_0512: newarr [System.Runtime]System.Object
+					IL_0517: dup
+					IL_0518: ldc.i4.0
+					IL_0519: ldarg.0
+					IL_051a: ldc.i4.0
+					IL_051b: ldelem.ref
+					IL_051c: stelem.ref
+					IL_051d: dup
+					IL_051e: ldc.i4.1
+					IL_051f: ldarg.0
+					IL_0520: ldc.i4.1
+					IL_0521: ldelem.ref
+					IL_0522: stelem.ref
+					IL_0523: dup
+					IL_0524: ldc.i4.2
+					IL_0525: ldarg.0
+					IL_0526: ldc.i4.2
+					IL_0527: ldelem.ref
+					IL_0528: stelem.ref
+					IL_0529: dup
+					IL_052a: ldc.i4.3
+					IL_052b: ldloc.0
+					IL_052c: stelem.ref
+					IL_052d: stloc.s 12
+					IL_052f: ldloc.s 12
+					IL_0531: ldc.i4.0
+					IL_0532: ldelem.ref
+					IL_0533: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_0538: ldloc.s 12
+					IL_053a: ldc.i4.1
 					IL_053b: ldelem.ref
-					IL_053c: stelem.ref
-					IL_053d: dup
-					IL_053e: ldc.i4.1
-					IL_053f: ldarg.0
-					IL_0540: ldc.i4.1
-					IL_0541: ldelem.ref
-					IL_0542: stelem.ref
-					IL_0543: dup
-					IL_0544: ldc.i4.2
-					IL_0545: ldarg.0
-					IL_0546: ldc.i4.2
-					IL_0547: ldelem.ref
-					IL_0548: stelem.ref
-					IL_0549: dup
-					IL_054a: ldc.i4.3
-					IL_054b: ldloc.0
-					IL_054c: stelem.ref
-					IL_054d: stloc.s 12
-					IL_054f: ldloc.s 12
-					IL_0551: ldc.i4.0
-					IL_0552: ldelem.ref
-					IL_0553: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0558: ldloc.s 12
-					IL_055a: ldc.i4.1
-					IL_055b: ldelem.ref
-					IL_055c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0561: ldloc.s 12
-					IL_0563: ldc.i4.2
-					IL_0564: ldelem.ref
-					IL_0565: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_056a: ldloc.s 12
-					IL_056c: ldc.i4.3
-					IL_056d: ldelem.ref
-					IL_056e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-					IL_0573: ldloc.s 12
-					IL_0575: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
-					IL_057a: ldc.i4.0
-					IL_057b: conv.r8
-					IL_057c: ldstr ""
-					IL_0581: ldc.i4.0
-					IL_0582: ldc.i4.0
-					IL_0583: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0, float64, string, bool, bool)
-					IL_0588: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0)
-					IL_058d: stloc.s 21
-					IL_058f: ldloc.s 18
-					IL_0591: ldstr "on"
-					IL_0596: ldstr "end"
-					IL_059b: ldloc.s 21
-					IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_05a2: pop
-					IL_05a3: ldnull
-					IL_05a4: ret
+					IL_053c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0541: ldloc.s 12
+					IL_0543: ldc.i4.2
+					IL_0544: ldelem.ref
+					IL_0545: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_054a: ldloc.s 12
+					IL_054c: ldc.i4.3
+					IL_054d: ldelem.ref
+					IL_054e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+					IL_0553: ldloc.s 12
+					IL_0555: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
+					IL_055a: ldc.i4.0
+					IL_055b: conv.r8
+					IL_055c: ldstr ""
+					IL_0561: ldc.i4.0
+					IL_0562: ldc.i4.0
+					IL_0563: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0, float64, string, bool, bool)
+					IL_0568: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0)
+					IL_056d: stloc.s 21
+					IL_056f: ldloc.s 18
+					IL_0571: ldstr "on"
+					IL_0576: ldstr "end"
+					IL_057b: ldloc.s 21
+					IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0582: pop
+					IL_0583: ldnull
+					IL_0584: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -4699,7 +4677,7 @@
 				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1413 (0x585)
+			// Code size: 1385 (0x569)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4719,11 +4697,10 @@
 				[14] string,
 				[15] object,
 				[16] bool,
-				[17] object[],
-				[18] float64,
+				[17] float64,
+				[18] object,
 				[19] object,
-				[20] object,
-				[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[20] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
@@ -4925,310 +4902,296 @@
 			IL_0224: throw
 
 			IL_0225: ldarg.0
-			IL_0226: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_022b: ldc.i4.1
-			IL_022c: newarr [System.Runtime]System.Object
-			IL_0231: dup
-			IL_0232: ldc.i4.0
-			IL_0233: ldarg.0
-			IL_0234: stelem.ref
-			IL_0235: stloc.s 17
-			IL_0237: ldloc.s 17
-			IL_0239: ldarg.2
-			IL_023a: ldloc.s 4
-			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0241: stloc.s 6
-			IL_0243: ldloc.s 6
-			IL_0245: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_024a: ldc.i4.0
-			IL_024b: ceq
-			IL_024d: stloc.s 16
-			IL_024f: ldloc.s 16
-			IL_0251: brfalse IL_0296
+			IL_0226: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_022b: ldnull
+			IL_022c: ldarg.2
+			IL_022d: ldloc.s 4
+			IL_022f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0234: stloc.s 6
+			IL_0236: ldloc.s 6
+			IL_0238: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_023d: ldc.i4.0
+			IL_023e: ceq
+			IL_0240: stloc.s 16
+			IL_0242: ldloc.s 16
+			IL_0244: brfalse IL_0289
 
-			IL_0256: ldarg.3
-			IL_0257: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_025c: stloc.s 14
-			IL_025e: ldstr "Could not determine tag name for id '"
-			IL_0263: ldloc.s 14
-			IL_0265: call string [System.Runtime]System.String::Concat(string, string)
-			IL_026a: ldstr "'."
-			IL_026f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0274: stloc.s 14
-			IL_0276: ldloc.s 14
-			IL_0278: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_027d: stloc.s 7
-			IL_027f: ldloc.s 7
-			IL_0281: isinst [System.Runtime]System.Exception
-			IL_0286: dup
-			IL_0287: brtrue IL_0295
+			IL_0249: ldarg.3
+			IL_024a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_024f: stloc.s 14
+			IL_0251: ldstr "Could not determine tag name for id '"
+			IL_0256: ldloc.s 14
+			IL_0258: call string [System.Runtime]System.String::Concat(string, string)
+			IL_025d: ldstr "'."
+			IL_0262: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0267: stloc.s 14
+			IL_0269: ldloc.s 14
+			IL_026b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0270: stloc.s 7
+			IL_0272: ldloc.s 7
+			IL_0274: isinst [System.Runtime]System.Exception
+			IL_0279: dup
+			IL_027a: brtrue IL_0288
 
-			IL_028c: pop
-			IL_028d: ldloc.s 7
-			IL_028f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0294: throw
+			IL_027f: pop
+			IL_0280: ldloc.s 7
+			IL_0282: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0287: throw
 
-			IL_0295: throw
+			IL_0288: throw
 
-			IL_0296: ldarg.0
-			IL_0297: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_029c: ldc.i4.1
-			IL_029d: newarr [System.Runtime]System.Object
-			IL_02a2: dup
-			IL_02a3: ldc.i4.0
-			IL_02a4: ldarg.0
-			IL_02a5: stelem.ref
-			IL_02a6: ldloc.s 6
-			IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_02ad: stloc.s 15
-			IL_02af: ldloc.s 15
-			IL_02b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02b6: stloc.s 14
-			IL_02b8: ldstr "<\\/?"
-			IL_02bd: ldloc.s 14
-			IL_02bf: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02c4: ldstr "\\b[^>]*>"
-			IL_02c9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02ce: stloc.s 14
-			IL_02d0: ldloc.s 14
-			IL_02d2: ldstr "gi"
-			IL_02d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02dc: stloc.s 8
-			IL_02de: ldloc.s 8
-			IL_02e0: ldstr "lastIndex"
-			IL_02e5: ldloc.s 4
-			IL_02e7: ldc.i4.1
-			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_02ed: pop
-			IL_02ee: ldc.r8 0.0
-			IL_02f7: stloc.s 9
-			IL_02f9: ldc.r8 1
-			IL_0302: neg
-			IL_0303: stloc.s 18
-			IL_0305: ldloc.s 18
-			IL_0307: box [System.Runtime]System.Double
-			IL_030c: stloc.s 10
-			// loop start (head: IL_030e)
-				IL_030e: ldc.i4.1
-				IL_030f: brfalse IL_0529
+			IL_0289: ldnull
+			IL_028a: ldloc.s 6
+			IL_028c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+			IL_0291: stloc.s 15
+			IL_0293: ldloc.s 15
+			IL_0295: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_029a: stloc.s 14
+			IL_029c: ldstr "<\\/?"
+			IL_02a1: ldloc.s 14
+			IL_02a3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02a8: ldstr "\\b[^>]*>"
+			IL_02ad: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02b2: stloc.s 14
+			IL_02b4: ldloc.s 14
+			IL_02b6: ldstr "gi"
+			IL_02bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_02c0: stloc.s 8
+			IL_02c2: ldloc.s 8
+			IL_02c4: ldstr "lastIndex"
+			IL_02c9: ldloc.s 4
+			IL_02cb: ldc.i4.1
+			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_02d1: pop
+			IL_02d2: ldc.r8 0.0
+			IL_02db: stloc.s 9
+			IL_02dd: ldc.r8 1
+			IL_02e6: neg
+			IL_02e7: stloc.s 17
+			IL_02e9: ldloc.s 17
+			IL_02eb: box [System.Runtime]System.Double
+			IL_02f0: stloc.s 10
+			// loop start (head: IL_02f2)
+				IL_02f2: ldc.i4.1
+				IL_02f3: brfalse IL_050d
 
-				IL_0314: volatile.
-				IL_0316: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-				IL_031b: brfalse IL_0332
+				IL_02f8: volatile.
+				IL_02fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+				IL_02ff: brfalse IL_0316
 
-				IL_0320: ldloc.s 8
-				IL_0322: ldstr "exec"
-				IL_0327: ldarg.2
-				IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_032d: br IL_0349
+				IL_0304: ldloc.s 8
+				IL_0306: ldstr "exec"
+				IL_030b: ldarg.2
+				IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0311: br IL_032d
 
-				IL_0332: ldloc.s 8
-				IL_0334: ldstr "exec"
-				IL_0339: ldarg.2
-				IL_033a: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:122"
-				IL_033f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-				IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+				IL_0316: ldloc.s 8
+				IL_0318: ldstr "exec"
+				IL_031d: ldarg.2
+				IL_031e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:120"
+				IL_0323: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+				IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0349: stloc.s 11
-				IL_034b: ldloc.s 11
-				IL_034d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0352: ldc.i4.0
-				IL_0353: ceq
-				IL_0355: stloc.s 16
-				IL_0357: ldloc.s 16
-				IL_0359: brfalse IL_0363
+				IL_032d: stloc.s 11
+				IL_032f: ldloc.s 11
+				IL_0331: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0336: ldc.i4.0
+				IL_0337: ceq
+				IL_0339: stloc.s 16
+				IL_033b: ldloc.s 16
+				IL_033d: brfalse IL_0347
 
-				IL_035e: br IL_0529
+				IL_0342: br IL_050d
 
-				IL_0363: ldloc.s 11
-				IL_0365: ldc.r8 0.0
-				IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0373: stloc.s 12
-				IL_0375: ldloc.s 10
-				IL_0377: stloc.s 19
-				IL_0379: ldloc.s 19
-				IL_037b: ldc.r8 0.0
-				IL_0384: box [System.Runtime]System.Double
-				IL_0389: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-				IL_038e: stloc.s 16
-				IL_0390: ldloc.s 16
-				IL_0392: brfalse IL_03d0
+				IL_0347: ldloc.s 11
+				IL_0349: ldc.r8 0.0
+				IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0357: stloc.s 12
+				IL_0359: ldloc.s 10
+				IL_035b: stloc.s 18
+				IL_035d: ldloc.s 18
+				IL_035f: ldc.r8 0.0
+				IL_0368: box [System.Runtime]System.Double
+				IL_036d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+				IL_0372: stloc.s 16
+				IL_0374: ldloc.s 16
+				IL_0376: brfalse IL_03b4
 
-				IL_0397: volatile.
-				IL_0399: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-				IL_039e: brfalse IL_03b4
+				IL_037b: volatile.
+				IL_037d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+				IL_0382: brfalse IL_0398
 
-				IL_03a3: ldloc.s 11
-				IL_03a5: ldstr "index"
-				IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03af: br IL_03ca
+				IL_0387: ldloc.s 11
+				IL_0389: ldstr "index"
+				IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0393: br IL_03ae
 
-				IL_03b4: ldloc.s 11
-				IL_03b6: ldstr "index"
-				IL_03bb: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:142"
-				IL_03c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-				IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0398: ldloc.s 11
+				IL_039a: ldstr "index"
+				IL_039f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:140"
+				IL_03a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_03ca: stloc.s 15
-				IL_03cc: ldloc.s 15
-				IL_03ce: stloc.s 10
+				IL_03ae: stloc.s 15
+				IL_03b0: ldloc.s 15
+				IL_03b2: stloc.s 10
 
-				IL_03d0: ldloc.s 12
-				IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03d7: stloc.s 15
-				IL_03d9: ldc.i4.0
-				IL_03da: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_03df: brfalse IL_041b
+				IL_03b4: ldloc.s 12
+				IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03bb: stloc.s 15
+				IL_03bd: ldc.i4.0
+				IL_03be: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_03c3: brfalse IL_03ff
 
-				IL_03e4: ldloc.s 15
-				IL_03e6: isinst [System.Runtime]System.String
-				IL_03eb: dup
-				IL_03ec: brtrue IL_0404
+				IL_03c8: ldloc.s 15
+				IL_03ca: isinst [System.Runtime]System.String
+				IL_03cf: dup
+				IL_03d0: brtrue IL_03e8
 
-				IL_03f1: pop
-				IL_03f2: ldloc.s 15
-				IL_03f4: ldstr "startsWith"
-				IL_03f9: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_03fe: dup
-				IL_03ff: brfalse IL_041a
+				IL_03d5: pop
+				IL_03d6: ldloc.s 15
+				IL_03d8: ldstr "startsWith"
+				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_03e2: dup
+				IL_03e3: brfalse IL_03fe
 
-				IL_0404: ldstr "</"
-				IL_0409: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-				IL_040e: box [System.Runtime]System.Boolean
-				IL_0413: stloc.s 15
-				IL_0415: br IL_042e
+				IL_03e8: ldstr "</"
+				IL_03ed: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_03f2: box [System.Runtime]System.Boolean
+				IL_03f7: stloc.s 15
+				IL_03f9: br IL_0412
 
-				IL_041a: pop
+				IL_03fe: pop
 
-				IL_041b: ldloc.s 15
-				IL_041d: ldstr "startsWith"
-				IL_0422: ldstr "</"
-				IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_042c: stloc.s 15
+				IL_03ff: ldloc.s 15
+				IL_0401: ldstr "startsWith"
+				IL_0406: ldstr "</"
+				IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0410: stloc.s 15
 
-				IL_042e: ldloc.s 15
-				IL_0430: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0435: stloc.s 16
-				IL_0437: ldloc.s 16
-				IL_0439: brfalse IL_0516
+				IL_0412: ldloc.s 15
+				IL_0414: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0419: stloc.s 16
+				IL_041b: ldloc.s 16
+				IL_041d: brfalse IL_04fa
 
-				IL_043e: ldloc.s 9
-				IL_0440: ldc.r8 1
-				IL_0449: sub
-				IL_044a: stloc.s 9
-				IL_044c: ldloc.s 9
-				IL_044e: stloc.s 18
-				IL_0450: ldloc.s 18
-				IL_0452: ldc.r8 0.0
-				IL_045b: ceq
-				IL_045d: brfalse IL_0511
+				IL_0422: ldloc.s 9
+				IL_0424: ldc.r8 1
+				IL_042d: sub
+				IL_042e: stloc.s 9
+				IL_0430: ldloc.s 9
+				IL_0432: stloc.s 17
+				IL_0434: ldloc.s 17
+				IL_0436: ldc.r8 0.0
+				IL_043f: ceq
+				IL_0441: brfalse IL_04f5
 
-				IL_0462: ldarg.2
-				IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0468: stloc.s 15
-				IL_046a: volatile.
-				IL_046c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-				IL_0471: brfalse IL_0487
+				IL_0446: ldarg.2
+				IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_044c: stloc.s 15
+				IL_044e: volatile.
+				IL_0450: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+				IL_0455: brfalse IL_046b
 
-				IL_0476: ldloc.s 8
-				IL_0478: ldstr "lastIndex"
-				IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0482: br IL_049d
+				IL_045a: ldloc.s 8
+				IL_045c: ldstr "lastIndex"
+				IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0466: br IL_0481
 
-				IL_0487: ldloc.s 8
-				IL_0489: ldstr "lastIndex"
-				IL_048e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:165"
-				IL_0493: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-				IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_046b: ldloc.s 8
+				IL_046d: ldstr "lastIndex"
+				IL_0472: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:163"
+				IL_0477: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+				IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_049d: stloc.s 20
-				IL_049f: ldc.i4.0
-				IL_04a0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_04a5: brfalse IL_04db
+				IL_0481: stloc.s 19
+				IL_0483: ldc.i4.0
+				IL_0484: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0489: brfalse IL_04bf
 
-				IL_04aa: ldloc.s 15
-				IL_04ac: isinst [System.Runtime]System.String
-				IL_04b1: dup
-				IL_04b2: brtrue IL_04ca
+				IL_048e: ldloc.s 15
+				IL_0490: isinst [System.Runtime]System.String
+				IL_0495: dup
+				IL_0496: brtrue IL_04ae
 
-				IL_04b7: pop
-				IL_04b8: ldloc.s 15
-				IL_04ba: ldstr "substring"
-				IL_04bf: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_04c4: dup
-				IL_04c5: brfalse IL_04da
+				IL_049b: pop
+				IL_049c: ldloc.s 15
+				IL_049e: ldstr "substring"
+				IL_04a3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_04a8: dup
+				IL_04a9: brfalse IL_04be
 
-				IL_04ca: ldloc.s 10
-				IL_04cc: ldloc.s 20
-				IL_04ce: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_04d3: stloc.s 20
-				IL_04d5: br IL_04ed
+				IL_04ae: ldloc.s 10
+				IL_04b0: ldloc.s 19
+				IL_04b2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_04b7: stloc.s 19
+				IL_04b9: br IL_04d1
 
-				IL_04da: pop
+				IL_04be: pop
 
-				IL_04db: ldloc.s 15
-				IL_04dd: ldstr "substring"
-				IL_04e2: ldloc.s 10
-				IL_04e4: ldloc.s 20
-				IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_04eb: stloc.s 20
+				IL_04bf: ldloc.s 15
+				IL_04c1: ldstr "substring"
+				IL_04c6: ldloc.s 10
+				IL_04c8: ldloc.s 19
+				IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_04cf: stloc.s 19
 
-				IL_04ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_04f2: dup
-				IL_04f3: ldstr "tagName"
-				IL_04f8: ldloc.s 6
-				IL_04fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_04ff: dup
-				IL_0500: ldstr "html"
-				IL_0505: ldloc.s 20
-				IL_0507: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_050c: stloc.s 21
-				IL_050e: ldloc.s 21
-				IL_0510: ret
+				IL_04d1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_04d6: dup
+				IL_04d7: ldstr "tagName"
+				IL_04dc: ldloc.s 6
+				IL_04de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_04e3: dup
+				IL_04e4: ldstr "html"
+				IL_04e9: ldloc.s 19
+				IL_04eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_04f0: stloc.s 20
+				IL_04f2: ldloc.s 20
+				IL_04f4: ret
 
-				IL_0511: br IL_0524
+				IL_04f5: br IL_0508
 
-				IL_0516: ldloc.s 9
-				IL_0518: ldc.r8 1
-				IL_0521: add
-				IL_0522: stloc.s 9
+				IL_04fa: ldloc.s 9
+				IL_04fc: ldc.r8 1
+				IL_0505: add
+				IL_0506: stloc.s 9
 
-				IL_0524: br IL_030e
+				IL_0508: br IL_02f2
 			// end loop
 
-			IL_0529: ldloc.s 6
-			IL_052b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0530: stloc.s 14
-			IL_0532: ldstr "Could not find a matching closing </"
-			IL_0537: ldloc.s 14
-			IL_0539: call string [System.Runtime]System.String::Concat(string, string)
-			IL_053e: ldstr "> for id '"
-			IL_0543: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0548: ldarg.3
-			IL_0549: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_054e: stloc.s 14
-			IL_0550: ldloc.s 14
-			IL_0552: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0557: ldstr "'."
-			IL_055c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0561: stloc.s 14
-			IL_0563: ldloc.s 14
-			IL_0565: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_056a: stloc.s 13
-			IL_056c: ldloc.s 13
-			IL_056e: isinst [System.Runtime]System.Exception
-			IL_0573: dup
-			IL_0574: brtrue IL_0582
+			IL_050d: ldloc.s 6
+			IL_050f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0514: stloc.s 14
+			IL_0516: ldstr "Could not find a matching closing </"
+			IL_051b: ldloc.s 14
+			IL_051d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0522: ldstr "> for id '"
+			IL_0527: call string [System.Runtime]System.String::Concat(string, string)
+			IL_052c: ldarg.3
+			IL_052d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0532: stloc.s 14
+			IL_0534: ldloc.s 14
+			IL_0536: call string [System.Runtime]System.String::Concat(string, string)
+			IL_053b: ldstr "'."
+			IL_0540: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0545: stloc.s 14
+			IL_0547: ldloc.s 14
+			IL_0549: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_054e: stloc.s 13
+			IL_0550: ldloc.s 13
+			IL_0552: isinst [System.Runtime]System.Exception
+			IL_0557: dup
+			IL_0558: brtrue IL_0566
 
-			IL_0579: pop
-			IL_057a: ldloc.s 13
-			IL_057c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0581: throw
+			IL_055d: pop
+			IL_055e: ldloc.s 13
+			IL_0560: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0565: throw
 
-			IL_0582: throw
+			IL_0566: throw
 
-			IL_0583: ldnull
-			IL_0584: ret
+			IL_0567: ldnull
+			IL_0568: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -5406,7 +5369,7 @@
 				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
-			// Code size: 631 (0x277)
+			// Code size: 612 (0x264)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5416,235 +5379,225 @@
 				[4] object,
 				[5] object,
 				[6] object,
-				[7] object[],
-				[8] string,
-				[9] bool,
+				[7] string,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
 				[13] object,
 				[14] object,
-				[15] object,
-				[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.s 7
-			IL_0012: ldloc.s 7
-			IL_0014: ldarg.3
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_001a: stloc.0
-			IL_001b: ldloc.0
-			IL_001c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0021: stloc.s 8
-			IL_0023: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_0028: ldloc.s 8
-			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
-			IL_0034: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0039: stloc.s 8
-			IL_003b: ldloc.s 8
-			IL_003d: ldstr "i"
-			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0047: stloc.1
-			IL_0048: volatile.
-			IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_004f: brfalse IL_0065
+			IL_0000: ldnull
+			IL_0001: ldarg.3
+			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+			IL_0007: stloc.0
+			IL_0008: ldloc.0
+			IL_0009: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_000e: stloc.s 7
+			IL_0010: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_0015: ldloc.s 7
+			IL_0017: call string [System.Runtime]System.String::Concat(string, string)
+			IL_001c: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_0021: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0026: stloc.s 7
+			IL_0028: ldloc.s 7
+			IL_002a: ldstr "i"
+			IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0034: stloc.1
+			IL_0035: volatile.
+			IL_0037: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_003c: brfalse IL_0052
 
-			IL_0054: ldloc.1
-			IL_0055: ldstr "exec"
-			IL_005a: ldarg.2
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0060: br IL_007b
+			IL_0041: ldloc.1
+			IL_0042: ldstr "exec"
+			IL_0047: ldarg.2
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_004d: br IL_0068
 
-			IL_0065: ldloc.1
-			IL_0066: ldstr "exec"
-			IL_006b: ldarg.2
-			IL_006c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:17"
-			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0052: ldloc.1
+			IL_0053: ldstr "exec"
+			IL_0058: ldarg.2
+			IL_0059: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:16"
+			IL_005e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_007b: stloc.2
-			IL_007c: ldloc.2
-			IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0082: stloc.s 9
-			IL_0084: ldloc.s 9
-			IL_0086: brfalse IL_00d3
+			IL_0068: stloc.2
+			IL_0069: ldloc.2
+			IL_006a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_006f: stloc.s 8
+			IL_0071: ldloc.s 8
+			IL_0073: brfalse IL_00c0
 
-			IL_008b: ldloc.2
-			IL_008c: ldc.r8 1
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_009a: stloc.s 10
-			IL_009c: ldloc.s 10
-			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a3: stloc.s 9
-			IL_00a5: ldloc.s 9
-			IL_00a7: brtrue IL_00c6
+			IL_0078: ldloc.2
+			IL_0079: ldc.r8 1
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0087: stloc.s 9
+			IL_0089: ldloc.s 9
+			IL_008b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0090: stloc.s 8
+			IL_0092: ldloc.s 8
+			IL_0094: brtrue IL_00b3
 
-			IL_00ac: ldloc.2
-			IL_00ad: ldc.r8 2
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00bb: stloc.s 11
-			IL_00bd: ldloc.s 11
-			IL_00bf: stloc.s 13
-			IL_00c1: br IL_00ca
+			IL_0099: ldloc.2
+			IL_009a: ldc.r8 2
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00a8: stloc.s 10
+			IL_00aa: ldloc.s 10
+			IL_00ac: stloc.s 12
+			IL_00ae: br IL_00b7
 
-			IL_00c6: ldloc.s 10
-			IL_00c8: stloc.s 13
+			IL_00b3: ldloc.s 9
+			IL_00b5: stloc.s 12
 
-			IL_00ca: ldloc.s 13
-			IL_00cc: stloc.s 14
-			IL_00ce: br IL_00d6
+			IL_00b7: ldloc.s 12
+			IL_00b9: stloc.s 13
+			IL_00bb: br IL_00c3
 
-			IL_00d3: ldloc.2
-			IL_00d4: stloc.s 14
+			IL_00c0: ldloc.2
+			IL_00c1: stloc.s 13
 
-			IL_00d6: ldloc.s 14
-			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00dd: stloc.s 9
-			IL_00df: ldloc.s 9
-			IL_00e1: brtrue IL_00f2
+			IL_00c3: ldloc.s 13
+			IL_00c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00ca: stloc.s 8
+			IL_00cc: ldloc.s 8
+			IL_00ce: brtrue IL_00df
 
-			IL_00e6: ldstr ""
-			IL_00eb: stloc.s 14
-			IL_00ed: br IL_00f2
+			IL_00d3: ldstr ""
+			IL_00d8: stloc.s 13
+			IL_00da: br IL_00df
 
-			IL_00f2: ldloc.s 14
-			IL_00f4: stloc.3
-			IL_00f5: ldloc.3
-			IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00fb: ldc.i4.0
-			IL_00fc: ceq
-			IL_00fe: stloc.s 9
-			IL_0100: ldloc.s 9
-			IL_0102: brfalse IL_010e
+			IL_00df: ldloc.s 13
+			IL_00e1: stloc.3
+			IL_00e2: ldloc.3
+			IL_00e3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00e8: ldc.i4.0
+			IL_00e9: ceq
+			IL_00eb: stloc.s 8
+			IL_00ed: ldloc.s 8
+			IL_00ef: brfalse IL_00fb
 
-			IL_0107: ldc.i4.0
-			IL_0108: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_010d: ret
+			IL_00f4: ldc.i4.0
+			IL_00f5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00fa: ret
 
-			IL_010e: ldloc.3
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0114: stloc.s 10
-			IL_0116: ldc.i4.0
-			IL_0117: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_011c: brfalse IL_013e
+			IL_00fb: ldloc.3
+			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0101: stloc.s 9
+			IL_0103: ldc.i4.0
+			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0109: brfalse IL_012b
 
-			IL_0121: ldloc.s 10
-			IL_0123: castclass [System.Runtime]System.String
-			IL_0128: ldstr "#"
-			IL_012d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0132: box [System.Runtime]System.Double
-			IL_0137: stloc.s 4
-			IL_0139: br IL_0151
+			IL_010e: ldloc.s 9
+			IL_0110: castclass [System.Runtime]System.String
+			IL_0115: ldstr "#"
+			IL_011a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_011f: box [System.Runtime]System.Double
+			IL_0124: stloc.s 4
+			IL_0126: br IL_013e
 
-			IL_013e: ldloc.s 10
-			IL_0140: ldstr "indexOf"
-			IL_0145: ldstr "#"
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_014f: stloc.s 4
+			IL_012b: ldloc.s 9
+			IL_012d: ldstr "indexOf"
+			IL_0132: ldstr "#"
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_013c: stloc.s 4
 
-			IL_0151: ldloc.s 4
-			IL_0153: ldc.r8 0.0
-			IL_015c: box [System.Runtime]System.Double
-			IL_0161: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
-			IL_0166: stloc.s 9
-			IL_0168: ldloc.s 9
-			IL_016a: brfalse IL_01cc
+			IL_013e: ldloc.s 4
+			IL_0140: ldc.r8 0.0
+			IL_0149: box [System.Runtime]System.Double
+			IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
+			IL_0153: stloc.s 8
+			IL_0155: ldloc.s 8
+			IL_0157: brfalse IL_01b9
 
-			IL_016f: ldloc.3
-			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0175: stloc.s 10
-			IL_0177: ldc.i4.0
-			IL_0178: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_017d: brfalse IL_01a5
+			IL_015c: ldloc.3
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0162: stloc.s 9
+			IL_0164: ldc.i4.0
+			IL_0165: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_016a: brfalse IL_0192
 
-			IL_0182: ldloc.s 10
-			IL_0184: castclass [System.Runtime]System.String
-			IL_0189: ldc.r8 0.0
-			IL_0192: box [System.Runtime]System.Double
-			IL_0197: ldloc.s 4
-			IL_0199: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_019e: stloc.s 10
-			IL_01a0: br IL_01c3
+			IL_016f: ldloc.s 9
+			IL_0171: castclass [System.Runtime]System.String
+			IL_0176: ldc.r8 0.0
+			IL_017f: box [System.Runtime]System.Double
+			IL_0184: ldloc.s 4
+			IL_0186: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_018b: stloc.s 9
+			IL_018d: br IL_01b0
 
-			IL_01a5: ldloc.s 10
-			IL_01a7: ldstr "substring"
-			IL_01ac: ldc.r8 0.0
-			IL_01b5: box [System.Runtime]System.Double
-			IL_01ba: ldloc.s 4
-			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01c1: stloc.s 10
+			IL_0192: ldloc.s 9
+			IL_0194: ldstr "substring"
+			IL_0199: ldc.r8 0.0
+			IL_01a2: box [System.Runtime]System.Double
+			IL_01a7: ldloc.s 4
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01ae: stloc.s 9
 
-			IL_01c3: ldloc.s 10
-			IL_01c5: stloc.s 5
-			IL_01c7: br IL_01cf
+			IL_01b0: ldloc.s 9
+			IL_01b2: stloc.s 5
+			IL_01b4: br IL_01bc
 
-			IL_01cc: ldloc.3
-			IL_01cd: stloc.s 5
+			IL_01b9: ldloc.3
+			IL_01ba: stloc.s 5
 
-			IL_01cf: ldloc.s 4
-			IL_01d1: ldc.r8 0.0
-			IL_01da: box [System.Runtime]System.Double
-			IL_01df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
-			IL_01e4: stloc.s 9
-			IL_01e6: ldloc.s 9
-			IL_01e8: brfalse IL_0240
+			IL_01bc: ldloc.s 4
+			IL_01be: ldc.r8 0.0
+			IL_01c7: box [System.Runtime]System.Double
+			IL_01cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
+			IL_01d1: stloc.s 8
+			IL_01d3: ldloc.s 8
+			IL_01d5: brfalse IL_022d
 
-			IL_01ed: ldloc.3
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f3: stloc.s 10
-			IL_01f5: ldloc.s 4
-			IL_01f7: ldc.r8 1
-			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0205: stloc.s 14
-			IL_0207: ldc.i4.0
-			IL_0208: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_020d: brfalse IL_0227
+			IL_01da: ldloc.3
+			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e0: stloc.s 9
+			IL_01e2: ldloc.s 4
+			IL_01e4: ldc.r8 1
+			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01f2: stloc.s 13
+			IL_01f4: ldc.i4.0
+			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01fa: brfalse IL_0214
 
-			IL_0212: ldloc.s 10
-			IL_0214: castclass [System.Runtime]System.String
-			IL_0219: ldloc.s 14
-			IL_021b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_0220: stloc.s 10
-			IL_0222: br IL_0237
+			IL_01ff: ldloc.s 9
+			IL_0201: castclass [System.Runtime]System.String
+			IL_0206: ldloc.s 13
+			IL_0208: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_020d: stloc.s 9
+			IL_020f: br IL_0224
 
-			IL_0227: ldloc.s 10
-			IL_0229: ldstr "substring"
-			IL_022e: ldloc.s 14
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0235: stloc.s 10
+			IL_0214: ldloc.s 9
+			IL_0216: ldstr "substring"
+			IL_021b: ldloc.s 13
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0222: stloc.s 9
 
-			IL_0237: ldloc.s 10
-			IL_0239: stloc.s 6
-			IL_023b: br IL_0247
+			IL_0224: ldloc.s 9
+			IL_0226: stloc.s 6
+			IL_0228: br IL_0234
 
-			IL_0240: ldstr ""
-			IL_0245: stloc.s 6
+			IL_022d: ldstr ""
+			IL_0232: stloc.s 6
 
-			IL_0247: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_024c: dup
-			IL_024d: ldstr "href"
-			IL_0252: ldloc.3
-			IL_0253: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0258: dup
-			IL_0259: ldstr "filePart"
-			IL_025e: ldloc.s 5
-			IL_0260: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0265: dup
-			IL_0266: ldstr "fragment"
-			IL_026b: ldloc.s 6
-			IL_026d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0272: stloc.s 16
-			IL_0274: ldloc.s 16
-			IL_0276: ret
+			IL_0234: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0239: dup
+			IL_023a: ldstr "href"
+			IL_023f: ldloc.3
+			IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0245: dup
+			IL_0246: ldstr "filePart"
+			IL_024b: ldloc.s 5
+			IL_024d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0252: dup
+			IL_0253: ldstr "fragment"
+			IL_0258: ldloc.s 6
+			IL_025a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_025f: stloc.s 15
+			IL_0261: ldloc.s 15
+			IL_0263: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -6127,7 +6080,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 4053 (0xfd5)
+			// Code size: 3934 (0xf5e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -6151,13 +6104,13 @@
 				[18] object,
 				[19] object,
 				[20] object,
-				[21] object[],
-				[22] object,
+				[21] object,
+				[22] object[],
 				[23] bool,
 				[24] object,
 				[25] object,
-				[26] object,
-				[27] string,
+				[26] string,
+				[27] object,
 				[28] object,
 				[29] object,
 				[30] object,
@@ -6301,11 +6254,11 @@
 			IL_0105: dup
 			IL_0106: ldc.i4.s 20
 			IL_0108: ldelem.ref
-			IL_0109: castclass object[]
-			IL_010e: stloc.s 21
-			IL_0110: dup
-			IL_0111: ldc.i4.s 21
-			IL_0113: ldelem.ref
+			IL_0109: stloc.s 21
+			IL_010b: dup
+			IL_010c: ldc.i4.s 21
+			IL_010e: ldelem.ref
+			IL_010f: castclass object[]
 			IL_0114: stloc.s 22
 			IL_0116: dup
 			IL_0117: ldc.i4.s 22
@@ -6323,11 +6276,11 @@
 			IL_012d: dup
 			IL_012e: ldc.i4.s 25
 			IL_0130: ldelem.ref
-			IL_0131: stloc.s 26
-			IL_0133: dup
-			IL_0134: ldc.i4.s 26
-			IL_0136: ldelem.ref
-			IL_0137: castclass [System.Runtime]System.String
+			IL_0131: castclass [System.Runtime]System.String
+			IL_0136: stloc.s 26
+			IL_0138: dup
+			IL_0139: ldc.i4.s 26
+			IL_013b: ldelem.ref
 			IL_013c: stloc.s 27
 			IL_013e: dup
 			IL_013f: ldc.i4.s 27
@@ -6360,1518 +6313,1469 @@
 
 			IL_0172: ldloc.0
 			IL_0173: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0178: switch (IL_018d, IL_0692, IL_09e9, IL_0bff)
+			IL_0178: switch (IL_018d, IL_0689, IL_09d3, IL_0be5)
 
-			IL_018d: ldarg.0
-			IL_018e: ldc.i4.1
-			IL_018f: ldelem.ref
-			IL_0190: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0195: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
-			IL_019a: ldc.i4.1
-			IL_019b: newarr [System.Runtime]System.Object
-			IL_01a0: dup
-			IL_01a1: ldc.i4.0
-			IL_01a2: ldarg.0
-			IL_01a3: ldc.i4.1
-			IL_01a4: ldelem.ref
-			IL_01a5: stelem.ref
-			IL_01a6: stloc.s 21
-			IL_01a8: ldstr "process"
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b2: stloc.s 22
-			IL_01b4: volatile.
-			IL_01b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_01bb: brfalse IL_01d1
+			IL_018d: ldstr "process"
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0197: stloc.s 21
+			IL_0199: volatile.
+			IL_019b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_01a0: brfalse IL_01b6
 
-			IL_01c0: ldloc.s 22
-			IL_01c2: ldstr "argv"
-			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01cc: br IL_01e7
+			IL_01a5: ldloc.s 21
+			IL_01a7: ldstr "argv"
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b1: br IL_01cc
 
-			IL_01d1: ldloc.s 22
-			IL_01d3: ldstr "argv"
-			IL_01d8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:7"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01b6: ldloc.s 21
+			IL_01b8: ldstr "argv"
+			IL_01bd: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:5"
+			IL_01c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01e7: stloc.s 22
-			IL_01e9: ldloc.s 21
-			IL_01eb: ldloc.s 22
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01f2: stloc.1
-			IL_01f3: volatile.
-			IL_01f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_01fa: brfalse IL_020f
+			IL_01cc: stloc.s 21
+			IL_01ce: ldc.i4.1
+			IL_01cf: newarr [System.Runtime]System.Object
+			IL_01d4: dup
+			IL_01d5: ldc.i4.0
+			IL_01d6: ldarg.0
+			IL_01d7: ldc.i4.1
+			IL_01d8: ldelem.ref
+			IL_01d9: stelem.ref
+			IL_01da: stloc.s 22
+			IL_01dc: ldloc.s 22
+			IL_01de: ldc.i4.0
+			IL_01df: ldelem.ref
+			IL_01e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_01e5: ldnull
+			IL_01e6: ldloc.s 21
+			IL_01e8: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+			IL_01ed: stloc.1
+			IL_01ee: volatile.
+			IL_01f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_01f5: brfalse IL_020a
 
-			IL_01ff: ldloc.1
-			IL_0200: ldstr "section"
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_020a: br IL_0224
+			IL_01fa: ldloc.1
+			IL_01fb: ldstr "section"
+			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0205: br IL_021f
 
-			IL_020f: ldloc.1
-			IL_0210: ldstr "section"
-			IL_0215: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:12"
-			IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_020a: ldloc.1
+			IL_020b: ldstr "section"
+			IL_0210: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:11"
+			IL_0215: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0224: stloc.s 22
-			IL_0226: ldloc.s 22
-			IL_0228: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_022d: ldc.i4.0
-			IL_022e: ceq
-			IL_0230: stloc.s 23
-			IL_0232: ldloc.s 23
-			IL_0234: brfalse IL_0273
+			IL_021f: stloc.s 21
+			IL_0221: ldloc.s 21
+			IL_0223: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0228: ldc.i4.0
+			IL_0229: ceq
+			IL_022b: stloc.s 23
+			IL_022d: ldloc.s 23
+			IL_022f: brfalse IL_026e
 
-			IL_0239: ldstr "Missing required --section (e.g. 27.3)."
-			IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0243: stloc.2
-			IL_0244: ldloc.0
-			IL_0245: ldc.i4.m1
-			IL_0246: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_024b: ldloc.0
-			IL_024c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0251: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0256: ldarg.0
-			IL_0257: ldc.i4.1
-			IL_0258: newarr [System.Runtime]System.Object
-			IL_025d: dup
-			IL_025e: ldc.i4.0
-			IL_025f: ldloc.2
-			IL_0260: stelem.ref
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0266: pop
-			IL_0267: ldloc.0
-			IL_0268: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_026d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0272: ret
+			IL_0234: ldstr "Missing required --section (e.g. 27.3)."
+			IL_0239: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_023e: stloc.2
+			IL_023f: ldloc.0
+			IL_0240: ldc.i4.m1
+			IL_0241: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0246: ldloc.0
+			IL_0247: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_024c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0251: ldarg.0
+			IL_0252: ldc.i4.1
+			IL_0253: newarr [System.Runtime]System.Object
+			IL_0258: dup
+			IL_0259: ldc.i4.0
+			IL_025a: ldloc.2
+			IL_025b: stelem.ref
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0261: pop
+			IL_0262: ldloc.0
+			IL_0263: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0268: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_026d: ret
 
-			IL_0273: volatile.
-			IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_027a: brfalse IL_028f
+			IL_026e: volatile.
+			IL_0270: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0275: brfalse IL_028a
 
-			IL_027f: ldloc.1
-			IL_0280: ldstr "outFile"
-			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028a: br IL_02a4
+			IL_027a: ldloc.1
+			IL_027b: ldstr "outFile"
+			IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0285: br IL_029f
 
-			IL_028f: ldloc.1
-			IL_0290: ldstr "outFile"
-			IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:23"
-			IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_028a: ldloc.1
+			IL_028b: ldstr "outFile"
+			IL_0290: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:22"
+			IL_0295: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02a4: stloc.s 22
-			IL_02a6: ldloc.s 22
-			IL_02a8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02ad: ldc.i4.0
-			IL_02ae: ceq
-			IL_02b0: stloc.s 23
-			IL_02b2: ldloc.s 23
-			IL_02b4: brfalse IL_02f3
+			IL_029f: stloc.s 21
+			IL_02a1: ldloc.s 21
+			IL_02a3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02a8: ldc.i4.0
+			IL_02a9: ceq
+			IL_02ab: stloc.s 23
+			IL_02ad: ldloc.s 23
+			IL_02af: brfalse IL_02ee
 
-			IL_02b9: ldstr "Missing required --out <output.html>."
-			IL_02be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_02c3: stloc.3
-			IL_02c4: ldloc.0
-			IL_02c5: ldc.i4.m1
-			IL_02c6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02cb: ldloc.0
-			IL_02cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_02d6: ldarg.0
-			IL_02d7: ldc.i4.1
-			IL_02d8: newarr [System.Runtime]System.Object
-			IL_02dd: dup
-			IL_02de: ldc.i4.0
-			IL_02df: ldloc.3
-			IL_02e0: stelem.ref
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02e6: pop
-			IL_02e7: ldloc.0
-			IL_02e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02f2: ret
+			IL_02b4: ldstr "Missing required --out <output.html>."
+			IL_02b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_02be: stloc.3
+			IL_02bf: ldloc.0
+			IL_02c0: ldc.i4.m1
+			IL_02c1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02c6: ldloc.0
+			IL_02c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_02d1: ldarg.0
+			IL_02d2: ldc.i4.1
+			IL_02d3: newarr [System.Runtime]System.Object
+			IL_02d8: dup
+			IL_02d9: ldc.i4.0
+			IL_02da: ldloc.3
+			IL_02db: stelem.ref
+			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02e1: pop
+			IL_02e2: ldloc.0
+			IL_02e3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02e8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02ed: ret
 
-			IL_02f3: volatile.
-			IL_02f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_02fa: brfalse IL_030f
+			IL_02ee: volatile.
+			IL_02f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_02f5: brfalse IL_030a
 
-			IL_02ff: ldloc.1
-			IL_0300: ldstr "url"
-			IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_030a: br IL_0324
+			IL_02fa: ldloc.1
+			IL_02fb: ldstr "url"
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0305: br IL_031f
 
-			IL_030f: ldloc.1
-			IL_0310: ldstr "url"
-			IL_0315: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:34"
-			IL_031a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_030a: ldloc.1
+			IL_030b: ldstr "url"
+			IL_0310: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:33"
+			IL_0315: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0324: stloc.s 22
-			IL_0326: ldloc.s 22
-			IL_0328: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_032d: stloc.s 23
-			IL_032f: ldloc.s 23
-			IL_0331: brfalse IL_034b
+			IL_031f: stloc.s 21
+			IL_0321: ldloc.s 21
+			IL_0323: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0328: stloc.s 23
+			IL_032a: ldloc.s 23
+			IL_032c: brfalse IL_0346
 
-			IL_0336: ldc.r8 1
-			IL_033f: box [System.Runtime]System.Double
-			IL_0344: stloc.s 4
-			IL_0346: br IL_035b
+			IL_0331: ldc.r8 1
+			IL_033a: box [System.Runtime]System.Double
+			IL_033f: stloc.s 4
+			IL_0341: br IL_0356
 
-			IL_034b: ldc.r8 0.0
-			IL_0354: box [System.Runtime]System.Double
-			IL_0359: stloc.s 4
+			IL_0346: ldc.r8 0.0
+			IL_034f: box [System.Runtime]System.Double
+			IL_0354: stloc.s 4
 
-			IL_035b: ldloc.s 4
-			IL_035d: stloc.s 24
-			IL_035f: volatile.
-			IL_0361: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_0366: brfalse IL_037b
+			IL_0356: ldloc.s 4
+			IL_0358: stloc.s 24
+			IL_035a: volatile.
+			IL_035c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0361: brfalse IL_0376
 
-			IL_036b: ldloc.1
-			IL_036c: ldstr "auto"
-			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0376: br IL_0390
+			IL_0366: ldloc.1
+			IL_0367: ldstr "auto"
+			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0371: br IL_038b
 
-			IL_037b: ldloc.1
-			IL_037c: ldstr "auto"
-			IL_0381: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:48"
-			IL_0386: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0376: ldloc.1
+			IL_0377: ldstr "auto"
+			IL_037c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:47"
+			IL_0381: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0390: stloc.s 22
-			IL_0392: ldloc.s 22
-			IL_0394: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0399: stloc.s 23
-			IL_039b: ldloc.s 23
-			IL_039d: brfalse IL_03b7
+			IL_038b: stloc.s 21
+			IL_038d: ldloc.s 21
+			IL_038f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0394: stloc.s 23
+			IL_0396: ldloc.s 23
+			IL_0398: brfalse IL_03b2
 
-			IL_03a2: ldc.r8 1
-			IL_03ab: box [System.Runtime]System.Double
-			IL_03b0: stloc.s 5
-			IL_03b2: br IL_03c7
+			IL_039d: ldc.r8 1
+			IL_03a6: box [System.Runtime]System.Double
+			IL_03ab: stloc.s 5
+			IL_03ad: br IL_03c2
 
-			IL_03b7: ldc.r8 0.0
-			IL_03c0: box [System.Runtime]System.Double
-			IL_03c5: stloc.s 5
+			IL_03b2: ldc.r8 0.0
+			IL_03bb: box [System.Runtime]System.Double
+			IL_03c0: stloc.s 5
 
-			IL_03c7: ldloc.s 24
-			IL_03c9: ldloc.s 5
-			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03d0: stloc.s 6
-			IL_03d2: ldloc.s 6
-			IL_03d4: ldc.r8 1
-			IL_03dd: box [System.Runtime]System.Double
-			IL_03e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03e7: stloc.s 23
-			IL_03e9: ldloc.s 23
-			IL_03eb: brfalse IL_042c
+			IL_03c2: ldloc.s 24
+			IL_03c4: ldloc.s 5
+			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03cb: stloc.s 6
+			IL_03cd: ldloc.s 6
+			IL_03cf: ldc.r8 1
+			IL_03d8: box [System.Runtime]System.Double
+			IL_03dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03e2: stloc.s 23
+			IL_03e4: ldloc.s 23
+			IL_03e6: brfalse IL_0427
 
-			IL_03f0: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_03f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03fa: stloc.s 7
-			IL_03fc: ldloc.0
-			IL_03fd: ldc.i4.m1
-			IL_03fe: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0403: ldloc.0
-			IL_0404: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0409: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_040e: ldarg.0
-			IL_040f: ldc.i4.1
-			IL_0410: newarr [System.Runtime]System.Object
-			IL_0415: dup
-			IL_0416: ldc.i4.0
-			IL_0417: ldloc.s 7
-			IL_0419: stelem.ref
-			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_041f: pop
-			IL_0420: ldloc.0
-			IL_0421: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0426: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_042b: ret
+			IL_03eb: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_03f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03f5: stloc.s 7
+			IL_03f7: ldloc.0
+			IL_03f8: ldc.i4.m1
+			IL_03f9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03fe: ldloc.0
+			IL_03ff: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0404: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0409: ldarg.0
+			IL_040a: ldc.i4.1
+			IL_040b: newarr [System.Runtime]System.Object
+			IL_0410: dup
+			IL_0411: ldc.i4.0
+			IL_0412: ldloc.s 7
+			IL_0414: stelem.ref
+			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_041a: pop
+			IL_041b: ldloc.0
+			IL_041c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0421: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0426: ret
 
-			IL_042c: ldnull
-			IL_042d: stloc.s 8
-			IL_042f: volatile.
-			IL_0431: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_0436: brfalse IL_044b
+			IL_0427: ldnull
+			IL_0428: stloc.s 8
+			IL_042a: volatile.
+			IL_042c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0431: brfalse IL_0446
 
-			IL_043b: ldloc.1
-			IL_043c: ldstr "id"
-			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0446: br IL_0460
+			IL_0436: ldloc.1
+			IL_0437: ldstr "id"
+			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0441: br IL_045b
 
-			IL_044b: ldloc.1
-			IL_044c: ldstr "id"
-			IL_0451: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:78"
-			IL_0456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0446: ldloc.1
+			IL_0447: ldstr "id"
+			IL_044c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:77"
+			IL_0451: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0460: stloc.s 22
-			IL_0462: ldloc.s 22
-			IL_0464: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0469: stloc.s 23
-			IL_046b: ldloc.s 23
-			IL_046d: brtrue IL_047e
+			IL_045b: stloc.s 21
+			IL_045d: ldloc.s 21
+			IL_045f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0464: stloc.s 23
+			IL_0466: ldloc.s 23
+			IL_0468: brtrue IL_0479
 
-			IL_0472: ldstr ""
-			IL_0477: stloc.s 25
-			IL_0479: br IL_0482
+			IL_046d: ldstr ""
+			IL_0472: stloc.s 25
+			IL_0474: br IL_047d
 
-			IL_047e: ldloc.s 22
-			IL_0480: stloc.s 25
+			IL_0479: ldloc.s 21
+			IL_047b: stloc.s 25
 
-			IL_0482: ldloc.s 25
-			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0489: stloc.s 22
-			IL_048b: ldc.i4.0
-			IL_048c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0491: brfalse IL_04a9
+			IL_047d: ldloc.s 25
+			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0484: stloc.s 21
+			IL_0486: ldc.i4.0
+			IL_0487: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_048c: brfalse IL_04a4
 
-			IL_0496: ldloc.s 22
-			IL_0498: castclass [System.Runtime]System.String
-			IL_049d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_04a2: stloc.s 9
-			IL_04a4: br IL_04b7
+			IL_0491: ldloc.s 21
+			IL_0493: castclass [System.Runtime]System.String
+			IL_0498: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_049d: stloc.s 9
+			IL_049f: br IL_04b2
 
-			IL_04a9: ldloc.s 22
-			IL_04ab: ldstr "trim"
-			IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_04b5: stloc.s 9
+			IL_04a4: ldloc.s 21
+			IL_04a6: ldstr "trim"
+			IL_04ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_04b0: stloc.s 9
 
-			IL_04b7: ldstr ""
-			IL_04bc: stloc.s 10
-			IL_04be: volatile.
-			IL_04c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_04c5: brfalse IL_04da
+			IL_04b2: ldstr ""
+			IL_04b7: stloc.s 10
+			IL_04b9: volatile.
+			IL_04bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_04c0: brfalse IL_04d5
 
-			IL_04ca: ldloc.1
-			IL_04cb: ldstr "auto"
-			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04d5: br IL_04ef
+			IL_04c5: ldloc.1
+			IL_04c6: ldstr "auto"
+			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04d0: br IL_04ea
 
-			IL_04da: ldloc.1
-			IL_04db: ldstr "auto"
-			IL_04e0: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:95"
-			IL_04e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04d5: ldloc.1
+			IL_04d6: ldstr "auto"
+			IL_04db: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:94"
+			IL_04e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04ef: stloc.s 22
-			IL_04f1: ldloc.s 22
-			IL_04f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04f8: stloc.s 23
-			IL_04fa: ldloc.s 23
-			IL_04fc: brfalse IL_0a6e
+			IL_04ea: stloc.s 21
+			IL_04ec: ldloc.s 21
+			IL_04ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04f3: stloc.s 23
+			IL_04f5: ldloc.s 23
+			IL_04f7: brfalse IL_0a58
 
-			IL_0501: volatile.
-			IL_0503: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_0508: brfalse IL_051d
+			IL_04fc: volatile.
+			IL_04fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_0503: brfalse IL_0518
 
-			IL_050d: ldloc.1
-			IL_050e: ldstr "indexUrl"
-			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0518: br IL_0532
+			IL_0508: ldloc.1
+			IL_0509: ldstr "indexUrl"
+			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0513: br IL_052d
 
-			IL_051d: ldloc.1
-			IL_051e: ldstr "indexUrl"
-			IL_0523: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:100"
-			IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0518: ldloc.1
+			IL_0519: ldstr "indexUrl"
+			IL_051e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:99"
+			IL_0523: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_0528: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0532: stloc.s 22
-			IL_0534: ldloc.s 22
-			IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_053b: stloc.s 22
-			IL_053d: ldc.i4.0
-			IL_053e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0543: brfalse IL_0575
+			IL_052d: stloc.s 21
+			IL_052f: ldloc.s 21
+			IL_0531: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0536: stloc.s 21
+			IL_0538: ldc.i4.0
+			IL_0539: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_053e: brfalse IL_0570
 
-			IL_0548: ldloc.s 22
-			IL_054a: isinst [System.Runtime]System.String
-			IL_054f: dup
-			IL_0550: brtrue IL_0568
+			IL_0543: ldloc.s 21
+			IL_0545: isinst [System.Runtime]System.String
+			IL_054a: dup
+			IL_054b: brtrue IL_0563
 
-			IL_0555: pop
-			IL_0556: ldloc.s 22
-			IL_0558: ldstr "trim"
-			IL_055d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0562: dup
-			IL_0563: brfalse IL_0574
+			IL_0550: pop
+			IL_0551: ldloc.s 21
+			IL_0553: ldstr "trim"
+			IL_0558: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_055d: dup
+			IL_055e: brfalse IL_056f
 
-			IL_0568: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_056d: stloc.s 11
-			IL_056f: br IL_0583
+			IL_0563: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0568: stloc.s 11
+			IL_056a: br IL_057e
 
-			IL_0574: pop
+			IL_056f: pop
 
-			IL_0575: ldloc.s 22
-			IL_0577: ldstr "trim"
-			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0581: stloc.s 11
+			IL_0570: ldloc.s 21
+			IL_0572: ldstr "trim"
+			IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_057c: stloc.s 11
 
-			IL_0583: ldarg.0
-			IL_0584: ldc.i4.1
-			IL_0585: ldelem.ref
-			IL_0586: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_058b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0590: ldc.i4.1
-			IL_0591: newarr [System.Runtime]System.Object
-			IL_0596: dup
-			IL_0597: ldc.i4.0
-			IL_0598: ldarg.0
-			IL_0599: ldc.i4.1
-			IL_059a: ldelem.ref
-			IL_059b: stelem.ref
-			IL_059c: stloc.s 21
-			IL_059e: ldloc.s 21
-			IL_05a0: ldloc.s 11
-			IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_05a7: stloc.s 22
-			IL_05a9: ldloc.0
-			IL_05aa: ldc.i4.1
-			IL_05ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05b0: ldloc.0
-			IL_05b1: ldloc.s 22
-			IL_05b3: ldarg.0
-			IL_05b4: ldc.i4.1
-			IL_05b5: ldloc.0
-			IL_05b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_05c0: ldloc.0
-			IL_05c1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05c6: dup
-			IL_05c7: ldc.i4.0
-			IL_05c8: ldloc.1
-			IL_05c9: stelem.ref
-			IL_05ca: dup
-			IL_05cb: ldc.i4.1
-			IL_05cc: ldloc.2
+			IL_057e: ldc.i4.1
+			IL_057f: newarr [System.Runtime]System.Object
+			IL_0584: dup
+			IL_0585: ldc.i4.0
+			IL_0586: ldarg.0
+			IL_0587: ldc.i4.1
+			IL_0588: ldelem.ref
+			IL_0589: stelem.ref
+			IL_058a: stloc.s 22
+			IL_058c: ldloc.s 22
+			IL_058e: ldc.i4.0
+			IL_058f: ldelem.ref
+			IL_0590: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0595: ldnull
+			IL_0596: ldloc.s 11
+			IL_0598: ldnull
+			IL_0599: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_059e: stloc.s 21
+			IL_05a0: ldloc.0
+			IL_05a1: ldc.i4.1
+			IL_05a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05a7: ldloc.0
+			IL_05a8: ldloc.s 21
+			IL_05aa: ldarg.0
+			IL_05ab: ldc.i4.1
+			IL_05ac: ldloc.0
+			IL_05ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_05b7: ldloc.0
+			IL_05b8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05bd: dup
+			IL_05be: ldc.i4.0
+			IL_05bf: ldloc.1
+			IL_05c0: stelem.ref
+			IL_05c1: dup
+			IL_05c2: ldc.i4.1
+			IL_05c3: ldloc.2
+			IL_05c4: stelem.ref
+			IL_05c5: dup
+			IL_05c6: ldc.i4.2
+			IL_05c7: ldloc.3
+			IL_05c8: stelem.ref
+			IL_05c9: dup
+			IL_05ca: ldc.i4.3
+			IL_05cb: ldloc.s 4
 			IL_05cd: stelem.ref
 			IL_05ce: dup
-			IL_05cf: ldc.i4.2
-			IL_05d0: ldloc.3
-			IL_05d1: stelem.ref
-			IL_05d2: dup
-			IL_05d3: ldc.i4.3
-			IL_05d4: ldloc.s 4
-			IL_05d6: stelem.ref
-			IL_05d7: dup
-			IL_05d8: ldc.i4.4
-			IL_05d9: ldloc.s 5
-			IL_05db: stelem.ref
-			IL_05dc: dup
-			IL_05dd: ldc.i4.5
-			IL_05de: ldloc.s 6
-			IL_05e0: stelem.ref
-			IL_05e1: dup
-			IL_05e2: ldc.i4.6
-			IL_05e3: ldloc.s 7
-			IL_05e5: stelem.ref
-			IL_05e6: dup
-			IL_05e7: ldc.i4.7
-			IL_05e8: ldloc.s 8
-			IL_05ea: stelem.ref
-			IL_05eb: dup
-			IL_05ec: ldc.i4.8
-			IL_05ed: ldloc.s 9
-			IL_05ef: stelem.ref
-			IL_05f0: dup
-			IL_05f1: ldc.i4.s 9
-			IL_05f3: ldloc.s 10
-			IL_05f5: stelem.ref
-			IL_05f6: dup
-			IL_05f7: ldc.i4.s 10
-			IL_05f9: ldloc.s 11
-			IL_05fb: stelem.ref
-			IL_05fc: dup
-			IL_05fd: ldc.i4.s 11
-			IL_05ff: ldloc.s 12
-			IL_0601: stelem.ref
-			IL_0602: dup
-			IL_0603: ldc.i4.s 12
-			IL_0605: ldloc.s 13
-			IL_0607: stelem.ref
-			IL_0608: dup
-			IL_0609: ldc.i4.s 13
-			IL_060b: ldloc.s 14
-			IL_060d: stelem.ref
-			IL_060e: dup
-			IL_060f: ldc.i4.s 14
-			IL_0611: ldloc.s 15
-			IL_0613: stelem.ref
-			IL_0614: dup
-			IL_0615: ldc.i4.s 15
-			IL_0617: ldloc.s 16
-			IL_0619: stelem.ref
-			IL_061a: dup
-			IL_061b: ldc.i4.s 16
-			IL_061d: ldloc.s 17
-			IL_061f: stelem.ref
-			IL_0620: dup
-			IL_0621: ldc.i4.s 17
-			IL_0623: ldloc.s 18
-			IL_0625: stelem.ref
-			IL_0626: dup
-			IL_0627: ldc.i4.s 18
-			IL_0629: ldloc.s 19
-			IL_062b: stelem.ref
-			IL_062c: dup
-			IL_062d: ldc.i4.s 19
-			IL_062f: ldloc.s 20
-			IL_0631: stelem.ref
-			IL_0632: dup
-			IL_0633: ldc.i4.s 20
-			IL_0635: ldloc.s 21
-			IL_0637: stelem.ref
-			IL_0638: dup
-			IL_0639: ldc.i4.s 21
-			IL_063b: ldloc.s 22
-			IL_063d: stelem.ref
-			IL_063e: dup
-			IL_063f: ldc.i4.s 22
-			IL_0641: ldloc.s 23
-			IL_0643: box [System.Runtime]System.Boolean
-			IL_0648: stelem.ref
-			IL_0649: dup
-			IL_064a: ldc.i4.s 23
-			IL_064c: ldloc.s 24
-			IL_064e: stelem.ref
-			IL_064f: dup
-			IL_0650: ldc.i4.s 24
-			IL_0652: ldloc.s 25
-			IL_0654: stelem.ref
-			IL_0655: dup
-			IL_0656: ldc.i4.s 25
-			IL_0658: ldloc.s 26
-			IL_065a: stelem.ref
-			IL_065b: dup
-			IL_065c: ldc.i4.s 26
-			IL_065e: ldloc.s 27
-			IL_0660: stelem.ref
-			IL_0661: dup
-			IL_0662: ldc.i4.s 27
-			IL_0664: ldloc.s 28
-			IL_0666: stelem.ref
-			IL_0667: dup
-			IL_0668: ldc.i4.s 28
-			IL_066a: ldloc.s 29
-			IL_066c: stelem.ref
-			IL_066d: dup
-			IL_066e: ldc.i4.s 29
-			IL_0670: ldloc.s 30
-			IL_0672: stelem.ref
-			IL_0673: dup
-			IL_0674: ldc.i4.s 30
-			IL_0676: ldloc.s 31
-			IL_0678: stelem.ref
-			IL_0679: dup
-			IL_067a: ldc.i4.s 31
-			IL_067c: ldloc.s 32
-			IL_067e: stelem.ref
-			IL_067f: dup
-			IL_0680: ldc.i4.s 32
-			IL_0682: ldloc.s 33
-			IL_0684: stelem.ref
-			IL_0685: pop
-			IL_0686: ldloc.0
-			IL_0687: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_068c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0691: ret
+			IL_05cf: ldc.i4.4
+			IL_05d0: ldloc.s 5
+			IL_05d2: stelem.ref
+			IL_05d3: dup
+			IL_05d4: ldc.i4.5
+			IL_05d5: ldloc.s 6
+			IL_05d7: stelem.ref
+			IL_05d8: dup
+			IL_05d9: ldc.i4.6
+			IL_05da: ldloc.s 7
+			IL_05dc: stelem.ref
+			IL_05dd: dup
+			IL_05de: ldc.i4.7
+			IL_05df: ldloc.s 8
+			IL_05e1: stelem.ref
+			IL_05e2: dup
+			IL_05e3: ldc.i4.8
+			IL_05e4: ldloc.s 9
+			IL_05e6: stelem.ref
+			IL_05e7: dup
+			IL_05e8: ldc.i4.s 9
+			IL_05ea: ldloc.s 10
+			IL_05ec: stelem.ref
+			IL_05ed: dup
+			IL_05ee: ldc.i4.s 10
+			IL_05f0: ldloc.s 11
+			IL_05f2: stelem.ref
+			IL_05f3: dup
+			IL_05f4: ldc.i4.s 11
+			IL_05f6: ldloc.s 12
+			IL_05f8: stelem.ref
+			IL_05f9: dup
+			IL_05fa: ldc.i4.s 12
+			IL_05fc: ldloc.s 13
+			IL_05fe: stelem.ref
+			IL_05ff: dup
+			IL_0600: ldc.i4.s 13
+			IL_0602: ldloc.s 14
+			IL_0604: stelem.ref
+			IL_0605: dup
+			IL_0606: ldc.i4.s 14
+			IL_0608: ldloc.s 15
+			IL_060a: stelem.ref
+			IL_060b: dup
+			IL_060c: ldc.i4.s 15
+			IL_060e: ldloc.s 16
+			IL_0610: stelem.ref
+			IL_0611: dup
+			IL_0612: ldc.i4.s 16
+			IL_0614: ldloc.s 17
+			IL_0616: stelem.ref
+			IL_0617: dup
+			IL_0618: ldc.i4.s 17
+			IL_061a: ldloc.s 18
+			IL_061c: stelem.ref
+			IL_061d: dup
+			IL_061e: ldc.i4.s 18
+			IL_0620: ldloc.s 19
+			IL_0622: stelem.ref
+			IL_0623: dup
+			IL_0624: ldc.i4.s 19
+			IL_0626: ldloc.s 20
+			IL_0628: stelem.ref
+			IL_0629: dup
+			IL_062a: ldc.i4.s 20
+			IL_062c: ldloc.s 21
+			IL_062e: stelem.ref
+			IL_062f: dup
+			IL_0630: ldc.i4.s 21
+			IL_0632: ldloc.s 22
+			IL_0634: stelem.ref
+			IL_0635: dup
+			IL_0636: ldc.i4.s 22
+			IL_0638: ldloc.s 23
+			IL_063a: box [System.Runtime]System.Boolean
+			IL_063f: stelem.ref
+			IL_0640: dup
+			IL_0641: ldc.i4.s 23
+			IL_0643: ldloc.s 24
+			IL_0645: stelem.ref
+			IL_0646: dup
+			IL_0647: ldc.i4.s 24
+			IL_0649: ldloc.s 25
+			IL_064b: stelem.ref
+			IL_064c: dup
+			IL_064d: ldc.i4.s 25
+			IL_064f: ldloc.s 26
+			IL_0651: stelem.ref
+			IL_0652: dup
+			IL_0653: ldc.i4.s 26
+			IL_0655: ldloc.s 27
+			IL_0657: stelem.ref
+			IL_0658: dup
+			IL_0659: ldc.i4.s 27
+			IL_065b: ldloc.s 28
+			IL_065d: stelem.ref
+			IL_065e: dup
+			IL_065f: ldc.i4.s 28
+			IL_0661: ldloc.s 29
+			IL_0663: stelem.ref
+			IL_0664: dup
+			IL_0665: ldc.i4.s 29
+			IL_0667: ldloc.s 30
+			IL_0669: stelem.ref
+			IL_066a: dup
+			IL_066b: ldc.i4.s 30
+			IL_066d: ldloc.s 31
+			IL_066f: stelem.ref
+			IL_0670: dup
+			IL_0671: ldc.i4.s 31
+			IL_0673: ldloc.s 32
+			IL_0675: stelem.ref
+			IL_0676: dup
+			IL_0677: ldc.i4.s 32
+			IL_0679: ldloc.s 33
+			IL_067b: stelem.ref
+			IL_067c: pop
+			IL_067d: ldloc.0
+			IL_067e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0683: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0688: ret
 
-			IL_0692: ldloc.0
-			IL_0693: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_0698: stloc.s 12
-			IL_069a: ldarg.0
-			IL_069b: ldc.i4.1
-			IL_069c: ldelem.ref
-			IL_069d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_06a2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_06a7: stloc.s 22
-			IL_06a9: ldc.i4.1
-			IL_06aa: newarr [System.Runtime]System.Object
-			IL_06af: dup
-			IL_06b0: ldc.i4.0
-			IL_06b1: ldarg.0
-			IL_06b2: ldc.i4.1
-			IL_06b3: ldelem.ref
-			IL_06b4: stelem.ref
-			IL_06b5: stloc.s 21
-			IL_06b7: volatile.
-			IL_06b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_06be: brfalse IL_06d3
+			IL_0689: ldloc.0
+			IL_068a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_068f: stloc.s 12
+			IL_0691: volatile.
+			IL_0693: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0698: brfalse IL_06ad
 
-			IL_06c3: ldloc.1
-			IL_06c4: ldstr "section"
-			IL_06c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06ce: br IL_06e8
+			IL_069d: ldloc.1
+			IL_069e: ldstr "section"
+			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06a8: br IL_06c2
 
-			IL_06d3: ldloc.1
-			IL_06d4: ldstr "section"
-			IL_06d9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:114"
-			IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06ad: ldloc.1
+			IL_06ae: ldstr "section"
+			IL_06b3: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:110"
+			IL_06b8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06e8: stloc.s 26
-			IL_06ea: ldloc.s 26
-			IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06f1: stloc.s 26
-			IL_06f3: ldc.i4.0
-			IL_06f4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_06f9: brfalse IL_072b
+			IL_06c2: stloc.s 21
+			IL_06c4: ldloc.s 21
+			IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06cb: stloc.s 21
+			IL_06cd: ldc.i4.0
+			IL_06ce: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_06d3: brfalse IL_0705
 
-			IL_06fe: ldloc.s 26
-			IL_0700: isinst [System.Runtime]System.String
-			IL_0705: dup
-			IL_0706: brtrue IL_071e
+			IL_06d8: ldloc.s 21
+			IL_06da: isinst [System.Runtime]System.String
+			IL_06df: dup
+			IL_06e0: brtrue IL_06f8
 
-			IL_070b: pop
-			IL_070c: ldloc.s 26
-			IL_070e: ldstr "trim"
-			IL_0713: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0718: dup
-			IL_0719: brfalse IL_072a
+			IL_06e5: pop
+			IL_06e6: ldloc.s 21
+			IL_06e8: ldstr "trim"
+			IL_06ed: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_06f2: dup
+			IL_06f3: brfalse IL_0704
 
-			IL_071e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0723: stloc.s 26
-			IL_0725: br IL_0739
+			IL_06f8: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_06fd: stloc.s 21
+			IL_06ff: br IL_0713
 
-			IL_072a: pop
+			IL_0704: pop
 
-			IL_072b: ldloc.s 26
-			IL_072d: ldstr "trim"
-			IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0737: stloc.s 26
+			IL_0705: ldloc.s 21
+			IL_0707: ldstr "trim"
+			IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0711: stloc.s 21
 
-			IL_0739: ldloc.s 22
-			IL_073b: ldloc.s 21
-			IL_073d: ldloc.s 12
-			IL_073f: ldloc.s 26
-			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0746: stloc.s 13
-			IL_0748: ldloc.s 13
-			IL_074a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_074f: ldc.i4.0
-			IL_0750: ceq
-			IL_0752: stloc.s 23
-			IL_0754: ldloc.s 23
-			IL_0756: brfalse IL_07f8
+			IL_0713: ldc.i4.1
+			IL_0714: newarr [System.Runtime]System.Object
+			IL_0719: dup
+			IL_071a: ldc.i4.0
+			IL_071b: ldarg.0
+			IL_071c: ldc.i4.1
+			IL_071d: ldelem.ref
+			IL_071e: stelem.ref
+			IL_071f: stloc.s 22
+			IL_0721: ldloc.s 22
+			IL_0723: ldc.i4.0
+			IL_0724: ldelem.ref
+			IL_0725: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_072a: ldnull
+			IL_072b: ldloc.s 12
+			IL_072d: ldloc.s 21
+			IL_072f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0734: stloc.s 13
+			IL_0736: ldloc.s 13
+			IL_0738: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_073d: ldc.i4.0
+			IL_073e: ceq
+			IL_0740: stloc.s 23
+			IL_0742: ldloc.s 23
+			IL_0744: brfalse IL_07e6
 
-			IL_075b: volatile.
-			IL_075d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_0762: brfalse IL_0777
+			IL_0749: volatile.
+			IL_074b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_0750: brfalse IL_0765
 
-			IL_0767: ldloc.1
-			IL_0768: ldstr "section"
-			IL_076d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0772: br IL_078c
+			IL_0755: ldloc.1
+			IL_0756: ldstr "section"
+			IL_075b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0760: br IL_077a
 
-			IL_0777: ldloc.1
-			IL_0778: ldstr "section"
-			IL_077d: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:125"
-			IL_0782: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0765: ldloc.1
+			IL_0766: ldstr "section"
+			IL_076b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:122"
+			IL_0770: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_078c: stloc.s 26
-			IL_078e: ldloc.s 26
-			IL_0790: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0795: stloc.s 27
-			IL_0797: ldstr "Could not find section '"
-			IL_079c: ldloc.s 27
-			IL_079e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07a3: ldstr "' in multipage index: "
-			IL_07a8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07ad: ldloc.s 11
-			IL_07af: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_07b4: stloc.s 27
-			IL_07b6: ldloc.s 27
-			IL_07b8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07bd: stloc.s 27
-			IL_07bf: ldloc.s 27
-			IL_07c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_07c6: stloc.s 14
-			IL_07c8: ldloc.0
-			IL_07c9: ldc.i4.m1
-			IL_07ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07cf: ldloc.0
-			IL_07d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_07da: ldarg.0
-			IL_07db: ldc.i4.1
-			IL_07dc: newarr [System.Runtime]System.Object
-			IL_07e1: dup
-			IL_07e2: ldc.i4.0
-			IL_07e3: ldloc.s 14
-			IL_07e5: stelem.ref
-			IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_07eb: pop
-			IL_07ec: ldloc.0
-			IL_07ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07f2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07f7: ret
+			IL_077a: stloc.s 21
+			IL_077c: ldloc.s 21
+			IL_077e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0783: stloc.s 26
+			IL_0785: ldstr "Could not find section '"
+			IL_078a: ldloc.s 26
+			IL_078c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0791: ldstr "' in multipage index: "
+			IL_0796: call string [System.Runtime]System.String::Concat(string, string)
+			IL_079b: ldloc.s 11
+			IL_079d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07a2: stloc.s 26
+			IL_07a4: ldloc.s 26
+			IL_07a6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07ab: stloc.s 26
+			IL_07ad: ldloc.s 26
+			IL_07af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_07b4: stloc.s 14
+			IL_07b6: ldloc.0
+			IL_07b7: ldc.i4.m1
+			IL_07b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07bd: ldloc.0
+			IL_07be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_07c8: ldarg.0
+			IL_07c9: ldc.i4.1
+			IL_07ca: newarr [System.Runtime]System.Object
+			IL_07cf: dup
+			IL_07d0: ldc.i4.0
+			IL_07d1: ldloc.s 14
+			IL_07d3: stelem.ref
+			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_07d9: pop
+			IL_07da: ldloc.0
+			IL_07db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07e0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07e5: ret
 
-			IL_07f8: ldarg.0
-			IL_07f9: ldc.i4.1
-			IL_07fa: ldelem.ref
-			IL_07fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0800: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_0805: stloc.s 26
-			IL_0807: volatile.
-			IL_0809: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_080e: brfalse IL_0824
+			IL_07e6: ldarg.0
+			IL_07e7: ldc.i4.1
+			IL_07e8: ldelem.ref
+			IL_07e9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07ee: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_07f3: stloc.s 21
+			IL_07f5: volatile.
+			IL_07f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_07fc: brfalse IL_0812
 
-			IL_0813: ldloc.s 13
-			IL_0815: ldstr "filePart"
-			IL_081a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_081f: br IL_083a
+			IL_0801: ldloc.s 13
+			IL_0803: ldstr "filePart"
+			IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_080d: br IL_0828
 
-			IL_0824: ldloc.s 13
-			IL_0826: ldstr "filePart"
-			IL_082b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:139"
-			IL_0830: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0812: ldloc.s 13
+			IL_0814: ldstr "filePart"
+			IL_0819: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:136"
+			IL_081e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_083a: stloc.s 22
-			IL_083c: ldloc.s 22
-			IL_083e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0843: stloc.s 23
-			IL_0845: ldloc.s 23
-			IL_0847: brtrue IL_088a
+			IL_0828: stloc.s 27
+			IL_082a: ldloc.s 27
+			IL_082c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0831: stloc.s 23
+			IL_0833: ldloc.s 23
+			IL_0835: brtrue IL_0878
 
-			IL_084c: volatile.
-			IL_084e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_0853: brfalse IL_0869
+			IL_083a: volatile.
+			IL_083c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0841: brfalse IL_0857
 
-			IL_0858: ldloc.s 13
-			IL_085a: ldstr "href"
-			IL_085f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0864: br IL_087f
+			IL_0846: ldloc.s 13
+			IL_0848: ldstr "href"
+			IL_084d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0852: br IL_086d
 
-			IL_0869: ldloc.s 13
-			IL_086b: ldstr "href"
-			IL_0870: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:143"
-			IL_0875: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0857: ldloc.s 13
+			IL_0859: ldstr "href"
+			IL_085e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:140"
+			IL_0863: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_087f: stloc.s 28
-			IL_0881: ldloc.s 28
-			IL_0883: stloc.s 29
-			IL_0885: br IL_088e
+			IL_086d: stloc.s 28
+			IL_086f: ldloc.s 28
+			IL_0871: stloc.s 29
+			IL_0873: br IL_087c
 
-			IL_088a: ldloc.s 22
-			IL_088c: stloc.s 29
+			IL_0878: ldloc.s 27
+			IL_087a: stloc.s 29
 
-			IL_088e: ldloc.s 26
-			IL_0890: dup
-			IL_0891: ldloc.s 29
-			IL_0893: ldloc.s 11
-			IL_0895: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-			IL_089a: stloc.s 26
-			IL_089c: ldloc.s 26
-			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08a3: stloc.s 26
-			IL_08a5: volatile.
-			IL_08a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-			IL_08ac: brfalse IL_08c2
+			IL_087c: ldloc.s 21
+			IL_087e: dup
+			IL_087f: ldloc.s 29
+			IL_0881: ldloc.s 11
+			IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+			IL_0888: stloc.s 21
+			IL_088a: ldloc.s 21
+			IL_088c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0891: stloc.s 21
+			IL_0893: volatile.
+			IL_0895: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_089a: brfalse IL_08b0
 
-			IL_08b1: ldloc.s 26
-			IL_08b3: ldstr "toString"
-			IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_08bd: br IL_08d8
+			IL_089f: ldloc.s 21
+			IL_08a1: ldstr "toString"
+			IL_08a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_08ab: br IL_08c6
 
-			IL_08c2: ldloc.s 26
-			IL_08c4: ldstr "toString"
-			IL_08c9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:151"
-			IL_08ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_08b0: ldloc.s 21
+			IL_08b2: ldstr "toString"
+			IL_08b7: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:148"
+			IL_08bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_08c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_08d8: stloc.s 15
-			IL_08da: ldarg.0
-			IL_08db: ldc.i4.1
-			IL_08dc: ldelem.ref
-			IL_08dd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_08e2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_08e7: ldc.i4.1
-			IL_08e8: newarr [System.Runtime]System.Object
-			IL_08ed: dup
-			IL_08ee: ldc.i4.0
-			IL_08ef: ldarg.0
-			IL_08f0: ldc.i4.1
-			IL_08f1: ldelem.ref
-			IL_08f2: stelem.ref
-			IL_08f3: stloc.s 21
-			IL_08f5: ldloc.s 21
-			IL_08f7: ldloc.s 15
-			IL_08f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_08fe: stloc.s 26
-			IL_0900: ldloc.0
-			IL_0901: ldc.i4.2
-			IL_0902: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0907: ldloc.0
-			IL_0908: ldloc.s 26
-			IL_090a: ldarg.0
-			IL_090b: ldc.i4.2
-			IL_090c: ldloc.0
-			IL_090d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0912: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0917: ldloc.0
-			IL_0918: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08c6: stloc.s 15
+			IL_08c8: ldc.i4.1
+			IL_08c9: newarr [System.Runtime]System.Object
+			IL_08ce: dup
+			IL_08cf: ldc.i4.0
+			IL_08d0: ldarg.0
+			IL_08d1: ldc.i4.1
+			IL_08d2: ldelem.ref
+			IL_08d3: stelem.ref
+			IL_08d4: stloc.s 22
+			IL_08d6: ldloc.s 22
+			IL_08d8: ldc.i4.0
+			IL_08d9: ldelem.ref
+			IL_08da: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08df: ldnull
+			IL_08e0: ldloc.s 15
+			IL_08e2: ldnull
+			IL_08e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_08e8: stloc.s 21
+			IL_08ea: ldloc.0
+			IL_08eb: ldc.i4.2
+			IL_08ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08f1: ldloc.0
+			IL_08f2: ldloc.s 21
+			IL_08f4: ldarg.0
+			IL_08f5: ldc.i4.2
+			IL_08f6: ldloc.0
+			IL_08f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0901: ldloc.0
+			IL_0902: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0907: dup
+			IL_0908: ldc.i4.0
+			IL_0909: ldloc.1
+			IL_090a: stelem.ref
+			IL_090b: dup
+			IL_090c: ldc.i4.1
+			IL_090d: ldloc.2
+			IL_090e: stelem.ref
+			IL_090f: dup
+			IL_0910: ldc.i4.2
+			IL_0911: ldloc.3
+			IL_0912: stelem.ref
+			IL_0913: dup
+			IL_0914: ldc.i4.3
+			IL_0915: ldloc.s 4
+			IL_0917: stelem.ref
+			IL_0918: dup
+			IL_0919: ldc.i4.4
+			IL_091a: ldloc.s 5
+			IL_091c: stelem.ref
 			IL_091d: dup
-			IL_091e: ldc.i4.0
-			IL_091f: ldloc.1
-			IL_0920: stelem.ref
-			IL_0921: dup
-			IL_0922: ldc.i4.1
-			IL_0923: ldloc.2
-			IL_0924: stelem.ref
-			IL_0925: dup
-			IL_0926: ldc.i4.2
-			IL_0927: ldloc.3
-			IL_0928: stelem.ref
-			IL_0929: dup
-			IL_092a: ldc.i4.3
-			IL_092b: ldloc.s 4
-			IL_092d: stelem.ref
-			IL_092e: dup
-			IL_092f: ldc.i4.4
-			IL_0930: ldloc.s 5
-			IL_0932: stelem.ref
-			IL_0933: dup
-			IL_0934: ldc.i4.5
-			IL_0935: ldloc.s 6
-			IL_0937: stelem.ref
-			IL_0938: dup
-			IL_0939: ldc.i4.6
-			IL_093a: ldloc.s 7
+			IL_091e: ldc.i4.5
+			IL_091f: ldloc.s 6
+			IL_0921: stelem.ref
+			IL_0922: dup
+			IL_0923: ldc.i4.6
+			IL_0924: ldloc.s 7
+			IL_0926: stelem.ref
+			IL_0927: dup
+			IL_0928: ldc.i4.7
+			IL_0929: ldloc.s 8
+			IL_092b: stelem.ref
+			IL_092c: dup
+			IL_092d: ldc.i4.8
+			IL_092e: ldloc.s 9
+			IL_0930: stelem.ref
+			IL_0931: dup
+			IL_0932: ldc.i4.s 9
+			IL_0934: ldloc.s 10
+			IL_0936: stelem.ref
+			IL_0937: dup
+			IL_0938: ldc.i4.s 10
+			IL_093a: ldloc.s 11
 			IL_093c: stelem.ref
 			IL_093d: dup
-			IL_093e: ldc.i4.7
-			IL_093f: ldloc.s 8
-			IL_0941: stelem.ref
-			IL_0942: dup
-			IL_0943: ldc.i4.8
-			IL_0944: ldloc.s 9
-			IL_0946: stelem.ref
-			IL_0947: dup
-			IL_0948: ldc.i4.s 9
-			IL_094a: ldloc.s 10
-			IL_094c: stelem.ref
-			IL_094d: dup
-			IL_094e: ldc.i4.s 10
-			IL_0950: ldloc.s 11
-			IL_0952: stelem.ref
-			IL_0953: dup
-			IL_0954: ldc.i4.s 11
-			IL_0956: ldloc.s 12
-			IL_0958: stelem.ref
-			IL_0959: dup
-			IL_095a: ldc.i4.s 12
-			IL_095c: ldloc.s 13
-			IL_095e: stelem.ref
-			IL_095f: dup
-			IL_0960: ldc.i4.s 13
-			IL_0962: ldloc.s 14
-			IL_0964: stelem.ref
-			IL_0965: dup
-			IL_0966: ldc.i4.s 14
-			IL_0968: ldloc.s 15
-			IL_096a: stelem.ref
-			IL_096b: dup
-			IL_096c: ldc.i4.s 15
-			IL_096e: ldloc.s 16
-			IL_0970: stelem.ref
-			IL_0971: dup
-			IL_0972: ldc.i4.s 16
-			IL_0974: ldloc.s 17
-			IL_0976: stelem.ref
-			IL_0977: dup
-			IL_0978: ldc.i4.s 17
-			IL_097a: ldloc.s 18
-			IL_097c: stelem.ref
-			IL_097d: dup
-			IL_097e: ldc.i4.s 18
-			IL_0980: ldloc.s 19
-			IL_0982: stelem.ref
-			IL_0983: dup
-			IL_0984: ldc.i4.s 19
-			IL_0986: ldloc.s 20
-			IL_0988: stelem.ref
-			IL_0989: dup
-			IL_098a: ldc.i4.s 20
-			IL_098c: ldloc.s 21
-			IL_098e: stelem.ref
-			IL_098f: dup
-			IL_0990: ldc.i4.s 21
-			IL_0992: ldloc.s 22
-			IL_0994: stelem.ref
-			IL_0995: dup
-			IL_0996: ldc.i4.s 22
-			IL_0998: ldloc.s 23
-			IL_099a: box [System.Runtime]System.Boolean
-			IL_099f: stelem.ref
-			IL_09a0: dup
-			IL_09a1: ldc.i4.s 23
-			IL_09a3: ldloc.s 24
-			IL_09a5: stelem.ref
-			IL_09a6: dup
-			IL_09a7: ldc.i4.s 24
-			IL_09a9: ldloc.s 25
-			IL_09ab: stelem.ref
-			IL_09ac: dup
-			IL_09ad: ldc.i4.s 25
-			IL_09af: ldloc.s 26
-			IL_09b1: stelem.ref
-			IL_09b2: dup
-			IL_09b3: ldc.i4.s 26
-			IL_09b5: ldloc.s 27
-			IL_09b7: stelem.ref
-			IL_09b8: dup
-			IL_09b9: ldc.i4.s 27
-			IL_09bb: ldloc.s 28
-			IL_09bd: stelem.ref
-			IL_09be: dup
-			IL_09bf: ldc.i4.s 28
-			IL_09c1: ldloc.s 29
-			IL_09c3: stelem.ref
-			IL_09c4: dup
-			IL_09c5: ldc.i4.s 29
-			IL_09c7: ldloc.s 30
-			IL_09c9: stelem.ref
-			IL_09ca: dup
-			IL_09cb: ldc.i4.s 30
-			IL_09cd: ldloc.s 31
-			IL_09cf: stelem.ref
-			IL_09d0: dup
-			IL_09d1: ldc.i4.s 31
-			IL_09d3: ldloc.s 32
-			IL_09d5: stelem.ref
-			IL_09d6: dup
-			IL_09d7: ldc.i4.s 32
-			IL_09d9: ldloc.s 33
-			IL_09db: stelem.ref
-			IL_09dc: pop
-			IL_09dd: ldloc.0
-			IL_09de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09e3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09e8: ret
+			IL_093e: ldc.i4.s 11
+			IL_0940: ldloc.s 12
+			IL_0942: stelem.ref
+			IL_0943: dup
+			IL_0944: ldc.i4.s 12
+			IL_0946: ldloc.s 13
+			IL_0948: stelem.ref
+			IL_0949: dup
+			IL_094a: ldc.i4.s 13
+			IL_094c: ldloc.s 14
+			IL_094e: stelem.ref
+			IL_094f: dup
+			IL_0950: ldc.i4.s 14
+			IL_0952: ldloc.s 15
+			IL_0954: stelem.ref
+			IL_0955: dup
+			IL_0956: ldc.i4.s 15
+			IL_0958: ldloc.s 16
+			IL_095a: stelem.ref
+			IL_095b: dup
+			IL_095c: ldc.i4.s 16
+			IL_095e: ldloc.s 17
+			IL_0960: stelem.ref
+			IL_0961: dup
+			IL_0962: ldc.i4.s 17
+			IL_0964: ldloc.s 18
+			IL_0966: stelem.ref
+			IL_0967: dup
+			IL_0968: ldc.i4.s 18
+			IL_096a: ldloc.s 19
+			IL_096c: stelem.ref
+			IL_096d: dup
+			IL_096e: ldc.i4.s 19
+			IL_0970: ldloc.s 20
+			IL_0972: stelem.ref
+			IL_0973: dup
+			IL_0974: ldc.i4.s 20
+			IL_0976: ldloc.s 21
+			IL_0978: stelem.ref
+			IL_0979: dup
+			IL_097a: ldc.i4.s 21
+			IL_097c: ldloc.s 22
+			IL_097e: stelem.ref
+			IL_097f: dup
+			IL_0980: ldc.i4.s 22
+			IL_0982: ldloc.s 23
+			IL_0984: box [System.Runtime]System.Boolean
+			IL_0989: stelem.ref
+			IL_098a: dup
+			IL_098b: ldc.i4.s 23
+			IL_098d: ldloc.s 24
+			IL_098f: stelem.ref
+			IL_0990: dup
+			IL_0991: ldc.i4.s 24
+			IL_0993: ldloc.s 25
+			IL_0995: stelem.ref
+			IL_0996: dup
+			IL_0997: ldc.i4.s 25
+			IL_0999: ldloc.s 26
+			IL_099b: stelem.ref
+			IL_099c: dup
+			IL_099d: ldc.i4.s 26
+			IL_099f: ldloc.s 27
+			IL_09a1: stelem.ref
+			IL_09a2: dup
+			IL_09a3: ldc.i4.s 27
+			IL_09a5: ldloc.s 28
+			IL_09a7: stelem.ref
+			IL_09a8: dup
+			IL_09a9: ldc.i4.s 28
+			IL_09ab: ldloc.s 29
+			IL_09ad: stelem.ref
+			IL_09ae: dup
+			IL_09af: ldc.i4.s 29
+			IL_09b1: ldloc.s 30
+			IL_09b3: stelem.ref
+			IL_09b4: dup
+			IL_09b5: ldc.i4.s 30
+			IL_09b7: ldloc.s 31
+			IL_09b9: stelem.ref
+			IL_09ba: dup
+			IL_09bb: ldc.i4.s 31
+			IL_09bd: ldloc.s 32
+			IL_09bf: stelem.ref
+			IL_09c0: dup
+			IL_09c1: ldc.i4.s 32
+			IL_09c3: ldloc.s 33
+			IL_09c5: stelem.ref
+			IL_09c6: pop
+			IL_09c7: ldloc.0
+			IL_09c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09cd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09d2: ret
 
-			IL_09e9: ldloc.0
-			IL_09ea: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_09ef: stloc.s 26
-			IL_09f1: ldloc.s 26
-			IL_09f3: stloc.s 8
-			IL_09f5: ldloc.s 15
-			IL_09f7: stloc.s 26
-			IL_09f9: ldloc.s 26
-			IL_09fb: stloc.s 10
-			IL_09fd: ldloc.s 9
-			IL_09ff: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0a04: ldc.i4.0
-			IL_0a05: ceq
-			IL_0a07: stloc.s 23
-			IL_0a09: ldloc.s 23
-			IL_0a0b: brfalse IL_0a69
+			IL_09d3: ldloc.0
+			IL_09d4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_09d9: stloc.s 21
+			IL_09db: ldloc.s 21
+			IL_09dd: stloc.s 8
+			IL_09df: ldloc.s 15
+			IL_09e1: stloc.s 21
+			IL_09e3: ldloc.s 21
+			IL_09e5: stloc.s 10
+			IL_09e7: ldloc.s 9
+			IL_09e9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09ee: ldc.i4.0
+			IL_09ef: ceq
+			IL_09f1: stloc.s 23
+			IL_09f3: ldloc.s 23
+			IL_09f5: brfalse IL_0a53
 
-			IL_0a10: volatile.
-			IL_0a12: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-			IL_0a17: brfalse IL_0a2d
+			IL_09fa: volatile.
+			IL_09fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0a01: brfalse IL_0a17
 
-			IL_0a1c: ldloc.s 13
-			IL_0a1e: ldstr "fragment"
-			IL_0a23: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a28: br IL_0a43
+			IL_0a06: ldloc.s 13
+			IL_0a08: ldstr "fragment"
+			IL_0a0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a12: br IL_0a2d
 
-			IL_0a2d: ldloc.s 13
-			IL_0a2f: ldstr "fragment"
-			IL_0a34: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:168"
-			IL_0a39: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-			IL_0a3e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0a17: ldloc.s 13
+			IL_0a19: ldstr "fragment"
+			IL_0a1e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:164"
+			IL_0a23: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0a28: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0a43: stloc.s 26
-			IL_0a45: ldloc.s 26
-			IL_0a47: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0a4c: stloc.s 23
-			IL_0a4e: ldloc.s 23
-			IL_0a50: brtrue IL_0a61
+			IL_0a2d: stloc.s 21
+			IL_0a2f: ldloc.s 21
+			IL_0a31: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0a36: stloc.s 23
+			IL_0a38: ldloc.s 23
+			IL_0a3a: brtrue IL_0a4b
 
-			IL_0a55: ldstr ""
-			IL_0a5a: stloc.s 30
-			IL_0a5c: br IL_0a65
+			IL_0a3f: ldstr ""
+			IL_0a44: stloc.s 30
+			IL_0a46: br IL_0a4f
 
-			IL_0a61: ldloc.s 26
-			IL_0a63: stloc.s 30
+			IL_0a4b: ldloc.s 21
+			IL_0a4d: stloc.s 30
 
-			IL_0a65: ldloc.s 30
-			IL_0a67: stloc.s 9
+			IL_0a4f: ldloc.s 30
+			IL_0a51: stloc.s 9
 
-			IL_0a69: br IL_0c13
+			IL_0a53: br IL_0bf9
 
-			IL_0a6e: volatile.
-			IL_0a70: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-			IL_0a75: brfalse IL_0a8a
+			IL_0a58: volatile.
+			IL_0a5a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_0a5f: brfalse IL_0a74
 
-			IL_0a7a: ldloc.1
-			IL_0a7b: ldstr "url"
-			IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a85: br IL_0a9f
+			IL_0a64: ldloc.1
+			IL_0a65: ldstr "url"
+			IL_0a6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a6f: br IL_0a89
 
-			IL_0a8a: ldloc.1
-			IL_0a8b: ldstr "url"
-			IL_0a90: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:184"
-			IL_0a95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-			IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0a74: ldloc.1
+			IL_0a75: ldstr "url"
+			IL_0a7a: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:180"
+			IL_0a7f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_0a84: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0a9f: stloc.s 26
-			IL_0aa1: ldloc.s 26
-			IL_0aa3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0aa8: stloc.s 26
-			IL_0aaa: ldc.i4.0
-			IL_0aab: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0ab0: brfalse IL_0ae2
+			IL_0a89: stloc.s 21
+			IL_0a8b: ldloc.s 21
+			IL_0a8d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a92: stloc.s 21
+			IL_0a94: ldc.i4.0
+			IL_0a95: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0a9a: brfalse IL_0acc
 
-			IL_0ab5: ldloc.s 26
-			IL_0ab7: isinst [System.Runtime]System.String
-			IL_0abc: dup
-			IL_0abd: brtrue IL_0ad5
+			IL_0a9f: ldloc.s 21
+			IL_0aa1: isinst [System.Runtime]System.String
+			IL_0aa6: dup
+			IL_0aa7: brtrue IL_0abf
 
-			IL_0ac2: pop
-			IL_0ac3: ldloc.s 26
-			IL_0ac5: ldstr "trim"
-			IL_0aca: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0acf: dup
-			IL_0ad0: brfalse IL_0ae1
+			IL_0aac: pop
+			IL_0aad: ldloc.s 21
+			IL_0aaf: ldstr "trim"
+			IL_0ab4: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0ab9: dup
+			IL_0aba: brfalse IL_0acb
 
-			IL_0ad5: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0ada: stloc.s 16
-			IL_0adc: br IL_0af0
+			IL_0abf: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0ac4: stloc.s 16
+			IL_0ac6: br IL_0ada
 
-			IL_0ae1: pop
+			IL_0acb: pop
 
-			IL_0ae2: ldloc.s 26
-			IL_0ae4: ldstr "trim"
-			IL_0ae9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0aee: stloc.s 16
+			IL_0acc: ldloc.s 21
+			IL_0ace: ldstr "trim"
+			IL_0ad3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0ad8: stloc.s 16
 
-			IL_0af0: ldarg.0
-			IL_0af1: ldc.i4.1
-			IL_0af2: ldelem.ref
-			IL_0af3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0af8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0afd: ldc.i4.1
-			IL_0afe: newarr [System.Runtime]System.Object
-			IL_0b03: dup
-			IL_0b04: ldc.i4.0
-			IL_0b05: ldarg.0
-			IL_0b06: ldc.i4.1
-			IL_0b07: ldelem.ref
-			IL_0b08: stelem.ref
-			IL_0b09: stloc.s 21
-			IL_0b0b: ldloc.s 21
-			IL_0b0d: ldloc.s 16
-			IL_0b0f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0b14: stloc.s 26
-			IL_0b16: ldloc.0
-			IL_0b17: ldc.i4.3
-			IL_0b18: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b1d: ldloc.0
-			IL_0b1e: ldloc.s 26
-			IL_0b20: ldarg.0
-			IL_0b21: ldc.i4.3
-			IL_0b22: ldloc.0
-			IL_0b23: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0b28: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0b2d: ldloc.0
-			IL_0b2e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0b33: dup
-			IL_0b34: ldc.i4.0
-			IL_0b35: ldloc.1
-			IL_0b36: stelem.ref
-			IL_0b37: dup
-			IL_0b38: ldc.i4.1
-			IL_0b39: ldloc.2
-			IL_0b3a: stelem.ref
-			IL_0b3b: dup
-			IL_0b3c: ldc.i4.2
-			IL_0b3d: ldloc.3
-			IL_0b3e: stelem.ref
-			IL_0b3f: dup
-			IL_0b40: ldc.i4.3
-			IL_0b41: ldloc.s 4
-			IL_0b43: stelem.ref
-			IL_0b44: dup
-			IL_0b45: ldc.i4.4
-			IL_0b46: ldloc.s 5
+			IL_0ada: ldc.i4.1
+			IL_0adb: newarr [System.Runtime]System.Object
+			IL_0ae0: dup
+			IL_0ae1: ldc.i4.0
+			IL_0ae2: ldarg.0
+			IL_0ae3: ldc.i4.1
+			IL_0ae4: ldelem.ref
+			IL_0ae5: stelem.ref
+			IL_0ae6: stloc.s 22
+			IL_0ae8: ldloc.s 22
+			IL_0aea: ldc.i4.0
+			IL_0aeb: ldelem.ref
+			IL_0aec: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0af1: ldnull
+			IL_0af2: ldloc.s 16
+			IL_0af4: ldnull
+			IL_0af5: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0afa: stloc.s 21
+			IL_0afc: ldloc.0
+			IL_0afd: ldc.i4.3
+			IL_0afe: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b03: ldloc.0
+			IL_0b04: ldloc.s 21
+			IL_0b06: ldarg.0
+			IL_0b07: ldc.i4.3
+			IL_0b08: ldloc.0
+			IL_0b09: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0b0e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0b13: ldloc.0
+			IL_0b14: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0b19: dup
+			IL_0b1a: ldc.i4.0
+			IL_0b1b: ldloc.1
+			IL_0b1c: stelem.ref
+			IL_0b1d: dup
+			IL_0b1e: ldc.i4.1
+			IL_0b1f: ldloc.2
+			IL_0b20: stelem.ref
+			IL_0b21: dup
+			IL_0b22: ldc.i4.2
+			IL_0b23: ldloc.3
+			IL_0b24: stelem.ref
+			IL_0b25: dup
+			IL_0b26: ldc.i4.3
+			IL_0b27: ldloc.s 4
+			IL_0b29: stelem.ref
+			IL_0b2a: dup
+			IL_0b2b: ldc.i4.4
+			IL_0b2c: ldloc.s 5
+			IL_0b2e: stelem.ref
+			IL_0b2f: dup
+			IL_0b30: ldc.i4.5
+			IL_0b31: ldloc.s 6
+			IL_0b33: stelem.ref
+			IL_0b34: dup
+			IL_0b35: ldc.i4.6
+			IL_0b36: ldloc.s 7
+			IL_0b38: stelem.ref
+			IL_0b39: dup
+			IL_0b3a: ldc.i4.7
+			IL_0b3b: ldloc.s 8
+			IL_0b3d: stelem.ref
+			IL_0b3e: dup
+			IL_0b3f: ldc.i4.8
+			IL_0b40: ldloc.s 9
+			IL_0b42: stelem.ref
+			IL_0b43: dup
+			IL_0b44: ldc.i4.s 9
+			IL_0b46: ldloc.s 10
 			IL_0b48: stelem.ref
 			IL_0b49: dup
-			IL_0b4a: ldc.i4.5
-			IL_0b4b: ldloc.s 6
-			IL_0b4d: stelem.ref
-			IL_0b4e: dup
-			IL_0b4f: ldc.i4.6
-			IL_0b50: ldloc.s 7
-			IL_0b52: stelem.ref
-			IL_0b53: dup
-			IL_0b54: ldc.i4.7
-			IL_0b55: ldloc.s 8
-			IL_0b57: stelem.ref
-			IL_0b58: dup
-			IL_0b59: ldc.i4.8
-			IL_0b5a: ldloc.s 9
-			IL_0b5c: stelem.ref
-			IL_0b5d: dup
-			IL_0b5e: ldc.i4.s 9
-			IL_0b60: ldloc.s 10
-			IL_0b62: stelem.ref
-			IL_0b63: dup
-			IL_0b64: ldc.i4.s 10
-			IL_0b66: ldloc.s 11
-			IL_0b68: stelem.ref
-			IL_0b69: dup
-			IL_0b6a: ldc.i4.s 11
-			IL_0b6c: ldloc.s 12
-			IL_0b6e: stelem.ref
-			IL_0b6f: dup
-			IL_0b70: ldc.i4.s 12
-			IL_0b72: ldloc.s 13
-			IL_0b74: stelem.ref
-			IL_0b75: dup
-			IL_0b76: ldc.i4.s 13
-			IL_0b78: ldloc.s 14
-			IL_0b7a: stelem.ref
-			IL_0b7b: dup
-			IL_0b7c: ldc.i4.s 14
-			IL_0b7e: ldloc.s 15
-			IL_0b80: stelem.ref
-			IL_0b81: dup
-			IL_0b82: ldc.i4.s 15
-			IL_0b84: ldloc.s 16
-			IL_0b86: stelem.ref
-			IL_0b87: dup
-			IL_0b88: ldc.i4.s 16
-			IL_0b8a: ldloc.s 17
-			IL_0b8c: stelem.ref
-			IL_0b8d: dup
-			IL_0b8e: ldc.i4.s 17
-			IL_0b90: ldloc.s 18
-			IL_0b92: stelem.ref
-			IL_0b93: dup
-			IL_0b94: ldc.i4.s 18
-			IL_0b96: ldloc.s 19
-			IL_0b98: stelem.ref
-			IL_0b99: dup
-			IL_0b9a: ldc.i4.s 19
-			IL_0b9c: ldloc.s 20
-			IL_0b9e: stelem.ref
-			IL_0b9f: dup
-			IL_0ba0: ldc.i4.s 20
-			IL_0ba2: ldloc.s 21
-			IL_0ba4: stelem.ref
-			IL_0ba5: dup
-			IL_0ba6: ldc.i4.s 21
-			IL_0ba8: ldloc.s 22
-			IL_0baa: stelem.ref
-			IL_0bab: dup
-			IL_0bac: ldc.i4.s 22
-			IL_0bae: ldloc.s 23
-			IL_0bb0: box [System.Runtime]System.Boolean
-			IL_0bb5: stelem.ref
-			IL_0bb6: dup
-			IL_0bb7: ldc.i4.s 23
-			IL_0bb9: ldloc.s 24
-			IL_0bbb: stelem.ref
-			IL_0bbc: dup
-			IL_0bbd: ldc.i4.s 24
-			IL_0bbf: ldloc.s 25
-			IL_0bc1: stelem.ref
-			IL_0bc2: dup
-			IL_0bc3: ldc.i4.s 25
-			IL_0bc5: ldloc.s 26
-			IL_0bc7: stelem.ref
-			IL_0bc8: dup
-			IL_0bc9: ldc.i4.s 26
-			IL_0bcb: ldloc.s 27
-			IL_0bcd: stelem.ref
-			IL_0bce: dup
-			IL_0bcf: ldc.i4.s 27
-			IL_0bd1: ldloc.s 28
-			IL_0bd3: stelem.ref
-			IL_0bd4: dup
-			IL_0bd5: ldc.i4.s 28
-			IL_0bd7: ldloc.s 29
-			IL_0bd9: stelem.ref
-			IL_0bda: dup
-			IL_0bdb: ldc.i4.s 29
-			IL_0bdd: ldloc.s 30
-			IL_0bdf: stelem.ref
-			IL_0be0: dup
-			IL_0be1: ldc.i4.s 30
-			IL_0be3: ldloc.s 31
-			IL_0be5: stelem.ref
-			IL_0be6: dup
-			IL_0be7: ldc.i4.s 31
-			IL_0be9: ldloc.s 32
-			IL_0beb: stelem.ref
-			IL_0bec: dup
-			IL_0bed: ldc.i4.s 32
-			IL_0bef: ldloc.s 33
-			IL_0bf1: stelem.ref
-			IL_0bf2: pop
-			IL_0bf3: ldloc.0
-			IL_0bf4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bf9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bfe: ret
+			IL_0b4a: ldc.i4.s 10
+			IL_0b4c: ldloc.s 11
+			IL_0b4e: stelem.ref
+			IL_0b4f: dup
+			IL_0b50: ldc.i4.s 11
+			IL_0b52: ldloc.s 12
+			IL_0b54: stelem.ref
+			IL_0b55: dup
+			IL_0b56: ldc.i4.s 12
+			IL_0b58: ldloc.s 13
+			IL_0b5a: stelem.ref
+			IL_0b5b: dup
+			IL_0b5c: ldc.i4.s 13
+			IL_0b5e: ldloc.s 14
+			IL_0b60: stelem.ref
+			IL_0b61: dup
+			IL_0b62: ldc.i4.s 14
+			IL_0b64: ldloc.s 15
+			IL_0b66: stelem.ref
+			IL_0b67: dup
+			IL_0b68: ldc.i4.s 15
+			IL_0b6a: ldloc.s 16
+			IL_0b6c: stelem.ref
+			IL_0b6d: dup
+			IL_0b6e: ldc.i4.s 16
+			IL_0b70: ldloc.s 17
+			IL_0b72: stelem.ref
+			IL_0b73: dup
+			IL_0b74: ldc.i4.s 17
+			IL_0b76: ldloc.s 18
+			IL_0b78: stelem.ref
+			IL_0b79: dup
+			IL_0b7a: ldc.i4.s 18
+			IL_0b7c: ldloc.s 19
+			IL_0b7e: stelem.ref
+			IL_0b7f: dup
+			IL_0b80: ldc.i4.s 19
+			IL_0b82: ldloc.s 20
+			IL_0b84: stelem.ref
+			IL_0b85: dup
+			IL_0b86: ldc.i4.s 20
+			IL_0b88: ldloc.s 21
+			IL_0b8a: stelem.ref
+			IL_0b8b: dup
+			IL_0b8c: ldc.i4.s 21
+			IL_0b8e: ldloc.s 22
+			IL_0b90: stelem.ref
+			IL_0b91: dup
+			IL_0b92: ldc.i4.s 22
+			IL_0b94: ldloc.s 23
+			IL_0b96: box [System.Runtime]System.Boolean
+			IL_0b9b: stelem.ref
+			IL_0b9c: dup
+			IL_0b9d: ldc.i4.s 23
+			IL_0b9f: ldloc.s 24
+			IL_0ba1: stelem.ref
+			IL_0ba2: dup
+			IL_0ba3: ldc.i4.s 24
+			IL_0ba5: ldloc.s 25
+			IL_0ba7: stelem.ref
+			IL_0ba8: dup
+			IL_0ba9: ldc.i4.s 25
+			IL_0bab: ldloc.s 26
+			IL_0bad: stelem.ref
+			IL_0bae: dup
+			IL_0baf: ldc.i4.s 26
+			IL_0bb1: ldloc.s 27
+			IL_0bb3: stelem.ref
+			IL_0bb4: dup
+			IL_0bb5: ldc.i4.s 27
+			IL_0bb7: ldloc.s 28
+			IL_0bb9: stelem.ref
+			IL_0bba: dup
+			IL_0bbb: ldc.i4.s 28
+			IL_0bbd: ldloc.s 29
+			IL_0bbf: stelem.ref
+			IL_0bc0: dup
+			IL_0bc1: ldc.i4.s 29
+			IL_0bc3: ldloc.s 30
+			IL_0bc5: stelem.ref
+			IL_0bc6: dup
+			IL_0bc7: ldc.i4.s 30
+			IL_0bc9: ldloc.s 31
+			IL_0bcb: stelem.ref
+			IL_0bcc: dup
+			IL_0bcd: ldc.i4.s 31
+			IL_0bcf: ldloc.s 32
+			IL_0bd1: stelem.ref
+			IL_0bd2: dup
+			IL_0bd3: ldc.i4.s 32
+			IL_0bd5: ldloc.s 33
+			IL_0bd7: stelem.ref
+			IL_0bd8: pop
+			IL_0bd9: ldloc.0
+			IL_0bda: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bdf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0be4: ret
 
-			IL_0bff: ldloc.0
-			IL_0c00: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_0c05: stloc.s 26
-			IL_0c07: ldloc.s 26
-			IL_0c09: stloc.s 8
-			IL_0c0b: ldloc.s 16
-			IL_0c0d: stloc.s 26
-			IL_0c0f: ldloc.s 26
-			IL_0c11: stloc.s 10
+			IL_0be5: ldloc.0
+			IL_0be6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_0beb: stloc.s 21
+			IL_0bed: ldloc.s 21
+			IL_0bef: stloc.s 8
+			IL_0bf1: ldloc.s 16
+			IL_0bf3: stloc.s 21
+			IL_0bf5: ldloc.s 21
+			IL_0bf7: stloc.s 10
 
-			IL_0c13: ldloc.s 9
-			IL_0c15: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0c1a: ldc.i4.0
-			IL_0c1b: ceq
-			IL_0c1d: stloc.s 23
-			IL_0c1f: ldloc.s 23
-			IL_0c21: brfalse IL_0cb3
+			IL_0bf9: ldloc.s 9
+			IL_0bfb: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0c00: ldc.i4.0
+			IL_0c01: ceq
+			IL_0c03: stloc.s 23
+			IL_0c05: ldloc.s 23
+			IL_0c07: brfalse IL_0c99
 
-			IL_0c26: volatile.
-			IL_0c28: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-			IL_0c2d: brfalse IL_0c42
+			IL_0c0c: volatile.
+			IL_0c0e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0c13: brfalse IL_0c28
 
-			IL_0c32: ldloc.1
-			IL_0c33: ldstr "section"
-			IL_0c38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c3d: br IL_0c57
+			IL_0c18: ldloc.1
+			IL_0c19: ldstr "section"
+			IL_0c1e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c23: br IL_0c3d
 
-			IL_0c42: ldloc.1
-			IL_0c43: ldstr "section"
-			IL_0c48: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:205"
-			IL_0c4d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-			IL_0c52: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0c28: ldloc.1
+			IL_0c29: ldstr "section"
+			IL_0c2e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:200"
+			IL_0c33: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0c38: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0c57: stloc.s 26
-			IL_0c59: ldloc.s 26
-			IL_0c5b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0c60: stloc.s 27
-			IL_0c62: ldstr "Could not infer an element id for section '"
-			IL_0c67: ldloc.s 27
-			IL_0c69: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c6e: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0c73: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c78: stloc.s 27
-			IL_0c7a: ldloc.s 27
-			IL_0c7c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0c81: stloc.s 17
-			IL_0c83: ldloc.0
-			IL_0c84: ldc.i4.m1
-			IL_0c85: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c8a: ldloc.0
-			IL_0c8b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c90: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0c95: ldarg.0
-			IL_0c96: ldc.i4.1
-			IL_0c97: newarr [System.Runtime]System.Object
-			IL_0c9c: dup
-			IL_0c9d: ldc.i4.0
-			IL_0c9e: ldloc.s 17
-			IL_0ca0: stelem.ref
-			IL_0ca1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0ca6: pop
-			IL_0ca7: ldloc.0
-			IL_0ca8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0cad: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0cb2: ret
+			IL_0c3d: stloc.s 21
+			IL_0c3f: ldloc.s 21
+			IL_0c41: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0c46: stloc.s 26
+			IL_0c48: ldstr "Could not infer an element id for section '"
+			IL_0c4d: ldloc.s 26
+			IL_0c4f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c54: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0c59: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c5e: stloc.s 26
+			IL_0c60: ldloc.s 26
+			IL_0c62: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0c67: stloc.s 17
+			IL_0c69: ldloc.0
+			IL_0c6a: ldc.i4.m1
+			IL_0c6b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c70: ldloc.0
+			IL_0c71: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c76: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0c7b: ldarg.0
+			IL_0c7c: ldc.i4.1
+			IL_0c7d: newarr [System.Runtime]System.Object
+			IL_0c82: dup
+			IL_0c83: ldc.i4.0
+			IL_0c84: ldloc.s 17
+			IL_0c86: stelem.ref
+			IL_0c87: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c8c: pop
+			IL_0c8d: ldloc.0
+			IL_0c8e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c93: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c98: ret
 
-			IL_0cb3: ldarg.0
-			IL_0cb4: ldc.i4.1
-			IL_0cb5: ldelem.ref
-			IL_0cb6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0cbb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0cc0: ldc.i4.1
-			IL_0cc1: newarr [System.Runtime]System.Object
-			IL_0cc6: dup
-			IL_0cc7: ldc.i4.0
-			IL_0cc8: ldarg.0
-			IL_0cc9: ldc.i4.1
-			IL_0cca: ldelem.ref
-			IL_0ccb: stelem.ref
-			IL_0ccc: stloc.s 21
-			IL_0cce: ldloc.s 21
-			IL_0cd0: ldloc.s 8
-			IL_0cd2: ldloc.s 9
-			IL_0cd4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0cd9: stloc.s 18
-			IL_0cdb: ldarg.0
-			IL_0cdc: ldc.i4.1
-			IL_0cdd: ldelem.ref
-			IL_0cde: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ce3: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0ce8: stloc.s 31
-			IL_0cea: ldstr "process"
-			IL_0cef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0cf4: stloc.s 26
-			IL_0cf6: ldloc.s 26
-			IL_0cf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0cfd: stloc.s 26
-			IL_0cff: volatile.
-			IL_0d01: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_0d06: brfalse IL_0d1c
+			IL_0c99: ldc.i4.1
+			IL_0c9a: newarr [System.Runtime]System.Object
+			IL_0c9f: dup
+			IL_0ca0: ldc.i4.0
+			IL_0ca1: ldarg.0
+			IL_0ca2: ldc.i4.1
+			IL_0ca3: ldelem.ref
+			IL_0ca4: stelem.ref
+			IL_0ca5: stloc.s 22
+			IL_0ca7: ldloc.s 22
+			IL_0ca9: ldc.i4.0
+			IL_0caa: ldelem.ref
+			IL_0cab: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0cb0: ldnull
+			IL_0cb1: ldloc.s 8
+			IL_0cb3: ldloc.s 9
+			IL_0cb5: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0cba: stloc.s 18
+			IL_0cbc: ldarg.0
+			IL_0cbd: ldc.i4.1
+			IL_0cbe: ldelem.ref
+			IL_0cbf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0cc4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0cc9: stloc.s 31
+			IL_0ccb: ldstr "process"
+			IL_0cd0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0cd5: stloc.s 21
+			IL_0cd7: ldloc.s 21
+			IL_0cd9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0cde: stloc.s 21
+			IL_0ce0: volatile.
+			IL_0ce2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0ce7: brfalse IL_0cfd
 
-			IL_0d0b: ldloc.s 26
-			IL_0d0d: ldstr "cwd"
-			IL_0d12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0d17: br IL_0d32
+			IL_0cec: ldloc.s 21
+			IL_0cee: ldstr "cwd"
+			IL_0cf3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0cf8: br IL_0d13
 
-			IL_0d1c: ldloc.s 26
-			IL_0d1e: ldstr "cwd"
-			IL_0d23: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:224"
-			IL_0d28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_0d2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0cfd: ldloc.s 21
+			IL_0cff: ldstr "cwd"
+			IL_0d04: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:218"
+			IL_0d09: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0d0e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0d32: stloc.s 26
-			IL_0d34: volatile.
-			IL_0d36: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_0d3b: brfalse IL_0d50
+			IL_0d13: stloc.s 21
+			IL_0d15: volatile.
+			IL_0d17: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0d1c: brfalse IL_0d31
 
-			IL_0d40: ldloc.1
-			IL_0d41: ldstr "outFile"
-			IL_0d46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d4b: br IL_0d65
+			IL_0d21: ldloc.1
+			IL_0d22: ldstr "outFile"
+			IL_0d27: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d2c: br IL_0d46
 
-			IL_0d50: ldloc.1
-			IL_0d51: ldstr "outFile"
-			IL_0d56: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:226"
-			IL_0d5b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_0d60: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0d31: ldloc.1
+			IL_0d32: ldstr "outFile"
+			IL_0d37: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:220"
+			IL_0d3c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0d41: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0d65: stloc.s 22
-			IL_0d67: ldloc.s 31
-			IL_0d69: ldc.i4.2
-			IL_0d6a: newarr [System.Runtime]System.Object
-			IL_0d6f: dup
-			IL_0d70: ldc.i4.0
-			IL_0d71: ldloc.s 26
-			IL_0d73: stelem.ref
-			IL_0d74: dup
-			IL_0d75: ldc.i4.1
-			IL_0d76: ldloc.s 22
-			IL_0d78: stelem.ref
-			IL_0d79: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0d7e: stloc.s 19
-			IL_0d80: ldarg.0
-			IL_0d81: ldc.i4.1
-			IL_0d82: ldelem.ref
-			IL_0d83: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0d88: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0d8d: ldc.i4.1
-			IL_0d8e: newarr [System.Runtime]System.Object
-			IL_0d93: dup
-			IL_0d94: ldc.i4.0
-			IL_0d95: ldarg.0
-			IL_0d96: ldc.i4.1
-			IL_0d97: ldelem.ref
-			IL_0d98: stelem.ref
-			IL_0d99: stloc.s 21
-			IL_0d9b: volatile.
-			IL_0d9d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-			IL_0da2: brfalse IL_0db8
+			IL_0d46: stloc.s 27
+			IL_0d48: ldloc.s 31
+			IL_0d4a: ldc.i4.2
+			IL_0d4b: newarr [System.Runtime]System.Object
+			IL_0d50: dup
+			IL_0d51: ldc.i4.0
+			IL_0d52: ldloc.s 21
+			IL_0d54: stelem.ref
+			IL_0d55: dup
+			IL_0d56: ldc.i4.1
+			IL_0d57: ldloc.s 27
+			IL_0d59: stelem.ref
+			IL_0d5a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0d5f: stloc.s 19
+			IL_0d61: volatile.
+			IL_0d63: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_0d68: brfalse IL_0d7e
 
-			IL_0da7: ldloc.s 18
-			IL_0da9: ldstr "html"
-			IL_0dae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0db3: br IL_0dce
+			IL_0d6d: ldloc.s 18
+			IL_0d6f: ldstr "html"
+			IL_0d74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d79: br IL_0d94
 
-			IL_0db8: ldloc.s 18
-			IL_0dba: ldstr "html"
-			IL_0dbf: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:233"
-			IL_0dc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-			IL_0dc9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0d7e: ldloc.s 18
+			IL_0d80: ldstr "html"
+			IL_0d85: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:225"
+			IL_0d8a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_0d8f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0dce: stloc.s 22
-			IL_0dd0: volatile.
-			IL_0dd2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
-			IL_0dd7: brfalse IL_0dec
+			IL_0d94: stloc.s 27
+			IL_0d96: volatile.
+			IL_0d98: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_0d9d: brfalse IL_0db2
 
-			IL_0ddc: ldloc.1
-			IL_0ddd: ldstr "section"
-			IL_0de2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0de7: br IL_0e01
+			IL_0da2: ldloc.1
+			IL_0da3: ldstr "section"
+			IL_0da8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dad: br IL_0dc7
 
-			IL_0dec: ldloc.1
-			IL_0ded: ldstr "section"
-			IL_0df2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:236"
-			IL_0df7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
-			IL_0dfc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0db2: ldloc.1
+			IL_0db3: ldstr "section"
+			IL_0db8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:228"
+			IL_0dbd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_0dc2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e01: stloc.s 26
-			IL_0e03: ldloc.s 26
-			IL_0e05: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0e0a: stloc.s 27
-			IL_0e0c: ldstr "ECMA-262 "
-			IL_0e11: ldloc.s 27
-			IL_0e13: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0e18: stloc.s 27
-			IL_0e1a: ldloc.s 21
-			IL_0e1c: ldloc.s 22
-			IL_0e1e: ldloc.s 27
-			IL_0e20: ldloc.s 10
-			IL_0e22: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0e27: stloc.s 20
-			IL_0e29: ldarg.0
-			IL_0e2a: ldc.i4.1
-			IL_0e2b: ldelem.ref
-			IL_0e2c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0e31: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0e36: stloc.s 32
-			IL_0e38: ldloc.s 32
-			IL_0e3a: ldloc.s 19
-			IL_0e3c: ldloc.s 20
-			IL_0e3e: ldstr "utf8"
-			IL_0e43: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0e48: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0e4d: stloc.s 33
-			IL_0e4f: ldarg.0
-			IL_0e50: ldc.i4.1
-			IL_0e51: ldelem.ref
-			IL_0e52: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0e57: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0e5c: ldc.i4.1
-			IL_0e5d: newarr [System.Runtime]System.Object
-			IL_0e62: dup
-			IL_0e63: ldc.i4.0
-			IL_0e64: ldarg.0
-			IL_0e65: ldc.i4.1
-			IL_0e66: ldelem.ref
-			IL_0e67: stelem.ref
-			IL_0e68: stloc.s 21
-			IL_0e6a: volatile.
-			IL_0e6c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
-			IL_0e71: brfalse IL_0e86
+			IL_0dc7: stloc.s 21
+			IL_0dc9: ldloc.s 21
+			IL_0dcb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0dd0: stloc.s 26
+			IL_0dd2: ldstr "ECMA-262 "
+			IL_0dd7: ldloc.s 26
+			IL_0dd9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0dde: stloc.s 26
+			IL_0de0: ldnull
+			IL_0de1: ldloc.s 27
+			IL_0de3: ldloc.s 26
+			IL_0de5: ldloc.s 10
+			IL_0de7: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+			IL_0dec: stloc.s 20
+			IL_0dee: ldarg.0
+			IL_0def: ldc.i4.1
+			IL_0df0: ldelem.ref
+			IL_0df1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0df6: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0dfb: stloc.s 32
+			IL_0dfd: ldloc.s 32
+			IL_0dff: ldloc.s 19
+			IL_0e01: ldloc.s 20
+			IL_0e03: ldstr "utf8"
+			IL_0e08: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0e0d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0e12: stloc.s 33
+			IL_0e14: volatile.
+			IL_0e16: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_0e1b: brfalse IL_0e30
 
-			IL_0e76: ldloc.1
-			IL_0e77: ldstr "section"
-			IL_0e7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e81: br IL_0e9b
+			IL_0e20: ldloc.1
+			IL_0e21: ldstr "section"
+			IL_0e26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e2b: br IL_0e45
 
-			IL_0e86: ldloc.1
-			IL_0e87: ldstr "section"
-			IL_0e8c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:251"
-			IL_0e91: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
-			IL_0e96: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0e30: ldloc.1
+			IL_0e31: ldstr "section"
+			IL_0e36: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:242"
+			IL_0e3b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_0e40: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e9b: stloc.s 22
-			IL_0e9d: ldloc.s 22
-			IL_0e9f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ea4: stloc.s 27
-			IL_0ea6: ldstr "Extracted section "
-			IL_0eab: ldloc.s 27
-			IL_0ead: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0eb2: ldstr " (id="
-			IL_0eb7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ebc: ldloc.s 9
-			IL_0ebe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ec3: stloc.s 27
-			IL_0ec5: ldloc.s 27
-			IL_0ec7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ecc: ldstr ", tag="
-			IL_0ed1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ed6: volatile.
-			IL_0ed8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0edd: brfalse IL_0ef3
+			IL_0e45: stloc.s 27
+			IL_0e47: ldloc.s 27
+			IL_0e49: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0e4e: stloc.s 26
+			IL_0e50: ldstr "Extracted section "
+			IL_0e55: ldloc.s 26
+			IL_0e57: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0e5c: ldstr " (id="
+			IL_0e61: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0e66: ldloc.s 9
+			IL_0e68: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0e6d: stloc.s 26
+			IL_0e6f: ldloc.s 26
+			IL_0e71: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0e76: ldstr ", tag="
+			IL_0e7b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0e80: volatile.
+			IL_0e82: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0e87: brfalse IL_0e9d
 
-			IL_0ee2: ldloc.s 18
-			IL_0ee4: ldstr "tagName"
-			IL_0ee9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0eee: br IL_0f09
+			IL_0e8c: ldloc.s 18
+			IL_0e8e: ldstr "tagName"
+			IL_0e93: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e98: br IL_0eb3
 
-			IL_0ef3: ldloc.s 18
-			IL_0ef5: ldstr "tagName"
-			IL_0efa: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:261"
-			IL_0eff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0f04: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0e9d: ldloc.s 18
+			IL_0e9f: ldstr "tagName"
+			IL_0ea4: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:252"
+			IL_0ea9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0eae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f09: stloc.s 22
-			IL_0f0b: ldloc.s 22
-			IL_0f0d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0f12: stloc.s 27
-			IL_0f14: ldloc.s 27
-			IL_0f16: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0f1b: ldstr ") -> "
-			IL_0f20: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0f25: ldloc.s 19
-			IL_0f27: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0f2c: stloc.s 27
-			IL_0f2e: ldloc.s 27
-			IL_0f30: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0f35: stloc.s 27
-			IL_0f37: ldloc.s 21
-			IL_0f39: ldloc.s 27
-			IL_0f3b: ldloc.s 19
-			IL_0f3d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0f42: stloc.s 22
-			IL_0f44: ldloc.s 33
-			IL_0f46: ldloc.s 22
-			IL_0f48: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0f4d: pop
-			IL_0f4e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0f53: stloc.s 33
-			IL_0f55: ldarg.0
-			IL_0f56: ldc.i4.1
-			IL_0f57: ldelem.ref
-			IL_0f58: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0f5d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0f62: stloc.s 22
-			IL_0f64: ldc.i4.1
-			IL_0f65: newarr [System.Runtime]System.Object
-			IL_0f6a: dup
-			IL_0f6b: ldc.i4.0
-			IL_0f6c: ldarg.0
-			IL_0f6d: ldc.i4.1
-			IL_0f6e: ldelem.ref
-			IL_0f6f: stelem.ref
-			IL_0f70: stloc.s 21
-			IL_0f72: ldarg.0
-			IL_0f73: ldc.i4.1
-			IL_0f74: ldelem.ref
-			IL_0f75: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0f7a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0f7f: stloc.s 32
-			IL_0f81: ldloc.s 32
-			IL_0f83: ldloc.s 19
-			IL_0f85: ldstr "utf8"
-			IL_0f8a: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0f8f: stloc.s 26
-			IL_0f91: ldloc.s 22
-			IL_0f93: ldloc.s 21
-			IL_0f95: ldloc.s 26
-			IL_0f97: ldloc.s 19
-			IL_0f99: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0f9e: stloc.s 26
-			IL_0fa0: ldloc.s 33
-			IL_0fa2: ldloc.s 26
-			IL_0fa4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0fa9: pop
-			IL_0faa: ldloc.0
-			IL_0fab: ldc.i4.m1
-			IL_0fac: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0fb1: ldloc.0
-			IL_0fb2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0fb7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0fbc: ldarg.0
-			IL_0fbd: ldc.i4.1
-			IL_0fbe: newarr [System.Runtime]System.Object
-			IL_0fc3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0fc8: pop
-			IL_0fc9: ldloc.0
-			IL_0fca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0fcf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0fd4: ret
+			IL_0eb3: stloc.s 27
+			IL_0eb5: ldloc.s 27
+			IL_0eb7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ebc: stloc.s 26
+			IL_0ebe: ldloc.s 26
+			IL_0ec0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ec5: ldstr ") -> "
+			IL_0eca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ecf: ldloc.s 19
+			IL_0ed1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ed6: stloc.s 26
+			IL_0ed8: ldloc.s 26
+			IL_0eda: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0edf: stloc.s 26
+			IL_0ee1: ldnull
+			IL_0ee2: ldloc.s 26
+			IL_0ee4: ldloc.s 19
+			IL_0ee6: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0eeb: stloc.s 27
+			IL_0eed: ldloc.s 33
+			IL_0eef: ldloc.s 27
+			IL_0ef1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ef6: pop
+			IL_0ef7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0efc: stloc.s 33
+			IL_0efe: ldarg.0
+			IL_0eff: ldc.i4.1
+			IL_0f00: ldelem.ref
+			IL_0f01: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0f06: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0f0b: stloc.s 32
+			IL_0f0d: ldloc.s 32
+			IL_0f0f: ldloc.s 19
+			IL_0f11: ldstr "utf8"
+			IL_0f16: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0f1b: stloc.s 27
+			IL_0f1d: ldnull
+			IL_0f1e: ldloc.s 27
+			IL_0f20: ldloc.s 19
+			IL_0f22: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0f27: stloc.s 27
+			IL_0f29: ldloc.s 33
+			IL_0f2b: ldloc.s 27
+			IL_0f2d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0f32: pop
+			IL_0f33: ldloc.0
+			IL_0f34: ldc.i4.m1
+			IL_0f35: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0f3a: ldloc.0
+			IL_0f3b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0f40: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0f45: ldarg.0
+			IL_0f46: ldc.i4.1
+			IL_0f47: newarr [System.Runtime]System.Object
+			IL_0f4c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0f51: pop
+			IL_0f52: ldloc.0
+			IL_0f53: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0f58: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0f5d: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -2451,7 +2451,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 1445 (0x5a5)
+					// Code size: 1413 (0x585)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -2587,7 +2587,7 @@
 					IL_0141: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_0146: stloc.s 5
 					IL_0148: ldloc.s 5
-					IL_014a: brfalse IL_0344
+					IL_014a: brfalse IL_0324
 
 					IL_014f: ldarg.0
 					IL_0150: ldc.i4.1
@@ -2721,324 +2721,302 @@
 
 					IL_02af: pop
 					IL_02b0: ldarg.0
-					IL_02b1: ldc.i4.0
+					IL_02b1: ldc.i4.1
 					IL_02b2: ldelem.ref
-					IL_02b3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_02b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-					IL_02bd: ldc.i4.3
-					IL_02be: newarr [System.Runtime]System.Object
-					IL_02c3: dup
-					IL_02c4: ldc.i4.0
-					IL_02c5: ldarg.0
-					IL_02c6: ldc.i4.0
-					IL_02c7: ldelem.ref
-					IL_02c8: stelem.ref
-					IL_02c9: dup
-					IL_02ca: ldc.i4.1
-					IL_02cb: ldarg.0
-					IL_02cc: ldc.i4.1
-					IL_02cd: ldelem.ref
-					IL_02ce: stelem.ref
-					IL_02cf: dup
-					IL_02d0: ldc.i4.2
-					IL_02d1: ldarg.0
-					IL_02d2: ldc.i4.2
-					IL_02d3: ldelem.ref
-					IL_02d4: stelem.ref
-					IL_02d5: stloc.s 12
+					IL_02b3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_02b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_02bd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_02c2: ldc.r8 1
+					IL_02cb: sub
+					IL_02cc: stloc.s 16
+					IL_02ce: ldloc.s 16
+					IL_02d0: box [System.Runtime]System.Double
+					IL_02d5: stloc.s 17
 					IL_02d7: ldarg.0
-					IL_02d8: ldc.i4.1
+					IL_02d8: ldc.i4.0
 					IL_02d9: ldelem.ref
-					IL_02da: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_02df: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_02e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_02e9: ldc.r8 1
-					IL_02f2: sub
-					IL_02f3: stloc.s 16
-					IL_02f5: ldloc.s 16
-					IL_02f7: box [System.Runtime]System.Double
-					IL_02fc: stloc.s 17
-					IL_02fe: ldloc.s 12
-					IL_0300: ldloc.3
-					IL_0301: ldloc.s 17
-					IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_0308: stloc.s 13
-					IL_030a: ldloc.s 13
-					IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0311: stloc.s 13
-					IL_0313: ldarg.0
-					IL_0314: ldc.i4.2
-					IL_0315: ldelem.ref
-					IL_0316: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_031b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_0320: stloc.s 4
-					IL_0322: ldarg.0
-					IL_0323: ldc.i4.2
-					IL_0324: ldelem.ref
-					IL_0325: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_032a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_032f: stloc.s 18
-					IL_0331: ldloc.s 13
-					IL_0333: ldstr "then"
-					IL_0338: ldloc.s 4
-					IL_033a: ldloc.s 18
-					IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_0341: pop
-					IL_0342: ldnull
-					IL_0343: ret
+					IL_02da: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_02df: ldnull
+					IL_02e0: ldloc.3
+					IL_02e1: ldloc.s 17
+					IL_02e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+					IL_02e8: stloc.s 13
+					IL_02ea: ldloc.s 13
+					IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02f1: stloc.s 13
+					IL_02f3: ldarg.0
+					IL_02f4: ldc.i4.2
+					IL_02f5: ldelem.ref
+					IL_02f6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02fb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_0300: stloc.s 4
+					IL_0302: ldarg.0
+					IL_0303: ldc.i4.2
+					IL_0304: ldelem.ref
+					IL_0305: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_030a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_030f: stloc.s 18
+					IL_0311: ldloc.s 13
+					IL_0313: ldstr "then"
+					IL_0318: ldloc.s 4
+					IL_031a: ldloc.s 18
+					IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0321: pop
+					IL_0322: ldnull
+					IL_0323: ret
 
-					IL_0344: ldloc.1
-					IL_0345: ldc.r8 200
-					IL_034e: box [System.Runtime]System.Double
-					IL_0353: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-					IL_0358: stloc.s 5
-					IL_035a: ldloc.s 5
-					IL_035c: box [System.Runtime]System.Boolean
-					IL_0361: stloc.s 8
-					IL_0363: ldloc.s 8
-					IL_0365: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_036a: stloc.s 5
-					IL_036c: ldloc.s 5
-					IL_036e: brtrue IL_039b
+					IL_0324: ldloc.1
+					IL_0325: ldc.r8 200
+					IL_032e: box [System.Runtime]System.Double
+					IL_0333: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+					IL_0338: stloc.s 5
+					IL_033a: ldloc.s 5
+					IL_033c: box [System.Runtime]System.Boolean
+					IL_0341: stloc.s 8
+					IL_0343: ldloc.s 8
+					IL_0345: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_034a: stloc.s 5
+					IL_034c: ldloc.s 5
+					IL_034e: brtrue IL_037b
 
-					IL_0373: ldloc.1
-					IL_0374: ldc.r8 300
-					IL_037d: box [System.Runtime]System.Double
-					IL_0382: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
-					IL_0387: stloc.s 5
-					IL_0389: ldloc.s 5
-					IL_038b: box [System.Runtime]System.Boolean
-					IL_0390: stloc.s 9
-					IL_0392: ldloc.s 9
-					IL_0394: stloc.s 19
-					IL_0396: br IL_039f
+					IL_0353: ldloc.1
+					IL_0354: ldc.r8 300
+					IL_035d: box [System.Runtime]System.Double
+					IL_0362: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
+					IL_0367: stloc.s 5
+					IL_0369: ldloc.s 5
+					IL_036b: box [System.Runtime]System.Boolean
+					IL_0370: stloc.s 9
+					IL_0372: ldloc.s 9
+					IL_0374: stloc.s 19
+					IL_0376: br IL_037f
 
-					IL_039b: ldloc.s 8
-					IL_039d: stloc.s 19
+					IL_037b: ldloc.s 8
+					IL_037d: stloc.s 19
 
-					IL_039f: ldloc.s 19
-					IL_03a1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_03a6: stloc.s 5
-					IL_03a8: ldloc.s 5
-					IL_03aa: brfalse IL_0464
+					IL_037f: ldloc.s 19
+					IL_0381: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0386: stloc.s 5
+					IL_0388: ldloc.s 5
+					IL_038a: brfalse IL_0444
 
-					IL_03af: ldarg.2
-					IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03b5: volatile.
-					IL_03b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
-					IL_03bc: brfalse IL_03d0
+					IL_038f: ldarg.2
+					IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0395: volatile.
+					IL_0397: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+					IL_039c: brfalse IL_03b0
 
-					IL_03c1: ldstr "resume"
-					IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_03cb: br IL_03e4
+					IL_03a1: ldstr "resume"
+					IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_03ab: br IL_03c4
 
-					IL_03d0: ldstr "resume"
-					IL_03d5: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:119"
-					IL_03da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
-					IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+					IL_03b0: ldstr "resume"
+					IL_03b5: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:118"
+					IL_03ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_100
+					IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-					IL_03e4: pop
-					IL_03e5: ldarg.0
-					IL_03e6: ldc.i4.2
-					IL_03e7: ldelem.ref
-					IL_03e8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_03ed: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_03f2: stloc.s 18
-					IL_03f4: ldc.i4.3
-					IL_03f5: newarr [System.Runtime]System.Object
-					IL_03fa: dup
-					IL_03fb: ldc.i4.0
-					IL_03fc: ldarg.0
-					IL_03fd: ldc.i4.0
-					IL_03fe: ldelem.ref
-					IL_03ff: stelem.ref
-					IL_0400: dup
-					IL_0401: ldc.i4.1
-					IL_0402: ldarg.0
-					IL_0403: ldc.i4.1
-					IL_0404: ldelem.ref
-					IL_0405: stelem.ref
-					IL_0406: dup
-					IL_0407: ldc.i4.2
-					IL_0408: ldarg.0
-					IL_0409: ldc.i4.2
-					IL_040a: ldelem.ref
-					IL_040b: stelem.ref
-					IL_040c: stloc.s 12
-					IL_040e: ldloc.1
-					IL_040f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0414: stloc.s 14
-					IL_0416: ldstr "HTTP "
-					IL_041b: ldloc.s 14
-					IL_041d: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0422: ldstr " fetching "
-					IL_0427: call string [System.Runtime]System.String::Concat(string, string)
-					IL_042c: ldarg.0
-					IL_042d: ldc.i4.1
-					IL_042e: ldelem.ref
-					IL_042f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0434: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0439: stloc.s 4
-					IL_043b: ldloc.s 4
-					IL_043d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0442: stloc.s 14
-					IL_0444: ldloc.s 14
-					IL_0446: call string [System.Runtime]System.String::Concat(string, string)
-					IL_044b: stloc.s 14
-					IL_044d: ldloc.s 14
-					IL_044f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0454: stloc.s 15
-					IL_0456: ldloc.s 18
-					IL_0458: ldloc.s 12
-					IL_045a: ldloc.s 15
-					IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0461: pop
-					IL_0462: ldnull
-					IL_0463: ret
+					IL_03c4: pop
+					IL_03c5: ldarg.0
+					IL_03c6: ldc.i4.2
+					IL_03c7: ldelem.ref
+					IL_03c8: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_03cd: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_03d2: stloc.s 18
+					IL_03d4: ldc.i4.3
+					IL_03d5: newarr [System.Runtime]System.Object
+					IL_03da: dup
+					IL_03db: ldc.i4.0
+					IL_03dc: ldarg.0
+					IL_03dd: ldc.i4.0
+					IL_03de: ldelem.ref
+					IL_03df: stelem.ref
+					IL_03e0: dup
+					IL_03e1: ldc.i4.1
+					IL_03e2: ldarg.0
+					IL_03e3: ldc.i4.1
+					IL_03e4: ldelem.ref
+					IL_03e5: stelem.ref
+					IL_03e6: dup
+					IL_03e7: ldc.i4.2
+					IL_03e8: ldarg.0
+					IL_03e9: ldc.i4.2
+					IL_03ea: ldelem.ref
+					IL_03eb: stelem.ref
+					IL_03ec: stloc.s 12
+					IL_03ee: ldloc.1
+					IL_03ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_03f4: stloc.s 14
+					IL_03f6: ldstr "HTTP "
+					IL_03fb: ldloc.s 14
+					IL_03fd: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0402: ldstr " fetching "
+					IL_0407: call string [System.Runtime]System.String::Concat(string, string)
+					IL_040c: ldarg.0
+					IL_040d: ldc.i4.1
+					IL_040e: ldelem.ref
+					IL_040f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0414: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0419: stloc.s 4
+					IL_041b: ldloc.s 4
+					IL_041d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0422: stloc.s 14
+					IL_0424: ldloc.s 14
+					IL_0426: call string [System.Runtime]System.String::Concat(string, string)
+					IL_042b: stloc.s 14
+					IL_042d: ldloc.s 14
+					IL_042f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0434: stloc.s 15
+					IL_0436: ldloc.s 18
+					IL_0438: ldloc.s 12
+					IL_043a: ldloc.s 15
+					IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0441: pop
+					IL_0442: ldnull
+					IL_0443: ret
 
-					IL_0464: ldarg.2
-					IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_046a: volatile.
-					IL_046c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-					IL_0471: brfalse IL_048a
+					IL_0444: ldarg.2
+					IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_044a: volatile.
+					IL_044c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+					IL_0451: brfalse IL_046a
 
-					IL_0476: ldstr "setEncoding"
-					IL_047b: ldstr "utf8"
-					IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_0485: br IL_04a3
+					IL_0456: ldstr "setEncoding"
+					IL_045b: ldstr "utf8"
+					IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0465: br IL_0483
 
-					IL_048a: ldstr "setEncoding"
-					IL_048f: ldstr "utf8"
-					IL_0494: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:141"
-					IL_0499: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
-					IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+					IL_046a: ldstr "setEncoding"
+					IL_046f: ldstr "utf8"
+					IL_0474: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M28>:__js_call__:140"
+					IL_0479: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_101
+					IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-					IL_04a3: pop
-					IL_04a4: ldloc.0
-					IL_04a5: ldstr ""
-					IL_04aa: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_04af: ldarg.2
-					IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_04b5: stloc.s 18
-					IL_04b7: ldc.i4.4
-					IL_04b8: newarr [System.Runtime]System.Object
-					IL_04bd: dup
-					IL_04be: ldc.i4.0
-					IL_04bf: ldarg.0
-					IL_04c0: ldc.i4.0
+					IL_0483: pop
+					IL_0484: ldloc.0
+					IL_0485: ldstr ""
+					IL_048a: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_048f: ldarg.2
+					IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0495: stloc.s 18
+					IL_0497: ldc.i4.4
+					IL_0498: newarr [System.Runtime]System.Object
+					IL_049d: dup
+					IL_049e: ldc.i4.0
+					IL_049f: ldarg.0
+					IL_04a0: ldc.i4.0
+					IL_04a1: ldelem.ref
+					IL_04a2: stelem.ref
+					IL_04a3: dup
+					IL_04a4: ldc.i4.1
+					IL_04a5: ldarg.0
+					IL_04a6: ldc.i4.1
+					IL_04a7: ldelem.ref
+					IL_04a8: stelem.ref
+					IL_04a9: dup
+					IL_04aa: ldc.i4.2
+					IL_04ab: ldarg.0
+					IL_04ac: ldc.i4.2
+					IL_04ad: ldelem.ref
+					IL_04ae: stelem.ref
+					IL_04af: dup
+					IL_04b0: ldc.i4.3
+					IL_04b1: ldloc.0
+					IL_04b2: stelem.ref
+					IL_04b3: stloc.s 12
+					IL_04b5: ldloc.s 12
+					IL_04b7: ldc.i4.0
+					IL_04b8: ldelem.ref
+					IL_04b9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_04be: ldloc.s 12
+					IL_04c0: ldc.i4.1
 					IL_04c1: ldelem.ref
-					IL_04c2: stelem.ref
-					IL_04c3: dup
-					IL_04c4: ldc.i4.1
-					IL_04c5: ldarg.0
-					IL_04c6: ldc.i4.1
-					IL_04c7: ldelem.ref
-					IL_04c8: stelem.ref
-					IL_04c9: dup
-					IL_04ca: ldc.i4.2
-					IL_04cb: ldarg.0
-					IL_04cc: ldc.i4.2
-					IL_04cd: ldelem.ref
-					IL_04ce: stelem.ref
-					IL_04cf: dup
-					IL_04d0: ldc.i4.3
-					IL_04d1: ldloc.0
-					IL_04d2: stelem.ref
-					IL_04d3: stloc.s 12
-					IL_04d5: ldloc.s 12
-					IL_04d7: ldc.i4.0
-					IL_04d8: ldelem.ref
-					IL_04d9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_04de: ldloc.s 12
+					IL_04c2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_04c7: ldloc.s 12
+					IL_04c9: ldc.i4.2
+					IL_04ca: ldelem.ref
+					IL_04cb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_04d0: ldloc.s 12
+					IL_04d2: ldc.i4.3
+					IL_04d3: ldelem.ref
+					IL_04d4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+					IL_04d9: ldloc.s 12
+					IL_04db: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
 					IL_04e0: ldc.i4.1
-					IL_04e1: ldelem.ref
-					IL_04e2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_04e7: ldloc.s 12
-					IL_04e9: ldc.i4.2
-					IL_04ea: ldelem.ref
-					IL_04eb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_04f0: ldloc.s 12
-					IL_04f2: ldc.i4.3
-					IL_04f3: ldelem.ref
-					IL_04f4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-					IL_04f9: ldloc.s 12
-					IL_04fb: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
-					IL_0500: ldc.i4.1
-					IL_0501: conv.r8
-					IL_0502: ldstr ""
-					IL_0507: ldc.i4.0
-					IL_0508: ldc.i4.0
-					IL_0509: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0, float64, string, bool, bool)
-					IL_050e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0)
-					IL_0513: stloc.s 20
-					IL_0515: ldloc.s 18
-					IL_0517: ldstr "on"
-					IL_051c: ldstr "data"
-					IL_0521: ldloc.s 20
-					IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_0528: pop
-					IL_0529: ldarg.2
-					IL_052a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_052f: stloc.s 18
-					IL_0531: ldc.i4.4
-					IL_0532: newarr [System.Runtime]System.Object
-					IL_0537: dup
-					IL_0538: ldc.i4.0
-					IL_0539: ldarg.0
-					IL_053a: ldc.i4.0
+					IL_04e1: conv.r8
+					IL_04e2: ldstr ""
+					IL_04e7: ldc.i4.0
+					IL_04e8: ldc.i4.0
+					IL_04e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0, float64, string, bool, bool)
+					IL_04ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24/FunctionObject>(!!0)
+					IL_04f3: stloc.s 20
+					IL_04f5: ldloc.s 18
+					IL_04f7: ldstr "on"
+					IL_04fc: ldstr "data"
+					IL_0501: ldloc.s 20
+					IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0508: pop
+					IL_0509: ldarg.2
+					IL_050a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_050f: stloc.s 18
+					IL_0511: ldc.i4.4
+					IL_0512: newarr [System.Runtime]System.Object
+					IL_0517: dup
+					IL_0518: ldc.i4.0
+					IL_0519: ldarg.0
+					IL_051a: ldc.i4.0
+					IL_051b: ldelem.ref
+					IL_051c: stelem.ref
+					IL_051d: dup
+					IL_051e: ldc.i4.1
+					IL_051f: ldarg.0
+					IL_0520: ldc.i4.1
+					IL_0521: ldelem.ref
+					IL_0522: stelem.ref
+					IL_0523: dup
+					IL_0524: ldc.i4.2
+					IL_0525: ldarg.0
+					IL_0526: ldc.i4.2
+					IL_0527: ldelem.ref
+					IL_0528: stelem.ref
+					IL_0529: dup
+					IL_052a: ldc.i4.3
+					IL_052b: ldloc.0
+					IL_052c: stelem.ref
+					IL_052d: stloc.s 12
+					IL_052f: ldloc.s 12
+					IL_0531: ldc.i4.0
+					IL_0532: ldelem.ref
+					IL_0533: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_0538: ldloc.s 12
+					IL_053a: ldc.i4.1
 					IL_053b: ldelem.ref
-					IL_053c: stelem.ref
-					IL_053d: dup
-					IL_053e: ldc.i4.1
-					IL_053f: ldarg.0
-					IL_0540: ldc.i4.1
-					IL_0541: ldelem.ref
-					IL_0542: stelem.ref
-					IL_0543: dup
-					IL_0544: ldc.i4.2
-					IL_0545: ldarg.0
-					IL_0546: ldc.i4.2
-					IL_0547: ldelem.ref
-					IL_0548: stelem.ref
-					IL_0549: dup
-					IL_054a: ldc.i4.3
-					IL_054b: ldloc.0
-					IL_054c: stelem.ref
-					IL_054d: stloc.s 12
-					IL_054f: ldloc.s 12
-					IL_0551: ldc.i4.0
-					IL_0552: ldelem.ref
-					IL_0553: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0558: ldloc.s 12
-					IL_055a: ldc.i4.1
-					IL_055b: ldelem.ref
-					IL_055c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0561: ldloc.s 12
-					IL_0563: ldc.i4.2
-					IL_0564: ldelem.ref
-					IL_0565: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_056a: ldloc.s 12
-					IL_056c: ldc.i4.3
-					IL_056d: ldelem.ref
-					IL_056e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
-					IL_0573: ldloc.s 12
-					IL_0575: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
-					IL_057a: ldc.i4.0
-					IL_057b: conv.r8
-					IL_057c: ldstr ""
-					IL_0581: ldc.i4.0
-					IL_0582: ldc.i4.0
-					IL_0583: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0, float64, string, bool, bool)
-					IL_0588: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0)
-					IL_058d: stloc.s 21
-					IL_058f: ldloc.s 18
-					IL_0591: ldstr "on"
-					IL_0596: ldstr "end"
-					IL_059b: ldloc.s 21
-					IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_05a2: pop
-					IL_05a3: ldnull
-					IL_05a4: ret
+					IL_053c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0541: ldloc.s 12
+					IL_0543: ldc.i4.2
+					IL_0544: ldelem.ref
+					IL_0545: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_054a: ldloc.s 12
+					IL_054c: ldc.i4.3
+					IL_054d: ldelem.ref
+					IL_054e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope
+					IL_0553: ldloc.s 12
+					IL_0555: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope, class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope, object[])
+					IL_055a: ldc.i4.0
+					IL_055b: conv.r8
+					IL_055c: ldstr ""
+					IL_0561: ldc.i4.0
+					IL_0562: ldc.i4.0
+					IL_0563: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0, float64, string, bool, bool)
+					IL_0568: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23/FunctionObject>(!!0)
+					IL_056d: stloc.s 21
+					IL_056f: ldloc.s 18
+					IL_0571: ldstr "on"
+					IL_0576: ldstr "end"
+					IL_057b: ldloc.s 21
+					IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_0582: pop
+					IL_0583: ldnull
+					IL_0584: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -4699,7 +4677,7 @@
 				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1413 (0x585)
+			// Code size: 1385 (0x569)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4719,11 +4697,10 @@
 				[14] string,
 				[15] object,
 				[16] bool,
-				[17] object[],
-				[18] float64,
+				[17] float64,
+				[18] object,
 				[19] object,
-				[20] object,
-				[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[20] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
@@ -4925,310 +4902,296 @@
 			IL_0224: throw
 
 			IL_0225: ldarg.0
-			IL_0226: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_022b: ldc.i4.1
-			IL_022c: newarr [System.Runtime]System.Object
-			IL_0231: dup
-			IL_0232: ldc.i4.0
-			IL_0233: ldarg.0
-			IL_0234: stelem.ref
-			IL_0235: stloc.s 17
-			IL_0237: ldloc.s 17
-			IL_0239: ldarg.2
-			IL_023a: ldloc.s 4
-			IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0241: stloc.s 6
-			IL_0243: ldloc.s 6
-			IL_0245: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_024a: ldc.i4.0
-			IL_024b: ceq
-			IL_024d: stloc.s 16
-			IL_024f: ldloc.s 16
-			IL_0251: brfalse IL_0296
+			IL_0226: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_022b: ldnull
+			IL_022c: ldarg.2
+			IL_022d: ldloc.s 4
+			IL_022f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0234: stloc.s 6
+			IL_0236: ldloc.s 6
+			IL_0238: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_023d: ldc.i4.0
+			IL_023e: ceq
+			IL_0240: stloc.s 16
+			IL_0242: ldloc.s 16
+			IL_0244: brfalse IL_0289
 
-			IL_0256: ldarg.3
-			IL_0257: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_025c: stloc.s 14
-			IL_025e: ldstr "Could not determine tag name for id '"
-			IL_0263: ldloc.s 14
-			IL_0265: call string [System.Runtime]System.String::Concat(string, string)
-			IL_026a: ldstr "'."
-			IL_026f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0274: stloc.s 14
-			IL_0276: ldloc.s 14
-			IL_0278: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_027d: stloc.s 7
-			IL_027f: ldloc.s 7
-			IL_0281: isinst [System.Runtime]System.Exception
-			IL_0286: dup
-			IL_0287: brtrue IL_0295
+			IL_0249: ldarg.3
+			IL_024a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_024f: stloc.s 14
+			IL_0251: ldstr "Could not determine tag name for id '"
+			IL_0256: ldloc.s 14
+			IL_0258: call string [System.Runtime]System.String::Concat(string, string)
+			IL_025d: ldstr "'."
+			IL_0262: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0267: stloc.s 14
+			IL_0269: ldloc.s 14
+			IL_026b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0270: stloc.s 7
+			IL_0272: ldloc.s 7
+			IL_0274: isinst [System.Runtime]System.Exception
+			IL_0279: dup
+			IL_027a: brtrue IL_0288
 
-			IL_028c: pop
-			IL_028d: ldloc.s 7
-			IL_028f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0294: throw
+			IL_027f: pop
+			IL_0280: ldloc.s 7
+			IL_0282: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0287: throw
 
-			IL_0295: throw
+			IL_0288: throw
 
-			IL_0296: ldarg.0
-			IL_0297: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_029c: ldc.i4.1
-			IL_029d: newarr [System.Runtime]System.Object
-			IL_02a2: dup
-			IL_02a3: ldc.i4.0
-			IL_02a4: ldarg.0
-			IL_02a5: stelem.ref
-			IL_02a6: ldloc.s 6
-			IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_02ad: stloc.s 15
-			IL_02af: ldloc.s 15
-			IL_02b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02b6: stloc.s 14
-			IL_02b8: ldstr "<\\/?"
-			IL_02bd: ldloc.s 14
-			IL_02bf: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02c4: ldstr "\\b[^>]*>"
-			IL_02c9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02ce: stloc.s 14
-			IL_02d0: ldloc.s 14
-			IL_02d2: ldstr "gi"
-			IL_02d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02dc: stloc.s 8
-			IL_02de: ldloc.s 8
-			IL_02e0: ldstr "lastIndex"
-			IL_02e5: ldloc.s 4
-			IL_02e7: ldc.i4.1
-			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_02ed: pop
-			IL_02ee: ldc.r8 0.0
-			IL_02f7: stloc.s 9
-			IL_02f9: ldc.r8 1
-			IL_0302: neg
-			IL_0303: stloc.s 18
-			IL_0305: ldloc.s 18
-			IL_0307: box [System.Runtime]System.Double
-			IL_030c: stloc.s 10
-			// loop start (head: IL_030e)
-				IL_030e: ldc.i4.1
-				IL_030f: brfalse IL_0529
+			IL_0289: ldnull
+			IL_028a: ldloc.s 6
+			IL_028c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+			IL_0291: stloc.s 15
+			IL_0293: ldloc.s 15
+			IL_0295: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_029a: stloc.s 14
+			IL_029c: ldstr "<\\/?"
+			IL_02a1: ldloc.s 14
+			IL_02a3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02a8: ldstr "\\b[^>]*>"
+			IL_02ad: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02b2: stloc.s 14
+			IL_02b4: ldloc.s 14
+			IL_02b6: ldstr "gi"
+			IL_02bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_02c0: stloc.s 8
+			IL_02c2: ldloc.s 8
+			IL_02c4: ldstr "lastIndex"
+			IL_02c9: ldloc.s 4
+			IL_02cb: ldc.i4.1
+			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_02d1: pop
+			IL_02d2: ldc.r8 0.0
+			IL_02db: stloc.s 9
+			IL_02dd: ldc.r8 1
+			IL_02e6: neg
+			IL_02e7: stloc.s 17
+			IL_02e9: ldloc.s 17
+			IL_02eb: box [System.Runtime]System.Double
+			IL_02f0: stloc.s 10
+			// loop start (head: IL_02f2)
+				IL_02f2: ldc.i4.1
+				IL_02f3: brfalse IL_050d
 
-				IL_0314: volatile.
-				IL_0316: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-				IL_031b: brfalse IL_0332
+				IL_02f8: volatile.
+				IL_02fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+				IL_02ff: brfalse IL_0316
 
-				IL_0320: ldloc.s 8
-				IL_0322: ldstr "exec"
-				IL_0327: ldarg.2
-				IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_032d: br IL_0349
+				IL_0304: ldloc.s 8
+				IL_0306: ldstr "exec"
+				IL_030b: ldarg.2
+				IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0311: br IL_032d
 
-				IL_0332: ldloc.s 8
-				IL_0334: ldstr "exec"
-				IL_0339: ldarg.2
-				IL_033a: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:122"
-				IL_033f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-				IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+				IL_0316: ldloc.s 8
+				IL_0318: ldstr "exec"
+				IL_031d: ldarg.2
+				IL_031e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:120"
+				IL_0323: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+				IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-				IL_0349: stloc.s 11
-				IL_034b: ldloc.s 11
-				IL_034d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0352: ldc.i4.0
-				IL_0353: ceq
-				IL_0355: stloc.s 16
-				IL_0357: ldloc.s 16
-				IL_0359: brfalse IL_0363
+				IL_032d: stloc.s 11
+				IL_032f: ldloc.s 11
+				IL_0331: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0336: ldc.i4.0
+				IL_0337: ceq
+				IL_0339: stloc.s 16
+				IL_033b: ldloc.s 16
+				IL_033d: brfalse IL_0347
 
-				IL_035e: br IL_0529
+				IL_0342: br IL_050d
 
-				IL_0363: ldloc.s 11
-				IL_0365: ldc.r8 0.0
-				IL_036e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0373: stloc.s 12
-				IL_0375: ldloc.s 10
-				IL_0377: stloc.s 19
-				IL_0379: ldloc.s 19
-				IL_037b: ldc.r8 0.0
-				IL_0384: box [System.Runtime]System.Double
-				IL_0389: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-				IL_038e: stloc.s 16
-				IL_0390: ldloc.s 16
-				IL_0392: brfalse IL_03d0
+				IL_0347: ldloc.s 11
+				IL_0349: ldc.r8 0.0
+				IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0357: stloc.s 12
+				IL_0359: ldloc.s 10
+				IL_035b: stloc.s 18
+				IL_035d: ldloc.s 18
+				IL_035f: ldc.r8 0.0
+				IL_0368: box [System.Runtime]System.Double
+				IL_036d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+				IL_0372: stloc.s 16
+				IL_0374: ldloc.s 16
+				IL_0376: brfalse IL_03b4
 
-				IL_0397: volatile.
-				IL_0399: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-				IL_039e: brfalse IL_03b4
+				IL_037b: volatile.
+				IL_037d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+				IL_0382: brfalse IL_0398
 
-				IL_03a3: ldloc.s 11
-				IL_03a5: ldstr "index"
-				IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03af: br IL_03ca
+				IL_0387: ldloc.s 11
+				IL_0389: ldstr "index"
+				IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0393: br IL_03ae
 
-				IL_03b4: ldloc.s 11
-				IL_03b6: ldstr "index"
-				IL_03bb: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:142"
-				IL_03c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-				IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0398: ldloc.s 11
+				IL_039a: ldstr "index"
+				IL_039f: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:140"
+				IL_03a4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_03ca: stloc.s 15
-				IL_03cc: ldloc.s 15
-				IL_03ce: stloc.s 10
+				IL_03ae: stloc.s 15
+				IL_03b0: ldloc.s 15
+				IL_03b2: stloc.s 10
 
-				IL_03d0: ldloc.s 12
-				IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03d7: stloc.s 15
-				IL_03d9: ldc.i4.0
-				IL_03da: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_03df: brfalse IL_041b
+				IL_03b4: ldloc.s 12
+				IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03bb: stloc.s 15
+				IL_03bd: ldc.i4.0
+				IL_03be: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_03c3: brfalse IL_03ff
 
-				IL_03e4: ldloc.s 15
-				IL_03e6: isinst [System.Runtime]System.String
-				IL_03eb: dup
-				IL_03ec: brtrue IL_0404
+				IL_03c8: ldloc.s 15
+				IL_03ca: isinst [System.Runtime]System.String
+				IL_03cf: dup
+				IL_03d0: brtrue IL_03e8
 
-				IL_03f1: pop
-				IL_03f2: ldloc.s 15
-				IL_03f4: ldstr "startsWith"
-				IL_03f9: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_03fe: dup
-				IL_03ff: brfalse IL_041a
+				IL_03d5: pop
+				IL_03d6: ldloc.s 15
+				IL_03d8: ldstr "startsWith"
+				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_03e2: dup
+				IL_03e3: brfalse IL_03fe
 
-				IL_0404: ldstr "</"
-				IL_0409: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-				IL_040e: box [System.Runtime]System.Boolean
-				IL_0413: stloc.s 15
-				IL_0415: br IL_042e
+				IL_03e8: ldstr "</"
+				IL_03ed: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_03f2: box [System.Runtime]System.Boolean
+				IL_03f7: stloc.s 15
+				IL_03f9: br IL_0412
 
-				IL_041a: pop
+				IL_03fe: pop
 
-				IL_041b: ldloc.s 15
-				IL_041d: ldstr "startsWith"
-				IL_0422: ldstr "</"
-				IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_042c: stloc.s 15
+				IL_03ff: ldloc.s 15
+				IL_0401: ldstr "startsWith"
+				IL_0406: ldstr "</"
+				IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0410: stloc.s 15
 
-				IL_042e: ldloc.s 15
-				IL_0430: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0435: stloc.s 16
-				IL_0437: ldloc.s 16
-				IL_0439: brfalse IL_0516
+				IL_0412: ldloc.s 15
+				IL_0414: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0419: stloc.s 16
+				IL_041b: ldloc.s 16
+				IL_041d: brfalse IL_04fa
 
-				IL_043e: ldloc.s 9
-				IL_0440: ldc.r8 1
-				IL_0449: sub
-				IL_044a: stloc.s 9
-				IL_044c: ldloc.s 9
-				IL_044e: stloc.s 18
-				IL_0450: ldloc.s 18
-				IL_0452: ldc.r8 0.0
-				IL_045b: ceq
-				IL_045d: brfalse IL_0511
+				IL_0422: ldloc.s 9
+				IL_0424: ldc.r8 1
+				IL_042d: sub
+				IL_042e: stloc.s 9
+				IL_0430: ldloc.s 9
+				IL_0432: stloc.s 17
+				IL_0434: ldloc.s 17
+				IL_0436: ldc.r8 0.0
+				IL_043f: ceq
+				IL_0441: brfalse IL_04f5
 
-				IL_0462: ldarg.2
-				IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0468: stloc.s 15
-				IL_046a: volatile.
-				IL_046c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-				IL_0471: brfalse IL_0487
+				IL_0446: ldarg.2
+				IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_044c: stloc.s 15
+				IL_044e: volatile.
+				IL_0450: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+				IL_0455: brfalse IL_046b
 
-				IL_0476: ldloc.s 8
-				IL_0478: ldstr "lastIndex"
-				IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0482: br IL_049d
+				IL_045a: ldloc.s 8
+				IL_045c: ldstr "lastIndex"
+				IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0466: br IL_0481
 
-				IL_0487: ldloc.s 8
-				IL_0489: ldstr "lastIndex"
-				IL_048e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:165"
-				IL_0493: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-				IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_046b: ldloc.s 8
+				IL_046d: ldstr "lastIndex"
+				IL_0472: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M23>:__js_call__:163"
+				IL_0477: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+				IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_049d: stloc.s 20
-				IL_049f: ldc.i4.0
-				IL_04a0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_04a5: brfalse IL_04db
+				IL_0481: stloc.s 19
+				IL_0483: ldc.i4.0
+				IL_0484: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0489: brfalse IL_04bf
 
-				IL_04aa: ldloc.s 15
-				IL_04ac: isinst [System.Runtime]System.String
-				IL_04b1: dup
-				IL_04b2: brtrue IL_04ca
+				IL_048e: ldloc.s 15
+				IL_0490: isinst [System.Runtime]System.String
+				IL_0495: dup
+				IL_0496: brtrue IL_04ae
 
-				IL_04b7: pop
-				IL_04b8: ldloc.s 15
-				IL_04ba: ldstr "substring"
-				IL_04bf: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-				IL_04c4: dup
-				IL_04c5: brfalse IL_04da
+				IL_049b: pop
+				IL_049c: ldloc.s 15
+				IL_049e: ldstr "substring"
+				IL_04a3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_04a8: dup
+				IL_04a9: brfalse IL_04be
 
-				IL_04ca: ldloc.s 10
-				IL_04cc: ldloc.s 20
-				IL_04ce: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_04d3: stloc.s 20
-				IL_04d5: br IL_04ed
+				IL_04ae: ldloc.s 10
+				IL_04b0: ldloc.s 19
+				IL_04b2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_04b7: stloc.s 19
+				IL_04b9: br IL_04d1
 
-				IL_04da: pop
+				IL_04be: pop
 
-				IL_04db: ldloc.s 15
-				IL_04dd: ldstr "substring"
-				IL_04e2: ldloc.s 10
-				IL_04e4: ldloc.s 20
-				IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_04eb: stloc.s 20
+				IL_04bf: ldloc.s 15
+				IL_04c1: ldstr "substring"
+				IL_04c6: ldloc.s 10
+				IL_04c8: ldloc.s 19
+				IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_04cf: stloc.s 19
 
-				IL_04ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_04f2: dup
-				IL_04f3: ldstr "tagName"
-				IL_04f8: ldloc.s 6
-				IL_04fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_04ff: dup
-				IL_0500: ldstr "html"
-				IL_0505: ldloc.s 20
-				IL_0507: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_050c: stloc.s 21
-				IL_050e: ldloc.s 21
-				IL_0510: ret
+				IL_04d1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_04d6: dup
+				IL_04d7: ldstr "tagName"
+				IL_04dc: ldloc.s 6
+				IL_04de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_04e3: dup
+				IL_04e4: ldstr "html"
+				IL_04e9: ldloc.s 19
+				IL_04eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_04f0: stloc.s 20
+				IL_04f2: ldloc.s 20
+				IL_04f4: ret
 
-				IL_0511: br IL_0524
+				IL_04f5: br IL_0508
 
-				IL_0516: ldloc.s 9
-				IL_0518: ldc.r8 1
-				IL_0521: add
-				IL_0522: stloc.s 9
+				IL_04fa: ldloc.s 9
+				IL_04fc: ldc.r8 1
+				IL_0505: add
+				IL_0506: stloc.s 9
 
-				IL_0524: br IL_030e
+				IL_0508: br IL_02f2
 			// end loop
 
-			IL_0529: ldloc.s 6
-			IL_052b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0530: stloc.s 14
-			IL_0532: ldstr "Could not find a matching closing </"
-			IL_0537: ldloc.s 14
-			IL_0539: call string [System.Runtime]System.String::Concat(string, string)
-			IL_053e: ldstr "> for id '"
-			IL_0543: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0548: ldarg.3
-			IL_0549: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_054e: stloc.s 14
-			IL_0550: ldloc.s 14
-			IL_0552: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0557: ldstr "'."
-			IL_055c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0561: stloc.s 14
-			IL_0563: ldloc.s 14
-			IL_0565: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_056a: stloc.s 13
-			IL_056c: ldloc.s 13
-			IL_056e: isinst [System.Runtime]System.Exception
-			IL_0573: dup
-			IL_0574: brtrue IL_0582
+			IL_050d: ldloc.s 6
+			IL_050f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0514: stloc.s 14
+			IL_0516: ldstr "Could not find a matching closing </"
+			IL_051b: ldloc.s 14
+			IL_051d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0522: ldstr "> for id '"
+			IL_0527: call string [System.Runtime]System.String::Concat(string, string)
+			IL_052c: ldarg.3
+			IL_052d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0532: stloc.s 14
+			IL_0534: ldloc.s 14
+			IL_0536: call string [System.Runtime]System.String::Concat(string, string)
+			IL_053b: ldstr "'."
+			IL_0540: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0545: stloc.s 14
+			IL_0547: ldloc.s 14
+			IL_0549: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_054e: stloc.s 13
+			IL_0550: ldloc.s 13
+			IL_0552: isinst [System.Runtime]System.Exception
+			IL_0557: dup
+			IL_0558: brtrue IL_0566
 
-			IL_0579: pop
-			IL_057a: ldloc.s 13
-			IL_057c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0581: throw
+			IL_055d: pop
+			IL_055e: ldloc.s 13
+			IL_0560: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0565: throw
 
-			IL_0582: throw
+			IL_0566: throw
 
-			IL_0583: ldnull
-			IL_0584: ret
+			IL_0567: ldnull
+			IL_0568: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -5406,7 +5369,7 @@
 				74 61 54 6f 6b 65 6e 23 00 00 02
 			)
 			// Header size: 12
-			// Code size: 631 (0x277)
+			// Code size: 612 (0x264)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5416,235 +5379,225 @@
 				[4] object,
 				[5] object,
 				[6] object,
-				[7] object[],
-				[8] string,
-				[9] bool,
+				[7] string,
+				[8] bool,
+				[9] object,
 				[10] object,
 				[11] object,
 				[12] object,
 				[13] object,
 				[14] object,
-				[15] object,
-				[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.s 7
-			IL_0012: ldloc.s 7
-			IL_0014: ldarg.3
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_001a: stloc.0
-			IL_001b: ldloc.0
-			IL_001c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0021: stloc.s 8
-			IL_0023: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_0028: ldloc.s 8
-			IL_002a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002f: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
-			IL_0034: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0039: stloc.s 8
-			IL_003b: ldloc.s 8
-			IL_003d: ldstr "i"
-			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0047: stloc.1
-			IL_0048: volatile.
-			IL_004a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_004f: brfalse IL_0065
+			IL_0000: ldnull
+			IL_0001: ldarg.3
+			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+			IL_0007: stloc.0
+			IL_0008: ldloc.0
+			IL_0009: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_000e: stloc.s 7
+			IL_0010: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_0015: ldloc.s 7
+			IL_0017: call string [System.Runtime]System.String::Concat(string, string)
+			IL_001c: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_0021: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0026: stloc.s 7
+			IL_0028: ldloc.s 7
+			IL_002a: ldstr "i"
+			IL_002f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0034: stloc.1
+			IL_0035: volatile.
+			IL_0037: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_003c: brfalse IL_0052
 
-			IL_0054: ldloc.1
-			IL_0055: ldstr "exec"
-			IL_005a: ldarg.2
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0060: br IL_007b
+			IL_0041: ldloc.1
+			IL_0042: ldstr "exec"
+			IL_0047: ldarg.2
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_004d: br IL_0068
 
-			IL_0065: ldloc.1
-			IL_0066: ldstr "exec"
-			IL_006b: ldarg.2
-			IL_006c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:17"
-			IL_0071: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0052: ldloc.1
+			IL_0053: ldstr "exec"
+			IL_0058: ldarg.2
+			IL_0059: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M24>:__js_call__:16"
+			IL_005e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_007b: stloc.2
-			IL_007c: ldloc.2
-			IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0082: stloc.s 9
-			IL_0084: ldloc.s 9
-			IL_0086: brfalse IL_00d3
+			IL_0068: stloc.2
+			IL_0069: ldloc.2
+			IL_006a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_006f: stloc.s 8
+			IL_0071: ldloc.s 8
+			IL_0073: brfalse IL_00c0
 
-			IL_008b: ldloc.2
-			IL_008c: ldc.r8 1
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_009a: stloc.s 10
-			IL_009c: ldloc.s 10
-			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a3: stloc.s 9
-			IL_00a5: ldloc.s 9
-			IL_00a7: brtrue IL_00c6
+			IL_0078: ldloc.2
+			IL_0079: ldc.r8 1
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0087: stloc.s 9
+			IL_0089: ldloc.s 9
+			IL_008b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0090: stloc.s 8
+			IL_0092: ldloc.s 8
+			IL_0094: brtrue IL_00b3
 
-			IL_00ac: ldloc.2
-			IL_00ad: ldc.r8 2
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00bb: stloc.s 11
-			IL_00bd: ldloc.s 11
-			IL_00bf: stloc.s 13
-			IL_00c1: br IL_00ca
+			IL_0099: ldloc.2
+			IL_009a: ldc.r8 2
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00a8: stloc.s 10
+			IL_00aa: ldloc.s 10
+			IL_00ac: stloc.s 12
+			IL_00ae: br IL_00b7
 
-			IL_00c6: ldloc.s 10
-			IL_00c8: stloc.s 13
+			IL_00b3: ldloc.s 9
+			IL_00b5: stloc.s 12
 
-			IL_00ca: ldloc.s 13
-			IL_00cc: stloc.s 14
-			IL_00ce: br IL_00d6
+			IL_00b7: ldloc.s 12
+			IL_00b9: stloc.s 13
+			IL_00bb: br IL_00c3
 
-			IL_00d3: ldloc.2
-			IL_00d4: stloc.s 14
+			IL_00c0: ldloc.2
+			IL_00c1: stloc.s 13
 
-			IL_00d6: ldloc.s 14
-			IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00dd: stloc.s 9
-			IL_00df: ldloc.s 9
-			IL_00e1: brtrue IL_00f2
+			IL_00c3: ldloc.s 13
+			IL_00c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00ca: stloc.s 8
+			IL_00cc: ldloc.s 8
+			IL_00ce: brtrue IL_00df
 
-			IL_00e6: ldstr ""
-			IL_00eb: stloc.s 14
-			IL_00ed: br IL_00f2
+			IL_00d3: ldstr ""
+			IL_00d8: stloc.s 13
+			IL_00da: br IL_00df
 
-			IL_00f2: ldloc.s 14
-			IL_00f4: stloc.3
-			IL_00f5: ldloc.3
-			IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00fb: ldc.i4.0
-			IL_00fc: ceq
-			IL_00fe: stloc.s 9
-			IL_0100: ldloc.s 9
-			IL_0102: brfalse IL_010e
+			IL_00df: ldloc.s 13
+			IL_00e1: stloc.3
+			IL_00e2: ldloc.3
+			IL_00e3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_00e8: ldc.i4.0
+			IL_00e9: ceq
+			IL_00eb: stloc.s 8
+			IL_00ed: ldloc.s 8
+			IL_00ef: brfalse IL_00fb
 
-			IL_0107: ldc.i4.0
-			IL_0108: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_010d: ret
+			IL_00f4: ldc.i4.0
+			IL_00f5: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00fa: ret
 
-			IL_010e: ldloc.3
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0114: stloc.s 10
-			IL_0116: ldc.i4.0
-			IL_0117: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_011c: brfalse IL_013e
+			IL_00fb: ldloc.3
+			IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0101: stloc.s 9
+			IL_0103: ldc.i4.0
+			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0109: brfalse IL_012b
 
-			IL_0121: ldloc.s 10
-			IL_0123: castclass [System.Runtime]System.String
-			IL_0128: ldstr "#"
-			IL_012d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0132: box [System.Runtime]System.Double
-			IL_0137: stloc.s 4
-			IL_0139: br IL_0151
+			IL_010e: ldloc.s 9
+			IL_0110: castclass [System.Runtime]System.String
+			IL_0115: ldstr "#"
+			IL_011a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_011f: box [System.Runtime]System.Double
+			IL_0124: stloc.s 4
+			IL_0126: br IL_013e
 
-			IL_013e: ldloc.s 10
-			IL_0140: ldstr "indexOf"
-			IL_0145: ldstr "#"
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_014f: stloc.s 4
+			IL_012b: ldloc.s 9
+			IL_012d: ldstr "indexOf"
+			IL_0132: ldstr "#"
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_013c: stloc.s 4
 
-			IL_0151: ldloc.s 4
-			IL_0153: ldc.r8 0.0
-			IL_015c: box [System.Runtime]System.Double
-			IL_0161: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
-			IL_0166: stloc.s 9
-			IL_0168: ldloc.s 9
-			IL_016a: brfalse IL_01cc
+			IL_013e: ldloc.s 4
+			IL_0140: ldc.r8 0.0
+			IL_0149: box [System.Runtime]System.Double
+			IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
+			IL_0153: stloc.s 8
+			IL_0155: ldloc.s 8
+			IL_0157: brfalse IL_01b9
 
-			IL_016f: ldloc.3
-			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0175: stloc.s 10
-			IL_0177: ldc.i4.0
-			IL_0178: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_017d: brfalse IL_01a5
+			IL_015c: ldloc.3
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0162: stloc.s 9
+			IL_0164: ldc.i4.0
+			IL_0165: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_016a: brfalse IL_0192
 
-			IL_0182: ldloc.s 10
-			IL_0184: castclass [System.Runtime]System.String
-			IL_0189: ldc.r8 0.0
-			IL_0192: box [System.Runtime]System.Double
-			IL_0197: ldloc.s 4
-			IL_0199: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_019e: stloc.s 10
-			IL_01a0: br IL_01c3
+			IL_016f: ldloc.s 9
+			IL_0171: castclass [System.Runtime]System.String
+			IL_0176: ldc.r8 0.0
+			IL_017f: box [System.Runtime]System.Double
+			IL_0184: ldloc.s 4
+			IL_0186: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_018b: stloc.s 9
+			IL_018d: br IL_01b0
 
-			IL_01a5: ldloc.s 10
-			IL_01a7: ldstr "substring"
-			IL_01ac: ldc.r8 0.0
-			IL_01b5: box [System.Runtime]System.Double
-			IL_01ba: ldloc.s 4
-			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01c1: stloc.s 10
+			IL_0192: ldloc.s 9
+			IL_0194: ldstr "substring"
+			IL_0199: ldc.r8 0.0
+			IL_01a2: box [System.Runtime]System.Double
+			IL_01a7: ldloc.s 4
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01ae: stloc.s 9
 
-			IL_01c3: ldloc.s 10
-			IL_01c5: stloc.s 5
-			IL_01c7: br IL_01cf
+			IL_01b0: ldloc.s 9
+			IL_01b2: stloc.s 5
+			IL_01b4: br IL_01bc
 
-			IL_01cc: ldloc.3
-			IL_01cd: stloc.s 5
+			IL_01b9: ldloc.3
+			IL_01ba: stloc.s 5
 
-			IL_01cf: ldloc.s 4
-			IL_01d1: ldc.r8 0.0
-			IL_01da: box [System.Runtime]System.Double
-			IL_01df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
-			IL_01e4: stloc.s 9
-			IL_01e6: ldloc.s 9
-			IL_01e8: brfalse IL_0240
+			IL_01bc: ldloc.s 4
+			IL_01be: ldc.r8 0.0
+			IL_01c7: box [System.Runtime]System.Double
+			IL_01cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThanOrEqual(object, object)
+			IL_01d1: stloc.s 8
+			IL_01d3: ldloc.s 8
+			IL_01d5: brfalse IL_022d
 
-			IL_01ed: ldloc.3
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f3: stloc.s 10
-			IL_01f5: ldloc.s 4
-			IL_01f7: ldc.r8 1
-			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0205: stloc.s 14
-			IL_0207: ldc.i4.0
-			IL_0208: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_020d: brfalse IL_0227
+			IL_01da: ldloc.3
+			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e0: stloc.s 9
+			IL_01e2: ldloc.s 4
+			IL_01e4: ldc.r8 1
+			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01f2: stloc.s 13
+			IL_01f4: ldc.i4.0
+			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01fa: brfalse IL_0214
 
-			IL_0212: ldloc.s 10
-			IL_0214: castclass [System.Runtime]System.String
-			IL_0219: ldloc.s 14
-			IL_021b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_0220: stloc.s 10
-			IL_0222: br IL_0237
+			IL_01ff: ldloc.s 9
+			IL_0201: castclass [System.Runtime]System.String
+			IL_0206: ldloc.s 13
+			IL_0208: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_020d: stloc.s 9
+			IL_020f: br IL_0224
 
-			IL_0227: ldloc.s 10
-			IL_0229: ldstr "substring"
-			IL_022e: ldloc.s 14
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0235: stloc.s 10
+			IL_0214: ldloc.s 9
+			IL_0216: ldstr "substring"
+			IL_021b: ldloc.s 13
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0222: stloc.s 9
 
-			IL_0237: ldloc.s 10
-			IL_0239: stloc.s 6
-			IL_023b: br IL_0247
+			IL_0224: ldloc.s 9
+			IL_0226: stloc.s 6
+			IL_0228: br IL_0234
 
-			IL_0240: ldstr ""
-			IL_0245: stloc.s 6
+			IL_022d: ldstr ""
+			IL_0232: stloc.s 6
 
-			IL_0247: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_024c: dup
-			IL_024d: ldstr "href"
-			IL_0252: ldloc.3
-			IL_0253: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0258: dup
-			IL_0259: ldstr "filePart"
-			IL_025e: ldloc.s 5
-			IL_0260: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0265: dup
-			IL_0266: ldstr "fragment"
-			IL_026b: ldloc.s 6
-			IL_026d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0272: stloc.s 16
-			IL_0274: ldloc.s 16
-			IL_0276: ret
+			IL_0234: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0239: dup
+			IL_023a: ldstr "href"
+			IL_023f: ldloc.3
+			IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0245: dup
+			IL_0246: ldstr "filePart"
+			IL_024b: ldloc.s 5
+			IL_024d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0252: dup
+			IL_0253: ldstr "fragment"
+			IL_0258: ldloc.s 6
+			IL_025a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_025f: stloc.s 15
+			IL_0261: ldloc.s 15
+			IL_0263: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -6127,7 +6080,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 4053 (0xfd5)
+			// Code size: 3934 (0xf5e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -6151,13 +6104,13 @@
 				[18] object,
 				[19] object,
 				[20] object,
-				[21] object[],
-				[22] object,
+				[21] object,
+				[22] object[],
 				[23] bool,
 				[24] object,
 				[25] object,
-				[26] object,
-				[27] string,
+				[26] string,
+				[27] object,
 				[28] object,
 				[29] object,
 				[30] object,
@@ -6301,11 +6254,11 @@
 			IL_0105: dup
 			IL_0106: ldc.i4.s 20
 			IL_0108: ldelem.ref
-			IL_0109: castclass object[]
-			IL_010e: stloc.s 21
-			IL_0110: dup
-			IL_0111: ldc.i4.s 21
-			IL_0113: ldelem.ref
+			IL_0109: stloc.s 21
+			IL_010b: dup
+			IL_010c: ldc.i4.s 21
+			IL_010e: ldelem.ref
+			IL_010f: castclass object[]
 			IL_0114: stloc.s 22
 			IL_0116: dup
 			IL_0117: ldc.i4.s 22
@@ -6323,11 +6276,11 @@
 			IL_012d: dup
 			IL_012e: ldc.i4.s 25
 			IL_0130: ldelem.ref
-			IL_0131: stloc.s 26
-			IL_0133: dup
-			IL_0134: ldc.i4.s 26
-			IL_0136: ldelem.ref
-			IL_0137: castclass [System.Runtime]System.String
+			IL_0131: castclass [System.Runtime]System.String
+			IL_0136: stloc.s 26
+			IL_0138: dup
+			IL_0139: ldc.i4.s 26
+			IL_013b: ldelem.ref
 			IL_013c: stloc.s 27
 			IL_013e: dup
 			IL_013f: ldc.i4.s 27
@@ -6360,1518 +6313,1469 @@
 
 			IL_0172: ldloc.0
 			IL_0173: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0178: switch (IL_018d, IL_0692, IL_09e9, IL_0bff)
+			IL_0178: switch (IL_018d, IL_0689, IL_09d3, IL_0be5)
 
-			IL_018d: ldarg.0
-			IL_018e: ldc.i4.1
-			IL_018f: ldelem.ref
-			IL_0190: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0195: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
-			IL_019a: ldc.i4.1
-			IL_019b: newarr [System.Runtime]System.Object
-			IL_01a0: dup
-			IL_01a1: ldc.i4.0
-			IL_01a2: ldarg.0
-			IL_01a3: ldc.i4.1
-			IL_01a4: ldelem.ref
-			IL_01a5: stelem.ref
-			IL_01a6: stloc.s 21
-			IL_01a8: ldstr "process"
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b2: stloc.s 22
-			IL_01b4: volatile.
-			IL_01b6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_01bb: brfalse IL_01d1
+			IL_018d: ldstr "process"
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0197: stloc.s 21
+			IL_0199: volatile.
+			IL_019b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_01a0: brfalse IL_01b6
 
-			IL_01c0: ldloc.s 22
-			IL_01c2: ldstr "argv"
-			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01cc: br IL_01e7
+			IL_01a5: ldloc.s 21
+			IL_01a7: ldstr "argv"
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b1: br IL_01cc
 
-			IL_01d1: ldloc.s 22
-			IL_01d3: ldstr "argv"
-			IL_01d8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:7"
-			IL_01dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01b6: ldloc.s 21
+			IL_01b8: ldstr "argv"
+			IL_01bd: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:5"
+			IL_01c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01e7: stloc.s 22
-			IL_01e9: ldloc.s 21
-			IL_01eb: ldloc.s 22
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01f2: stloc.1
-			IL_01f3: volatile.
-			IL_01f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_01fa: brfalse IL_020f
+			IL_01cc: stloc.s 21
+			IL_01ce: ldc.i4.1
+			IL_01cf: newarr [System.Runtime]System.Object
+			IL_01d4: dup
+			IL_01d5: ldc.i4.0
+			IL_01d6: ldarg.0
+			IL_01d7: ldc.i4.1
+			IL_01d8: ldelem.ref
+			IL_01d9: stelem.ref
+			IL_01da: stloc.s 22
+			IL_01dc: ldloc.s 22
+			IL_01de: ldc.i4.0
+			IL_01df: ldelem.ref
+			IL_01e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_01e5: ldnull
+			IL_01e6: ldloc.s 21
+			IL_01e8: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+			IL_01ed: stloc.1
+			IL_01ee: volatile.
+			IL_01f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_01f5: brfalse IL_020a
 
-			IL_01ff: ldloc.1
-			IL_0200: ldstr "section"
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_020a: br IL_0224
+			IL_01fa: ldloc.1
+			IL_01fb: ldstr "section"
+			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0205: br IL_021f
 
-			IL_020f: ldloc.1
-			IL_0210: ldstr "section"
-			IL_0215: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:12"
-			IL_021a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_020a: ldloc.1
+			IL_020b: ldstr "section"
+			IL_0210: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:11"
+			IL_0215: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0224: stloc.s 22
-			IL_0226: ldloc.s 22
-			IL_0228: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_022d: ldc.i4.0
-			IL_022e: ceq
-			IL_0230: stloc.s 23
-			IL_0232: ldloc.s 23
-			IL_0234: brfalse IL_0273
+			IL_021f: stloc.s 21
+			IL_0221: ldloc.s 21
+			IL_0223: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0228: ldc.i4.0
+			IL_0229: ceq
+			IL_022b: stloc.s 23
+			IL_022d: ldloc.s 23
+			IL_022f: brfalse IL_026e
 
-			IL_0239: ldstr "Missing required --section (e.g. 27.3)."
-			IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0243: stloc.2
-			IL_0244: ldloc.0
-			IL_0245: ldc.i4.m1
-			IL_0246: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_024b: ldloc.0
-			IL_024c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0251: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0256: ldarg.0
-			IL_0257: ldc.i4.1
-			IL_0258: newarr [System.Runtime]System.Object
-			IL_025d: dup
-			IL_025e: ldc.i4.0
-			IL_025f: ldloc.2
-			IL_0260: stelem.ref
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0266: pop
-			IL_0267: ldloc.0
-			IL_0268: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_026d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0272: ret
+			IL_0234: ldstr "Missing required --section (e.g. 27.3)."
+			IL_0239: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_023e: stloc.2
+			IL_023f: ldloc.0
+			IL_0240: ldc.i4.m1
+			IL_0241: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0246: ldloc.0
+			IL_0247: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_024c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0251: ldarg.0
+			IL_0252: ldc.i4.1
+			IL_0253: newarr [System.Runtime]System.Object
+			IL_0258: dup
+			IL_0259: ldc.i4.0
+			IL_025a: ldloc.2
+			IL_025b: stelem.ref
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0261: pop
+			IL_0262: ldloc.0
+			IL_0263: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0268: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_026d: ret
 
-			IL_0273: volatile.
-			IL_0275: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_027a: brfalse IL_028f
+			IL_026e: volatile.
+			IL_0270: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_0275: brfalse IL_028a
 
-			IL_027f: ldloc.1
-			IL_0280: ldstr "outFile"
-			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028a: br IL_02a4
+			IL_027a: ldloc.1
+			IL_027b: ldstr "outFile"
+			IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0285: br IL_029f
 
-			IL_028f: ldloc.1
-			IL_0290: ldstr "outFile"
-			IL_0295: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:23"
-			IL_029a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_028a: ldloc.1
+			IL_028b: ldstr "outFile"
+			IL_0290: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:22"
+			IL_0295: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02a4: stloc.s 22
-			IL_02a6: ldloc.s 22
-			IL_02a8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02ad: ldc.i4.0
-			IL_02ae: ceq
-			IL_02b0: stloc.s 23
-			IL_02b2: ldloc.s 23
-			IL_02b4: brfalse IL_02f3
+			IL_029f: stloc.s 21
+			IL_02a1: ldloc.s 21
+			IL_02a3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02a8: ldc.i4.0
+			IL_02a9: ceq
+			IL_02ab: stloc.s 23
+			IL_02ad: ldloc.s 23
+			IL_02af: brfalse IL_02ee
 
-			IL_02b9: ldstr "Missing required --out <output.html>."
-			IL_02be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_02c3: stloc.3
-			IL_02c4: ldloc.0
-			IL_02c5: ldc.i4.m1
-			IL_02c6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02cb: ldloc.0
-			IL_02cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_02d6: ldarg.0
-			IL_02d7: ldc.i4.1
-			IL_02d8: newarr [System.Runtime]System.Object
-			IL_02dd: dup
-			IL_02de: ldc.i4.0
-			IL_02df: ldloc.3
-			IL_02e0: stelem.ref
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02e6: pop
-			IL_02e7: ldloc.0
-			IL_02e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02f2: ret
+			IL_02b4: ldstr "Missing required --out <output.html>."
+			IL_02b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_02be: stloc.3
+			IL_02bf: ldloc.0
+			IL_02c0: ldc.i4.m1
+			IL_02c1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02c6: ldloc.0
+			IL_02c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_02d1: ldarg.0
+			IL_02d2: ldc.i4.1
+			IL_02d3: newarr [System.Runtime]System.Object
+			IL_02d8: dup
+			IL_02d9: ldc.i4.0
+			IL_02da: ldloc.3
+			IL_02db: stelem.ref
+			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02e1: pop
+			IL_02e2: ldloc.0
+			IL_02e3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02e8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02ed: ret
 
-			IL_02f3: volatile.
-			IL_02f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_02fa: brfalse IL_030f
+			IL_02ee: volatile.
+			IL_02f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_02f5: brfalse IL_030a
 
-			IL_02ff: ldloc.1
-			IL_0300: ldstr "url"
-			IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_030a: br IL_0324
+			IL_02fa: ldloc.1
+			IL_02fb: ldstr "url"
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0305: br IL_031f
 
-			IL_030f: ldloc.1
-			IL_0310: ldstr "url"
-			IL_0315: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:34"
-			IL_031a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-			IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_030a: ldloc.1
+			IL_030b: ldstr "url"
+			IL_0310: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:33"
+			IL_0315: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0324: stloc.s 22
-			IL_0326: ldloc.s 22
-			IL_0328: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_032d: stloc.s 23
-			IL_032f: ldloc.s 23
-			IL_0331: brfalse IL_034b
+			IL_031f: stloc.s 21
+			IL_0321: ldloc.s 21
+			IL_0323: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0328: stloc.s 23
+			IL_032a: ldloc.s 23
+			IL_032c: brfalse IL_0346
 
-			IL_0336: ldc.r8 1
-			IL_033f: box [System.Runtime]System.Double
-			IL_0344: stloc.s 4
-			IL_0346: br IL_035b
+			IL_0331: ldc.r8 1
+			IL_033a: box [System.Runtime]System.Double
+			IL_033f: stloc.s 4
+			IL_0341: br IL_0356
 
-			IL_034b: ldc.r8 0.0
-			IL_0354: box [System.Runtime]System.Double
-			IL_0359: stloc.s 4
+			IL_0346: ldc.r8 0.0
+			IL_034f: box [System.Runtime]System.Double
+			IL_0354: stloc.s 4
 
-			IL_035b: ldloc.s 4
-			IL_035d: stloc.s 24
-			IL_035f: volatile.
-			IL_0361: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_0366: brfalse IL_037b
+			IL_0356: ldloc.s 4
+			IL_0358: stloc.s 24
+			IL_035a: volatile.
+			IL_035c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0361: brfalse IL_0376
 
-			IL_036b: ldloc.1
-			IL_036c: ldstr "auto"
-			IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0376: br IL_0390
+			IL_0366: ldloc.1
+			IL_0367: ldstr "auto"
+			IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0371: br IL_038b
 
-			IL_037b: ldloc.1
-			IL_037c: ldstr "auto"
-			IL_0381: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:48"
-			IL_0386: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0376: ldloc.1
+			IL_0377: ldstr "auto"
+			IL_037c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:47"
+			IL_0381: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0390: stloc.s 22
-			IL_0392: ldloc.s 22
-			IL_0394: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0399: stloc.s 23
-			IL_039b: ldloc.s 23
-			IL_039d: brfalse IL_03b7
+			IL_038b: stloc.s 21
+			IL_038d: ldloc.s 21
+			IL_038f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0394: stloc.s 23
+			IL_0396: ldloc.s 23
+			IL_0398: brfalse IL_03b2
 
-			IL_03a2: ldc.r8 1
-			IL_03ab: box [System.Runtime]System.Double
-			IL_03b0: stloc.s 5
-			IL_03b2: br IL_03c7
+			IL_039d: ldc.r8 1
+			IL_03a6: box [System.Runtime]System.Double
+			IL_03ab: stloc.s 5
+			IL_03ad: br IL_03c2
 
-			IL_03b7: ldc.r8 0.0
-			IL_03c0: box [System.Runtime]System.Double
-			IL_03c5: stloc.s 5
+			IL_03b2: ldc.r8 0.0
+			IL_03bb: box [System.Runtime]System.Double
+			IL_03c0: stloc.s 5
 
-			IL_03c7: ldloc.s 24
-			IL_03c9: ldloc.s 5
-			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03d0: stloc.s 6
-			IL_03d2: ldloc.s 6
-			IL_03d4: ldc.r8 1
-			IL_03dd: box [System.Runtime]System.Double
-			IL_03e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_03e7: stloc.s 23
-			IL_03e9: ldloc.s 23
-			IL_03eb: brfalse IL_042c
+			IL_03c2: ldloc.s 24
+			IL_03c4: ldloc.s 5
+			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03cb: stloc.s 6
+			IL_03cd: ldloc.s 6
+			IL_03cf: ldc.r8 1
+			IL_03d8: box [System.Runtime]System.Double
+			IL_03dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_03e2: stloc.s 23
+			IL_03e4: ldloc.s 23
+			IL_03e6: brfalse IL_0427
 
-			IL_03f0: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_03f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_03fa: stloc.s 7
-			IL_03fc: ldloc.0
-			IL_03fd: ldc.i4.m1
-			IL_03fe: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0403: ldloc.0
-			IL_0404: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0409: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_040e: ldarg.0
-			IL_040f: ldc.i4.1
-			IL_0410: newarr [System.Runtime]System.Object
-			IL_0415: dup
-			IL_0416: ldc.i4.0
-			IL_0417: ldloc.s 7
-			IL_0419: stelem.ref
-			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_041f: pop
-			IL_0420: ldloc.0
-			IL_0421: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0426: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_042b: ret
+			IL_03eb: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_03f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03f5: stloc.s 7
+			IL_03f7: ldloc.0
+			IL_03f8: ldc.i4.m1
+			IL_03f9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03fe: ldloc.0
+			IL_03ff: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0404: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0409: ldarg.0
+			IL_040a: ldc.i4.1
+			IL_040b: newarr [System.Runtime]System.Object
+			IL_0410: dup
+			IL_0411: ldc.i4.0
+			IL_0412: ldloc.s 7
+			IL_0414: stelem.ref
+			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_041a: pop
+			IL_041b: ldloc.0
+			IL_041c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0421: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0426: ret
 
-			IL_042c: ldnull
-			IL_042d: stloc.s 8
-			IL_042f: volatile.
-			IL_0431: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_0436: brfalse IL_044b
+			IL_0427: ldnull
+			IL_0428: stloc.s 8
+			IL_042a: volatile.
+			IL_042c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0431: brfalse IL_0446
 
-			IL_043b: ldloc.1
-			IL_043c: ldstr "id"
-			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0446: br IL_0460
+			IL_0436: ldloc.1
+			IL_0437: ldstr "id"
+			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0441: br IL_045b
 
-			IL_044b: ldloc.1
-			IL_044c: ldstr "id"
-			IL_0451: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:78"
-			IL_0456: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0446: ldloc.1
+			IL_0447: ldstr "id"
+			IL_044c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:77"
+			IL_0451: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+			IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0460: stloc.s 22
-			IL_0462: ldloc.s 22
-			IL_0464: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0469: stloc.s 23
-			IL_046b: ldloc.s 23
-			IL_046d: brtrue IL_047e
+			IL_045b: stloc.s 21
+			IL_045d: ldloc.s 21
+			IL_045f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0464: stloc.s 23
+			IL_0466: ldloc.s 23
+			IL_0468: brtrue IL_0479
 
-			IL_0472: ldstr ""
-			IL_0477: stloc.s 25
-			IL_0479: br IL_0482
+			IL_046d: ldstr ""
+			IL_0472: stloc.s 25
+			IL_0474: br IL_047d
 
-			IL_047e: ldloc.s 22
-			IL_0480: stloc.s 25
+			IL_0479: ldloc.s 21
+			IL_047b: stloc.s 25
 
-			IL_0482: ldloc.s 25
-			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0489: stloc.s 22
-			IL_048b: ldc.i4.0
-			IL_048c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0491: brfalse IL_04a9
+			IL_047d: ldloc.s 25
+			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0484: stloc.s 21
+			IL_0486: ldc.i4.0
+			IL_0487: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_048c: brfalse IL_04a4
 
-			IL_0496: ldloc.s 22
-			IL_0498: castclass [System.Runtime]System.String
-			IL_049d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_04a2: stloc.s 9
-			IL_04a4: br IL_04b7
+			IL_0491: ldloc.s 21
+			IL_0493: castclass [System.Runtime]System.String
+			IL_0498: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_049d: stloc.s 9
+			IL_049f: br IL_04b2
 
-			IL_04a9: ldloc.s 22
-			IL_04ab: ldstr "trim"
-			IL_04b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_04b5: stloc.s 9
+			IL_04a4: ldloc.s 21
+			IL_04a6: ldstr "trim"
+			IL_04ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_04b0: stloc.s 9
 
-			IL_04b7: ldstr ""
-			IL_04bc: stloc.s 10
-			IL_04be: volatile.
-			IL_04c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_04c5: brfalse IL_04da
+			IL_04b2: ldstr ""
+			IL_04b7: stloc.s 10
+			IL_04b9: volatile.
+			IL_04bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_04c0: brfalse IL_04d5
 
-			IL_04ca: ldloc.1
-			IL_04cb: ldstr "auto"
-			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04d5: br IL_04ef
+			IL_04c5: ldloc.1
+			IL_04c6: ldstr "auto"
+			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04d0: br IL_04ea
 
-			IL_04da: ldloc.1
-			IL_04db: ldstr "auto"
-			IL_04e0: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:95"
-			IL_04e5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_04d5: ldloc.1
+			IL_04d6: ldstr "auto"
+			IL_04db: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:94"
+			IL_04e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+			IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_04ef: stloc.s 22
-			IL_04f1: ldloc.s 22
-			IL_04f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04f8: stloc.s 23
-			IL_04fa: ldloc.s 23
-			IL_04fc: brfalse IL_0a6e
+			IL_04ea: stloc.s 21
+			IL_04ec: ldloc.s 21
+			IL_04ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04f3: stloc.s 23
+			IL_04f5: ldloc.s 23
+			IL_04f7: brfalse IL_0a58
 
-			IL_0501: volatile.
-			IL_0503: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_0508: brfalse IL_051d
+			IL_04fc: volatile.
+			IL_04fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_0503: brfalse IL_0518
 
-			IL_050d: ldloc.1
-			IL_050e: ldstr "indexUrl"
-			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0518: br IL_0532
+			IL_0508: ldloc.1
+			IL_0509: ldstr "indexUrl"
+			IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0513: br IL_052d
 
-			IL_051d: ldloc.1
-			IL_051e: ldstr "indexUrl"
-			IL_0523: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:100"
-			IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0518: ldloc.1
+			IL_0519: ldstr "indexUrl"
+			IL_051e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:99"
+			IL_0523: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+			IL_0528: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0532: stloc.s 22
-			IL_0534: ldloc.s 22
-			IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_053b: stloc.s 22
-			IL_053d: ldc.i4.0
-			IL_053e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0543: brfalse IL_0575
+			IL_052d: stloc.s 21
+			IL_052f: ldloc.s 21
+			IL_0531: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0536: stloc.s 21
+			IL_0538: ldc.i4.0
+			IL_0539: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_053e: brfalse IL_0570
 
-			IL_0548: ldloc.s 22
-			IL_054a: isinst [System.Runtime]System.String
-			IL_054f: dup
-			IL_0550: brtrue IL_0568
+			IL_0543: ldloc.s 21
+			IL_0545: isinst [System.Runtime]System.String
+			IL_054a: dup
+			IL_054b: brtrue IL_0563
 
-			IL_0555: pop
-			IL_0556: ldloc.s 22
-			IL_0558: ldstr "trim"
-			IL_055d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0562: dup
-			IL_0563: brfalse IL_0574
+			IL_0550: pop
+			IL_0551: ldloc.s 21
+			IL_0553: ldstr "trim"
+			IL_0558: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_055d: dup
+			IL_055e: brfalse IL_056f
 
-			IL_0568: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_056d: stloc.s 11
-			IL_056f: br IL_0583
+			IL_0563: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0568: stloc.s 11
+			IL_056a: br IL_057e
 
-			IL_0574: pop
+			IL_056f: pop
 
-			IL_0575: ldloc.s 22
-			IL_0577: ldstr "trim"
-			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0581: stloc.s 11
+			IL_0570: ldloc.s 21
+			IL_0572: ldstr "trim"
+			IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_057c: stloc.s 11
 
-			IL_0583: ldarg.0
-			IL_0584: ldc.i4.1
-			IL_0585: ldelem.ref
-			IL_0586: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_058b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0590: ldc.i4.1
-			IL_0591: newarr [System.Runtime]System.Object
-			IL_0596: dup
-			IL_0597: ldc.i4.0
-			IL_0598: ldarg.0
-			IL_0599: ldc.i4.1
-			IL_059a: ldelem.ref
-			IL_059b: stelem.ref
-			IL_059c: stloc.s 21
-			IL_059e: ldloc.s 21
-			IL_05a0: ldloc.s 11
-			IL_05a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_05a7: stloc.s 22
-			IL_05a9: ldloc.0
-			IL_05aa: ldc.i4.1
-			IL_05ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05b0: ldloc.0
-			IL_05b1: ldloc.s 22
-			IL_05b3: ldarg.0
-			IL_05b4: ldc.i4.1
-			IL_05b5: ldloc.0
-			IL_05b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_05c0: ldloc.0
-			IL_05c1: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05c6: dup
-			IL_05c7: ldc.i4.0
-			IL_05c8: ldloc.1
-			IL_05c9: stelem.ref
-			IL_05ca: dup
-			IL_05cb: ldc.i4.1
-			IL_05cc: ldloc.2
+			IL_057e: ldc.i4.1
+			IL_057f: newarr [System.Runtime]System.Object
+			IL_0584: dup
+			IL_0585: ldc.i4.0
+			IL_0586: ldarg.0
+			IL_0587: ldc.i4.1
+			IL_0588: ldelem.ref
+			IL_0589: stelem.ref
+			IL_058a: stloc.s 22
+			IL_058c: ldloc.s 22
+			IL_058e: ldc.i4.0
+			IL_058f: ldelem.ref
+			IL_0590: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0595: ldnull
+			IL_0596: ldloc.s 11
+			IL_0598: ldnull
+			IL_0599: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_059e: stloc.s 21
+			IL_05a0: ldloc.0
+			IL_05a1: ldc.i4.1
+			IL_05a2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05a7: ldloc.0
+			IL_05a8: ldloc.s 21
+			IL_05aa: ldarg.0
+			IL_05ab: ldc.i4.1
+			IL_05ac: ldloc.0
+			IL_05ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_05b7: ldloc.0
+			IL_05b8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05bd: dup
+			IL_05be: ldc.i4.0
+			IL_05bf: ldloc.1
+			IL_05c0: stelem.ref
+			IL_05c1: dup
+			IL_05c2: ldc.i4.1
+			IL_05c3: ldloc.2
+			IL_05c4: stelem.ref
+			IL_05c5: dup
+			IL_05c6: ldc.i4.2
+			IL_05c7: ldloc.3
+			IL_05c8: stelem.ref
+			IL_05c9: dup
+			IL_05ca: ldc.i4.3
+			IL_05cb: ldloc.s 4
 			IL_05cd: stelem.ref
 			IL_05ce: dup
-			IL_05cf: ldc.i4.2
-			IL_05d0: ldloc.3
-			IL_05d1: stelem.ref
-			IL_05d2: dup
-			IL_05d3: ldc.i4.3
-			IL_05d4: ldloc.s 4
-			IL_05d6: stelem.ref
-			IL_05d7: dup
-			IL_05d8: ldc.i4.4
-			IL_05d9: ldloc.s 5
-			IL_05db: stelem.ref
-			IL_05dc: dup
-			IL_05dd: ldc.i4.5
-			IL_05de: ldloc.s 6
-			IL_05e0: stelem.ref
-			IL_05e1: dup
-			IL_05e2: ldc.i4.6
-			IL_05e3: ldloc.s 7
-			IL_05e5: stelem.ref
-			IL_05e6: dup
-			IL_05e7: ldc.i4.7
-			IL_05e8: ldloc.s 8
-			IL_05ea: stelem.ref
-			IL_05eb: dup
-			IL_05ec: ldc.i4.8
-			IL_05ed: ldloc.s 9
-			IL_05ef: stelem.ref
-			IL_05f0: dup
-			IL_05f1: ldc.i4.s 9
-			IL_05f3: ldloc.s 10
-			IL_05f5: stelem.ref
-			IL_05f6: dup
-			IL_05f7: ldc.i4.s 10
-			IL_05f9: ldloc.s 11
-			IL_05fb: stelem.ref
-			IL_05fc: dup
-			IL_05fd: ldc.i4.s 11
-			IL_05ff: ldloc.s 12
-			IL_0601: stelem.ref
-			IL_0602: dup
-			IL_0603: ldc.i4.s 12
-			IL_0605: ldloc.s 13
-			IL_0607: stelem.ref
-			IL_0608: dup
-			IL_0609: ldc.i4.s 13
-			IL_060b: ldloc.s 14
-			IL_060d: stelem.ref
-			IL_060e: dup
-			IL_060f: ldc.i4.s 14
-			IL_0611: ldloc.s 15
-			IL_0613: stelem.ref
-			IL_0614: dup
-			IL_0615: ldc.i4.s 15
-			IL_0617: ldloc.s 16
-			IL_0619: stelem.ref
-			IL_061a: dup
-			IL_061b: ldc.i4.s 16
-			IL_061d: ldloc.s 17
-			IL_061f: stelem.ref
-			IL_0620: dup
-			IL_0621: ldc.i4.s 17
-			IL_0623: ldloc.s 18
-			IL_0625: stelem.ref
-			IL_0626: dup
-			IL_0627: ldc.i4.s 18
-			IL_0629: ldloc.s 19
-			IL_062b: stelem.ref
-			IL_062c: dup
-			IL_062d: ldc.i4.s 19
-			IL_062f: ldloc.s 20
-			IL_0631: stelem.ref
-			IL_0632: dup
-			IL_0633: ldc.i4.s 20
-			IL_0635: ldloc.s 21
-			IL_0637: stelem.ref
-			IL_0638: dup
-			IL_0639: ldc.i4.s 21
-			IL_063b: ldloc.s 22
-			IL_063d: stelem.ref
-			IL_063e: dup
-			IL_063f: ldc.i4.s 22
-			IL_0641: ldloc.s 23
-			IL_0643: box [System.Runtime]System.Boolean
-			IL_0648: stelem.ref
-			IL_0649: dup
-			IL_064a: ldc.i4.s 23
-			IL_064c: ldloc.s 24
-			IL_064e: stelem.ref
-			IL_064f: dup
-			IL_0650: ldc.i4.s 24
-			IL_0652: ldloc.s 25
-			IL_0654: stelem.ref
-			IL_0655: dup
-			IL_0656: ldc.i4.s 25
-			IL_0658: ldloc.s 26
-			IL_065a: stelem.ref
-			IL_065b: dup
-			IL_065c: ldc.i4.s 26
-			IL_065e: ldloc.s 27
-			IL_0660: stelem.ref
-			IL_0661: dup
-			IL_0662: ldc.i4.s 27
-			IL_0664: ldloc.s 28
-			IL_0666: stelem.ref
-			IL_0667: dup
-			IL_0668: ldc.i4.s 28
-			IL_066a: ldloc.s 29
-			IL_066c: stelem.ref
-			IL_066d: dup
-			IL_066e: ldc.i4.s 29
-			IL_0670: ldloc.s 30
-			IL_0672: stelem.ref
-			IL_0673: dup
-			IL_0674: ldc.i4.s 30
-			IL_0676: ldloc.s 31
-			IL_0678: stelem.ref
-			IL_0679: dup
-			IL_067a: ldc.i4.s 31
-			IL_067c: ldloc.s 32
-			IL_067e: stelem.ref
-			IL_067f: dup
-			IL_0680: ldc.i4.s 32
-			IL_0682: ldloc.s 33
-			IL_0684: stelem.ref
-			IL_0685: pop
-			IL_0686: ldloc.0
-			IL_0687: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_068c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0691: ret
+			IL_05cf: ldc.i4.4
+			IL_05d0: ldloc.s 5
+			IL_05d2: stelem.ref
+			IL_05d3: dup
+			IL_05d4: ldc.i4.5
+			IL_05d5: ldloc.s 6
+			IL_05d7: stelem.ref
+			IL_05d8: dup
+			IL_05d9: ldc.i4.6
+			IL_05da: ldloc.s 7
+			IL_05dc: stelem.ref
+			IL_05dd: dup
+			IL_05de: ldc.i4.7
+			IL_05df: ldloc.s 8
+			IL_05e1: stelem.ref
+			IL_05e2: dup
+			IL_05e3: ldc.i4.8
+			IL_05e4: ldloc.s 9
+			IL_05e6: stelem.ref
+			IL_05e7: dup
+			IL_05e8: ldc.i4.s 9
+			IL_05ea: ldloc.s 10
+			IL_05ec: stelem.ref
+			IL_05ed: dup
+			IL_05ee: ldc.i4.s 10
+			IL_05f0: ldloc.s 11
+			IL_05f2: stelem.ref
+			IL_05f3: dup
+			IL_05f4: ldc.i4.s 11
+			IL_05f6: ldloc.s 12
+			IL_05f8: stelem.ref
+			IL_05f9: dup
+			IL_05fa: ldc.i4.s 12
+			IL_05fc: ldloc.s 13
+			IL_05fe: stelem.ref
+			IL_05ff: dup
+			IL_0600: ldc.i4.s 13
+			IL_0602: ldloc.s 14
+			IL_0604: stelem.ref
+			IL_0605: dup
+			IL_0606: ldc.i4.s 14
+			IL_0608: ldloc.s 15
+			IL_060a: stelem.ref
+			IL_060b: dup
+			IL_060c: ldc.i4.s 15
+			IL_060e: ldloc.s 16
+			IL_0610: stelem.ref
+			IL_0611: dup
+			IL_0612: ldc.i4.s 16
+			IL_0614: ldloc.s 17
+			IL_0616: stelem.ref
+			IL_0617: dup
+			IL_0618: ldc.i4.s 17
+			IL_061a: ldloc.s 18
+			IL_061c: stelem.ref
+			IL_061d: dup
+			IL_061e: ldc.i4.s 18
+			IL_0620: ldloc.s 19
+			IL_0622: stelem.ref
+			IL_0623: dup
+			IL_0624: ldc.i4.s 19
+			IL_0626: ldloc.s 20
+			IL_0628: stelem.ref
+			IL_0629: dup
+			IL_062a: ldc.i4.s 20
+			IL_062c: ldloc.s 21
+			IL_062e: stelem.ref
+			IL_062f: dup
+			IL_0630: ldc.i4.s 21
+			IL_0632: ldloc.s 22
+			IL_0634: stelem.ref
+			IL_0635: dup
+			IL_0636: ldc.i4.s 22
+			IL_0638: ldloc.s 23
+			IL_063a: box [System.Runtime]System.Boolean
+			IL_063f: stelem.ref
+			IL_0640: dup
+			IL_0641: ldc.i4.s 23
+			IL_0643: ldloc.s 24
+			IL_0645: stelem.ref
+			IL_0646: dup
+			IL_0647: ldc.i4.s 24
+			IL_0649: ldloc.s 25
+			IL_064b: stelem.ref
+			IL_064c: dup
+			IL_064d: ldc.i4.s 25
+			IL_064f: ldloc.s 26
+			IL_0651: stelem.ref
+			IL_0652: dup
+			IL_0653: ldc.i4.s 26
+			IL_0655: ldloc.s 27
+			IL_0657: stelem.ref
+			IL_0658: dup
+			IL_0659: ldc.i4.s 27
+			IL_065b: ldloc.s 28
+			IL_065d: stelem.ref
+			IL_065e: dup
+			IL_065f: ldc.i4.s 28
+			IL_0661: ldloc.s 29
+			IL_0663: stelem.ref
+			IL_0664: dup
+			IL_0665: ldc.i4.s 29
+			IL_0667: ldloc.s 30
+			IL_0669: stelem.ref
+			IL_066a: dup
+			IL_066b: ldc.i4.s 30
+			IL_066d: ldloc.s 31
+			IL_066f: stelem.ref
+			IL_0670: dup
+			IL_0671: ldc.i4.s 31
+			IL_0673: ldloc.s 32
+			IL_0675: stelem.ref
+			IL_0676: dup
+			IL_0677: ldc.i4.s 32
+			IL_0679: ldloc.s 33
+			IL_067b: stelem.ref
+			IL_067c: pop
+			IL_067d: ldloc.0
+			IL_067e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0683: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0688: ret
 
-			IL_0692: ldloc.0
-			IL_0693: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_0698: stloc.s 12
-			IL_069a: ldarg.0
-			IL_069b: ldc.i4.1
-			IL_069c: ldelem.ref
-			IL_069d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_06a2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_06a7: stloc.s 22
-			IL_06a9: ldc.i4.1
-			IL_06aa: newarr [System.Runtime]System.Object
-			IL_06af: dup
-			IL_06b0: ldc.i4.0
-			IL_06b1: ldarg.0
-			IL_06b2: ldc.i4.1
-			IL_06b3: ldelem.ref
-			IL_06b4: stelem.ref
-			IL_06b5: stloc.s 21
-			IL_06b7: volatile.
-			IL_06b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_06be: brfalse IL_06d3
+			IL_0689: ldloc.0
+			IL_068a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_068f: stloc.s 12
+			IL_0691: volatile.
+			IL_0693: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_0698: brfalse IL_06ad
 
-			IL_06c3: ldloc.1
-			IL_06c4: ldstr "section"
-			IL_06c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06ce: br IL_06e8
+			IL_069d: ldloc.1
+			IL_069e: ldstr "section"
+			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06a8: br IL_06c2
 
-			IL_06d3: ldloc.1
-			IL_06d4: ldstr "section"
-			IL_06d9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:114"
-			IL_06de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-			IL_06e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06ad: ldloc.1
+			IL_06ae: ldstr "section"
+			IL_06b3: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:110"
+			IL_06b8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06e8: stloc.s 26
-			IL_06ea: ldloc.s 26
-			IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06f1: stloc.s 26
-			IL_06f3: ldc.i4.0
-			IL_06f4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_06f9: brfalse IL_072b
+			IL_06c2: stloc.s 21
+			IL_06c4: ldloc.s 21
+			IL_06c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06cb: stloc.s 21
+			IL_06cd: ldc.i4.0
+			IL_06ce: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_06d3: brfalse IL_0705
 
-			IL_06fe: ldloc.s 26
-			IL_0700: isinst [System.Runtime]System.String
-			IL_0705: dup
-			IL_0706: brtrue IL_071e
+			IL_06d8: ldloc.s 21
+			IL_06da: isinst [System.Runtime]System.String
+			IL_06df: dup
+			IL_06e0: brtrue IL_06f8
 
-			IL_070b: pop
-			IL_070c: ldloc.s 26
-			IL_070e: ldstr "trim"
-			IL_0713: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0718: dup
-			IL_0719: brfalse IL_072a
+			IL_06e5: pop
+			IL_06e6: ldloc.s 21
+			IL_06e8: ldstr "trim"
+			IL_06ed: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_06f2: dup
+			IL_06f3: brfalse IL_0704
 
-			IL_071e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0723: stloc.s 26
-			IL_0725: br IL_0739
+			IL_06f8: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_06fd: stloc.s 21
+			IL_06ff: br IL_0713
 
-			IL_072a: pop
+			IL_0704: pop
 
-			IL_072b: ldloc.s 26
-			IL_072d: ldstr "trim"
-			IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0737: stloc.s 26
+			IL_0705: ldloc.s 21
+			IL_0707: ldstr "trim"
+			IL_070c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0711: stloc.s 21
 
-			IL_0739: ldloc.s 22
-			IL_073b: ldloc.s 21
-			IL_073d: ldloc.s 12
-			IL_073f: ldloc.s 26
-			IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0746: stloc.s 13
-			IL_0748: ldloc.s 13
-			IL_074a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_074f: ldc.i4.0
-			IL_0750: ceq
-			IL_0752: stloc.s 23
-			IL_0754: ldloc.s 23
-			IL_0756: brfalse IL_07f8
+			IL_0713: ldc.i4.1
+			IL_0714: newarr [System.Runtime]System.Object
+			IL_0719: dup
+			IL_071a: ldc.i4.0
+			IL_071b: ldarg.0
+			IL_071c: ldc.i4.1
+			IL_071d: ldelem.ref
+			IL_071e: stelem.ref
+			IL_071f: stloc.s 22
+			IL_0721: ldloc.s 22
+			IL_0723: ldc.i4.0
+			IL_0724: ldelem.ref
+			IL_0725: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_072a: ldnull
+			IL_072b: ldloc.s 12
+			IL_072d: ldloc.s 21
+			IL_072f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0734: stloc.s 13
+			IL_0736: ldloc.s 13
+			IL_0738: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_073d: ldc.i4.0
+			IL_073e: ceq
+			IL_0740: stloc.s 23
+			IL_0742: ldloc.s 23
+			IL_0744: brfalse IL_07e6
 
-			IL_075b: volatile.
-			IL_075d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_0762: brfalse IL_0777
+			IL_0749: volatile.
+			IL_074b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_0750: brfalse IL_0765
 
-			IL_0767: ldloc.1
-			IL_0768: ldstr "section"
-			IL_076d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0772: br IL_078c
+			IL_0755: ldloc.1
+			IL_0756: ldstr "section"
+			IL_075b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0760: br IL_077a
 
-			IL_0777: ldloc.1
-			IL_0778: ldstr "section"
-			IL_077d: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:125"
-			IL_0782: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0765: ldloc.1
+			IL_0766: ldstr "section"
+			IL_076b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:122"
+			IL_0770: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+			IL_0775: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_078c: stloc.s 26
-			IL_078e: ldloc.s 26
-			IL_0790: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0795: stloc.s 27
-			IL_0797: ldstr "Could not find section '"
-			IL_079c: ldloc.s 27
-			IL_079e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07a3: ldstr "' in multipage index: "
-			IL_07a8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07ad: ldloc.s 11
-			IL_07af: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_07b4: stloc.s 27
-			IL_07b6: ldloc.s 27
-			IL_07b8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07bd: stloc.s 27
-			IL_07bf: ldloc.s 27
-			IL_07c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_07c6: stloc.s 14
-			IL_07c8: ldloc.0
-			IL_07c9: ldc.i4.m1
-			IL_07ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07cf: ldloc.0
-			IL_07d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_07da: ldarg.0
-			IL_07db: ldc.i4.1
-			IL_07dc: newarr [System.Runtime]System.Object
-			IL_07e1: dup
-			IL_07e2: ldc.i4.0
-			IL_07e3: ldloc.s 14
-			IL_07e5: stelem.ref
-			IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_07eb: pop
-			IL_07ec: ldloc.0
-			IL_07ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07f2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07f7: ret
+			IL_077a: stloc.s 21
+			IL_077c: ldloc.s 21
+			IL_077e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0783: stloc.s 26
+			IL_0785: ldstr "Could not find section '"
+			IL_078a: ldloc.s 26
+			IL_078c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0791: ldstr "' in multipage index: "
+			IL_0796: call string [System.Runtime]System.String::Concat(string, string)
+			IL_079b: ldloc.s 11
+			IL_079d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07a2: stloc.s 26
+			IL_07a4: ldloc.s 26
+			IL_07a6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07ab: stloc.s 26
+			IL_07ad: ldloc.s 26
+			IL_07af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_07b4: stloc.s 14
+			IL_07b6: ldloc.0
+			IL_07b7: ldc.i4.m1
+			IL_07b8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07bd: ldloc.0
+			IL_07be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_07c8: ldarg.0
+			IL_07c9: ldc.i4.1
+			IL_07ca: newarr [System.Runtime]System.Object
+			IL_07cf: dup
+			IL_07d0: ldc.i4.0
+			IL_07d1: ldloc.s 14
+			IL_07d3: stelem.ref
+			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_07d9: pop
+			IL_07da: ldloc.0
+			IL_07db: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07e0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07e5: ret
 
-			IL_07f8: ldarg.0
-			IL_07f9: ldc.i4.1
-			IL_07fa: ldelem.ref
-			IL_07fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0800: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_0805: stloc.s 26
-			IL_0807: volatile.
-			IL_0809: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_080e: brfalse IL_0824
+			IL_07e6: ldarg.0
+			IL_07e7: ldc.i4.1
+			IL_07e8: ldelem.ref
+			IL_07e9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07ee: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_07f3: stloc.s 21
+			IL_07f5: volatile.
+			IL_07f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_07fc: brfalse IL_0812
 
-			IL_0813: ldloc.s 13
-			IL_0815: ldstr "filePart"
-			IL_081a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_081f: br IL_083a
+			IL_0801: ldloc.s 13
+			IL_0803: ldstr "filePart"
+			IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_080d: br IL_0828
 
-			IL_0824: ldloc.s 13
-			IL_0826: ldstr "filePart"
-			IL_082b: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:139"
-			IL_0830: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0812: ldloc.s 13
+			IL_0814: ldstr "filePart"
+			IL_0819: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:136"
+			IL_081e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+			IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_083a: stloc.s 22
-			IL_083c: ldloc.s 22
-			IL_083e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0843: stloc.s 23
-			IL_0845: ldloc.s 23
-			IL_0847: brtrue IL_088a
+			IL_0828: stloc.s 27
+			IL_082a: ldloc.s 27
+			IL_082c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0831: stloc.s 23
+			IL_0833: ldloc.s 23
+			IL_0835: brtrue IL_0878
 
-			IL_084c: volatile.
-			IL_084e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_0853: brfalse IL_0869
+			IL_083a: volatile.
+			IL_083c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0841: brfalse IL_0857
 
-			IL_0858: ldloc.s 13
-			IL_085a: ldstr "href"
-			IL_085f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0864: br IL_087f
+			IL_0846: ldloc.s 13
+			IL_0848: ldstr "href"
+			IL_084d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0852: br IL_086d
 
-			IL_0869: ldloc.s 13
-			IL_086b: ldstr "href"
-			IL_0870: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:143"
-			IL_0875: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-			IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0857: ldloc.s 13
+			IL_0859: ldstr "href"
+			IL_085e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:140"
+			IL_0863: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+			IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_087f: stloc.s 28
-			IL_0881: ldloc.s 28
-			IL_0883: stloc.s 29
-			IL_0885: br IL_088e
+			IL_086d: stloc.s 28
+			IL_086f: ldloc.s 28
+			IL_0871: stloc.s 29
+			IL_0873: br IL_087c
 
-			IL_088a: ldloc.s 22
-			IL_088c: stloc.s 29
+			IL_0878: ldloc.s 27
+			IL_087a: stloc.s 29
 
-			IL_088e: ldloc.s 26
-			IL_0890: dup
-			IL_0891: ldloc.s 29
-			IL_0893: ldloc.s 11
-			IL_0895: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-			IL_089a: stloc.s 26
-			IL_089c: ldloc.s 26
-			IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_08a3: stloc.s 26
-			IL_08a5: volatile.
-			IL_08a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-			IL_08ac: brfalse IL_08c2
+			IL_087c: ldloc.s 21
+			IL_087e: dup
+			IL_087f: ldloc.s 29
+			IL_0881: ldloc.s 11
+			IL_0883: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+			IL_0888: stloc.s 21
+			IL_088a: ldloc.s 21
+			IL_088c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0891: stloc.s 21
+			IL_0893: volatile.
+			IL_0895: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_089a: brfalse IL_08b0
 
-			IL_08b1: ldloc.s 26
-			IL_08b3: ldstr "toString"
-			IL_08b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_08bd: br IL_08d8
+			IL_089f: ldloc.s 21
+			IL_08a1: ldstr "toString"
+			IL_08a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_08ab: br IL_08c6
 
-			IL_08c2: ldloc.s 26
-			IL_08c4: ldstr "toString"
-			IL_08c9: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:151"
-			IL_08ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_08b0: ldloc.s 21
+			IL_08b2: ldstr "toString"
+			IL_08b7: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:148"
+			IL_08bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+			IL_08c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_08d8: stloc.s 15
-			IL_08da: ldarg.0
-			IL_08db: ldc.i4.1
-			IL_08dc: ldelem.ref
-			IL_08dd: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_08e2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_08e7: ldc.i4.1
-			IL_08e8: newarr [System.Runtime]System.Object
-			IL_08ed: dup
-			IL_08ee: ldc.i4.0
-			IL_08ef: ldarg.0
-			IL_08f0: ldc.i4.1
-			IL_08f1: ldelem.ref
-			IL_08f2: stelem.ref
-			IL_08f3: stloc.s 21
-			IL_08f5: ldloc.s 21
-			IL_08f7: ldloc.s 15
-			IL_08f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_08fe: stloc.s 26
-			IL_0900: ldloc.0
-			IL_0901: ldc.i4.2
-			IL_0902: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0907: ldloc.0
-			IL_0908: ldloc.s 26
-			IL_090a: ldarg.0
-			IL_090b: ldc.i4.2
-			IL_090c: ldloc.0
-			IL_090d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0912: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0917: ldloc.0
-			IL_0918: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08c6: stloc.s 15
+			IL_08c8: ldc.i4.1
+			IL_08c9: newarr [System.Runtime]System.Object
+			IL_08ce: dup
+			IL_08cf: ldc.i4.0
+			IL_08d0: ldarg.0
+			IL_08d1: ldc.i4.1
+			IL_08d2: ldelem.ref
+			IL_08d3: stelem.ref
+			IL_08d4: stloc.s 22
+			IL_08d6: ldloc.s 22
+			IL_08d8: ldc.i4.0
+			IL_08d9: ldelem.ref
+			IL_08da: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08df: ldnull
+			IL_08e0: ldloc.s 15
+			IL_08e2: ldnull
+			IL_08e3: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_08e8: stloc.s 21
+			IL_08ea: ldloc.0
+			IL_08eb: ldc.i4.2
+			IL_08ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08f1: ldloc.0
+			IL_08f2: ldloc.s 21
+			IL_08f4: ldarg.0
+			IL_08f5: ldc.i4.2
+			IL_08f6: ldloc.0
+			IL_08f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0901: ldloc.0
+			IL_0902: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0907: dup
+			IL_0908: ldc.i4.0
+			IL_0909: ldloc.1
+			IL_090a: stelem.ref
+			IL_090b: dup
+			IL_090c: ldc.i4.1
+			IL_090d: ldloc.2
+			IL_090e: stelem.ref
+			IL_090f: dup
+			IL_0910: ldc.i4.2
+			IL_0911: ldloc.3
+			IL_0912: stelem.ref
+			IL_0913: dup
+			IL_0914: ldc.i4.3
+			IL_0915: ldloc.s 4
+			IL_0917: stelem.ref
+			IL_0918: dup
+			IL_0919: ldc.i4.4
+			IL_091a: ldloc.s 5
+			IL_091c: stelem.ref
 			IL_091d: dup
-			IL_091e: ldc.i4.0
-			IL_091f: ldloc.1
-			IL_0920: stelem.ref
-			IL_0921: dup
-			IL_0922: ldc.i4.1
-			IL_0923: ldloc.2
-			IL_0924: stelem.ref
-			IL_0925: dup
-			IL_0926: ldc.i4.2
-			IL_0927: ldloc.3
-			IL_0928: stelem.ref
-			IL_0929: dup
-			IL_092a: ldc.i4.3
-			IL_092b: ldloc.s 4
-			IL_092d: stelem.ref
-			IL_092e: dup
-			IL_092f: ldc.i4.4
-			IL_0930: ldloc.s 5
-			IL_0932: stelem.ref
-			IL_0933: dup
-			IL_0934: ldc.i4.5
-			IL_0935: ldloc.s 6
-			IL_0937: stelem.ref
-			IL_0938: dup
-			IL_0939: ldc.i4.6
-			IL_093a: ldloc.s 7
+			IL_091e: ldc.i4.5
+			IL_091f: ldloc.s 6
+			IL_0921: stelem.ref
+			IL_0922: dup
+			IL_0923: ldc.i4.6
+			IL_0924: ldloc.s 7
+			IL_0926: stelem.ref
+			IL_0927: dup
+			IL_0928: ldc.i4.7
+			IL_0929: ldloc.s 8
+			IL_092b: stelem.ref
+			IL_092c: dup
+			IL_092d: ldc.i4.8
+			IL_092e: ldloc.s 9
+			IL_0930: stelem.ref
+			IL_0931: dup
+			IL_0932: ldc.i4.s 9
+			IL_0934: ldloc.s 10
+			IL_0936: stelem.ref
+			IL_0937: dup
+			IL_0938: ldc.i4.s 10
+			IL_093a: ldloc.s 11
 			IL_093c: stelem.ref
 			IL_093d: dup
-			IL_093e: ldc.i4.7
-			IL_093f: ldloc.s 8
-			IL_0941: stelem.ref
-			IL_0942: dup
-			IL_0943: ldc.i4.8
-			IL_0944: ldloc.s 9
-			IL_0946: stelem.ref
-			IL_0947: dup
-			IL_0948: ldc.i4.s 9
-			IL_094a: ldloc.s 10
-			IL_094c: stelem.ref
-			IL_094d: dup
-			IL_094e: ldc.i4.s 10
-			IL_0950: ldloc.s 11
-			IL_0952: stelem.ref
-			IL_0953: dup
-			IL_0954: ldc.i4.s 11
-			IL_0956: ldloc.s 12
-			IL_0958: stelem.ref
-			IL_0959: dup
-			IL_095a: ldc.i4.s 12
-			IL_095c: ldloc.s 13
-			IL_095e: stelem.ref
-			IL_095f: dup
-			IL_0960: ldc.i4.s 13
-			IL_0962: ldloc.s 14
-			IL_0964: stelem.ref
-			IL_0965: dup
-			IL_0966: ldc.i4.s 14
-			IL_0968: ldloc.s 15
-			IL_096a: stelem.ref
-			IL_096b: dup
-			IL_096c: ldc.i4.s 15
-			IL_096e: ldloc.s 16
-			IL_0970: stelem.ref
-			IL_0971: dup
-			IL_0972: ldc.i4.s 16
-			IL_0974: ldloc.s 17
-			IL_0976: stelem.ref
-			IL_0977: dup
-			IL_0978: ldc.i4.s 17
-			IL_097a: ldloc.s 18
-			IL_097c: stelem.ref
-			IL_097d: dup
-			IL_097e: ldc.i4.s 18
-			IL_0980: ldloc.s 19
-			IL_0982: stelem.ref
-			IL_0983: dup
-			IL_0984: ldc.i4.s 19
-			IL_0986: ldloc.s 20
-			IL_0988: stelem.ref
-			IL_0989: dup
-			IL_098a: ldc.i4.s 20
-			IL_098c: ldloc.s 21
-			IL_098e: stelem.ref
-			IL_098f: dup
-			IL_0990: ldc.i4.s 21
-			IL_0992: ldloc.s 22
-			IL_0994: stelem.ref
-			IL_0995: dup
-			IL_0996: ldc.i4.s 22
-			IL_0998: ldloc.s 23
-			IL_099a: box [System.Runtime]System.Boolean
-			IL_099f: stelem.ref
-			IL_09a0: dup
-			IL_09a1: ldc.i4.s 23
-			IL_09a3: ldloc.s 24
-			IL_09a5: stelem.ref
-			IL_09a6: dup
-			IL_09a7: ldc.i4.s 24
-			IL_09a9: ldloc.s 25
-			IL_09ab: stelem.ref
-			IL_09ac: dup
-			IL_09ad: ldc.i4.s 25
-			IL_09af: ldloc.s 26
-			IL_09b1: stelem.ref
-			IL_09b2: dup
-			IL_09b3: ldc.i4.s 26
-			IL_09b5: ldloc.s 27
-			IL_09b7: stelem.ref
-			IL_09b8: dup
-			IL_09b9: ldc.i4.s 27
-			IL_09bb: ldloc.s 28
-			IL_09bd: stelem.ref
-			IL_09be: dup
-			IL_09bf: ldc.i4.s 28
-			IL_09c1: ldloc.s 29
-			IL_09c3: stelem.ref
-			IL_09c4: dup
-			IL_09c5: ldc.i4.s 29
-			IL_09c7: ldloc.s 30
-			IL_09c9: stelem.ref
-			IL_09ca: dup
-			IL_09cb: ldc.i4.s 30
-			IL_09cd: ldloc.s 31
-			IL_09cf: stelem.ref
-			IL_09d0: dup
-			IL_09d1: ldc.i4.s 31
-			IL_09d3: ldloc.s 32
-			IL_09d5: stelem.ref
-			IL_09d6: dup
-			IL_09d7: ldc.i4.s 32
-			IL_09d9: ldloc.s 33
-			IL_09db: stelem.ref
-			IL_09dc: pop
-			IL_09dd: ldloc.0
-			IL_09de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09e3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09e8: ret
+			IL_093e: ldc.i4.s 11
+			IL_0940: ldloc.s 12
+			IL_0942: stelem.ref
+			IL_0943: dup
+			IL_0944: ldc.i4.s 12
+			IL_0946: ldloc.s 13
+			IL_0948: stelem.ref
+			IL_0949: dup
+			IL_094a: ldc.i4.s 13
+			IL_094c: ldloc.s 14
+			IL_094e: stelem.ref
+			IL_094f: dup
+			IL_0950: ldc.i4.s 14
+			IL_0952: ldloc.s 15
+			IL_0954: stelem.ref
+			IL_0955: dup
+			IL_0956: ldc.i4.s 15
+			IL_0958: ldloc.s 16
+			IL_095a: stelem.ref
+			IL_095b: dup
+			IL_095c: ldc.i4.s 16
+			IL_095e: ldloc.s 17
+			IL_0960: stelem.ref
+			IL_0961: dup
+			IL_0962: ldc.i4.s 17
+			IL_0964: ldloc.s 18
+			IL_0966: stelem.ref
+			IL_0967: dup
+			IL_0968: ldc.i4.s 18
+			IL_096a: ldloc.s 19
+			IL_096c: stelem.ref
+			IL_096d: dup
+			IL_096e: ldc.i4.s 19
+			IL_0970: ldloc.s 20
+			IL_0972: stelem.ref
+			IL_0973: dup
+			IL_0974: ldc.i4.s 20
+			IL_0976: ldloc.s 21
+			IL_0978: stelem.ref
+			IL_0979: dup
+			IL_097a: ldc.i4.s 21
+			IL_097c: ldloc.s 22
+			IL_097e: stelem.ref
+			IL_097f: dup
+			IL_0980: ldc.i4.s 22
+			IL_0982: ldloc.s 23
+			IL_0984: box [System.Runtime]System.Boolean
+			IL_0989: stelem.ref
+			IL_098a: dup
+			IL_098b: ldc.i4.s 23
+			IL_098d: ldloc.s 24
+			IL_098f: stelem.ref
+			IL_0990: dup
+			IL_0991: ldc.i4.s 24
+			IL_0993: ldloc.s 25
+			IL_0995: stelem.ref
+			IL_0996: dup
+			IL_0997: ldc.i4.s 25
+			IL_0999: ldloc.s 26
+			IL_099b: stelem.ref
+			IL_099c: dup
+			IL_099d: ldc.i4.s 26
+			IL_099f: ldloc.s 27
+			IL_09a1: stelem.ref
+			IL_09a2: dup
+			IL_09a3: ldc.i4.s 27
+			IL_09a5: ldloc.s 28
+			IL_09a7: stelem.ref
+			IL_09a8: dup
+			IL_09a9: ldc.i4.s 28
+			IL_09ab: ldloc.s 29
+			IL_09ad: stelem.ref
+			IL_09ae: dup
+			IL_09af: ldc.i4.s 29
+			IL_09b1: ldloc.s 30
+			IL_09b3: stelem.ref
+			IL_09b4: dup
+			IL_09b5: ldc.i4.s 30
+			IL_09b7: ldloc.s 31
+			IL_09b9: stelem.ref
+			IL_09ba: dup
+			IL_09bb: ldc.i4.s 31
+			IL_09bd: ldloc.s 32
+			IL_09bf: stelem.ref
+			IL_09c0: dup
+			IL_09c1: ldc.i4.s 32
+			IL_09c3: ldloc.s 33
+			IL_09c5: stelem.ref
+			IL_09c6: pop
+			IL_09c7: ldloc.0
+			IL_09c8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09cd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09d2: ret
 
-			IL_09e9: ldloc.0
-			IL_09ea: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_09ef: stloc.s 26
-			IL_09f1: ldloc.s 26
-			IL_09f3: stloc.s 8
-			IL_09f5: ldloc.s 15
-			IL_09f7: stloc.s 26
-			IL_09f9: ldloc.s 26
-			IL_09fb: stloc.s 10
-			IL_09fd: ldloc.s 9
-			IL_09ff: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0a04: ldc.i4.0
-			IL_0a05: ceq
-			IL_0a07: stloc.s 23
-			IL_0a09: ldloc.s 23
-			IL_0a0b: brfalse IL_0a69
+			IL_09d3: ldloc.0
+			IL_09d4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_09d9: stloc.s 21
+			IL_09db: ldloc.s 21
+			IL_09dd: stloc.s 8
+			IL_09df: ldloc.s 15
+			IL_09e1: stloc.s 21
+			IL_09e3: ldloc.s 21
+			IL_09e5: stloc.s 10
+			IL_09e7: ldloc.s 9
+			IL_09e9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09ee: ldc.i4.0
+			IL_09ef: ceq
+			IL_09f1: stloc.s 23
+			IL_09f3: ldloc.s 23
+			IL_09f5: brfalse IL_0a53
 
-			IL_0a10: volatile.
-			IL_0a12: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-			IL_0a17: brfalse IL_0a2d
+			IL_09fa: volatile.
+			IL_09fc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0a01: brfalse IL_0a17
 
-			IL_0a1c: ldloc.s 13
-			IL_0a1e: ldstr "fragment"
-			IL_0a23: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a28: br IL_0a43
+			IL_0a06: ldloc.s 13
+			IL_0a08: ldstr "fragment"
+			IL_0a0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a12: br IL_0a2d
 
-			IL_0a2d: ldloc.s 13
-			IL_0a2f: ldstr "fragment"
-			IL_0a34: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:168"
-			IL_0a39: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-			IL_0a3e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0a17: ldloc.s 13
+			IL_0a19: ldstr "fragment"
+			IL_0a1e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:164"
+			IL_0a23: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+			IL_0a28: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0a43: stloc.s 26
-			IL_0a45: ldloc.s 26
-			IL_0a47: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0a4c: stloc.s 23
-			IL_0a4e: ldloc.s 23
-			IL_0a50: brtrue IL_0a61
+			IL_0a2d: stloc.s 21
+			IL_0a2f: ldloc.s 21
+			IL_0a31: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0a36: stloc.s 23
+			IL_0a38: ldloc.s 23
+			IL_0a3a: brtrue IL_0a4b
 
-			IL_0a55: ldstr ""
-			IL_0a5a: stloc.s 30
-			IL_0a5c: br IL_0a65
+			IL_0a3f: ldstr ""
+			IL_0a44: stloc.s 30
+			IL_0a46: br IL_0a4f
 
-			IL_0a61: ldloc.s 26
-			IL_0a63: stloc.s 30
+			IL_0a4b: ldloc.s 21
+			IL_0a4d: stloc.s 30
 
-			IL_0a65: ldloc.s 30
-			IL_0a67: stloc.s 9
+			IL_0a4f: ldloc.s 30
+			IL_0a51: stloc.s 9
 
-			IL_0a69: br IL_0c13
+			IL_0a53: br IL_0bf9
 
-			IL_0a6e: volatile.
-			IL_0a70: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-			IL_0a75: brfalse IL_0a8a
+			IL_0a58: volatile.
+			IL_0a5a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_0a5f: brfalse IL_0a74
 
-			IL_0a7a: ldloc.1
-			IL_0a7b: ldstr "url"
-			IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a85: br IL_0a9f
+			IL_0a64: ldloc.1
+			IL_0a65: ldstr "url"
+			IL_0a6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a6f: br IL_0a89
 
-			IL_0a8a: ldloc.1
-			IL_0a8b: ldstr "url"
-			IL_0a90: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:184"
-			IL_0a95: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-			IL_0a9a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0a74: ldloc.1
+			IL_0a75: ldstr "url"
+			IL_0a7a: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:180"
+			IL_0a7f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+			IL_0a84: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0a9f: stloc.s 26
-			IL_0aa1: ldloc.s 26
-			IL_0aa3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0aa8: stloc.s 26
-			IL_0aaa: ldc.i4.0
-			IL_0aab: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0ab0: brfalse IL_0ae2
+			IL_0a89: stloc.s 21
+			IL_0a8b: ldloc.s 21
+			IL_0a8d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a92: stloc.s 21
+			IL_0a94: ldc.i4.0
+			IL_0a95: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0a9a: brfalse IL_0acc
 
-			IL_0ab5: ldloc.s 26
-			IL_0ab7: isinst [System.Runtime]System.String
-			IL_0abc: dup
-			IL_0abd: brtrue IL_0ad5
+			IL_0a9f: ldloc.s 21
+			IL_0aa1: isinst [System.Runtime]System.String
+			IL_0aa6: dup
+			IL_0aa7: brtrue IL_0abf
 
-			IL_0ac2: pop
-			IL_0ac3: ldloc.s 26
-			IL_0ac5: ldstr "trim"
-			IL_0aca: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
-			IL_0acf: dup
-			IL_0ad0: brfalse IL_0ae1
+			IL_0aac: pop
+			IL_0aad: ldloc.s 21
+			IL_0aaf: ldstr "trim"
+			IL_0ab4: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0ab9: dup
+			IL_0aba: brfalse IL_0acb
 
-			IL_0ad5: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0ada: stloc.s 16
-			IL_0adc: br IL_0af0
+			IL_0abf: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0ac4: stloc.s 16
+			IL_0ac6: br IL_0ada
 
-			IL_0ae1: pop
+			IL_0acb: pop
 
-			IL_0ae2: ldloc.s 26
-			IL_0ae4: ldstr "trim"
-			IL_0ae9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0aee: stloc.s 16
+			IL_0acc: ldloc.s 21
+			IL_0ace: ldstr "trim"
+			IL_0ad3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0ad8: stloc.s 16
 
-			IL_0af0: ldarg.0
-			IL_0af1: ldc.i4.1
-			IL_0af2: ldelem.ref
-			IL_0af3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0af8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0afd: ldc.i4.1
-			IL_0afe: newarr [System.Runtime]System.Object
-			IL_0b03: dup
-			IL_0b04: ldc.i4.0
-			IL_0b05: ldarg.0
-			IL_0b06: ldc.i4.1
-			IL_0b07: ldelem.ref
-			IL_0b08: stelem.ref
-			IL_0b09: stloc.s 21
-			IL_0b0b: ldloc.s 21
-			IL_0b0d: ldloc.s 16
-			IL_0b0f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0b14: stloc.s 26
-			IL_0b16: ldloc.0
-			IL_0b17: ldc.i4.3
-			IL_0b18: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b1d: ldloc.0
-			IL_0b1e: ldloc.s 26
-			IL_0b20: ldarg.0
-			IL_0b21: ldc.i4.3
-			IL_0b22: ldloc.0
-			IL_0b23: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0b28: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0b2d: ldloc.0
-			IL_0b2e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0b33: dup
-			IL_0b34: ldc.i4.0
-			IL_0b35: ldloc.1
-			IL_0b36: stelem.ref
-			IL_0b37: dup
-			IL_0b38: ldc.i4.1
-			IL_0b39: ldloc.2
-			IL_0b3a: stelem.ref
-			IL_0b3b: dup
-			IL_0b3c: ldc.i4.2
-			IL_0b3d: ldloc.3
-			IL_0b3e: stelem.ref
-			IL_0b3f: dup
-			IL_0b40: ldc.i4.3
-			IL_0b41: ldloc.s 4
-			IL_0b43: stelem.ref
-			IL_0b44: dup
-			IL_0b45: ldc.i4.4
-			IL_0b46: ldloc.s 5
+			IL_0ada: ldc.i4.1
+			IL_0adb: newarr [System.Runtime]System.Object
+			IL_0ae0: dup
+			IL_0ae1: ldc.i4.0
+			IL_0ae2: ldarg.0
+			IL_0ae3: ldc.i4.1
+			IL_0ae4: ldelem.ref
+			IL_0ae5: stelem.ref
+			IL_0ae6: stloc.s 22
+			IL_0ae8: ldloc.s 22
+			IL_0aea: ldc.i4.0
+			IL_0aeb: ldelem.ref
+			IL_0aec: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0af1: ldnull
+			IL_0af2: ldloc.s 16
+			IL_0af4: ldnull
+			IL_0af5: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0afa: stloc.s 21
+			IL_0afc: ldloc.0
+			IL_0afd: ldc.i4.3
+			IL_0afe: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b03: ldloc.0
+			IL_0b04: ldloc.s 21
+			IL_0b06: ldarg.0
+			IL_0b07: ldc.i4.3
+			IL_0b08: ldloc.0
+			IL_0b09: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0b0e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0b13: ldloc.0
+			IL_0b14: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0b19: dup
+			IL_0b1a: ldc.i4.0
+			IL_0b1b: ldloc.1
+			IL_0b1c: stelem.ref
+			IL_0b1d: dup
+			IL_0b1e: ldc.i4.1
+			IL_0b1f: ldloc.2
+			IL_0b20: stelem.ref
+			IL_0b21: dup
+			IL_0b22: ldc.i4.2
+			IL_0b23: ldloc.3
+			IL_0b24: stelem.ref
+			IL_0b25: dup
+			IL_0b26: ldc.i4.3
+			IL_0b27: ldloc.s 4
+			IL_0b29: stelem.ref
+			IL_0b2a: dup
+			IL_0b2b: ldc.i4.4
+			IL_0b2c: ldloc.s 5
+			IL_0b2e: stelem.ref
+			IL_0b2f: dup
+			IL_0b30: ldc.i4.5
+			IL_0b31: ldloc.s 6
+			IL_0b33: stelem.ref
+			IL_0b34: dup
+			IL_0b35: ldc.i4.6
+			IL_0b36: ldloc.s 7
+			IL_0b38: stelem.ref
+			IL_0b39: dup
+			IL_0b3a: ldc.i4.7
+			IL_0b3b: ldloc.s 8
+			IL_0b3d: stelem.ref
+			IL_0b3e: dup
+			IL_0b3f: ldc.i4.8
+			IL_0b40: ldloc.s 9
+			IL_0b42: stelem.ref
+			IL_0b43: dup
+			IL_0b44: ldc.i4.s 9
+			IL_0b46: ldloc.s 10
 			IL_0b48: stelem.ref
 			IL_0b49: dup
-			IL_0b4a: ldc.i4.5
-			IL_0b4b: ldloc.s 6
-			IL_0b4d: stelem.ref
-			IL_0b4e: dup
-			IL_0b4f: ldc.i4.6
-			IL_0b50: ldloc.s 7
-			IL_0b52: stelem.ref
-			IL_0b53: dup
-			IL_0b54: ldc.i4.7
-			IL_0b55: ldloc.s 8
-			IL_0b57: stelem.ref
-			IL_0b58: dup
-			IL_0b59: ldc.i4.8
-			IL_0b5a: ldloc.s 9
-			IL_0b5c: stelem.ref
-			IL_0b5d: dup
-			IL_0b5e: ldc.i4.s 9
-			IL_0b60: ldloc.s 10
-			IL_0b62: stelem.ref
-			IL_0b63: dup
-			IL_0b64: ldc.i4.s 10
-			IL_0b66: ldloc.s 11
-			IL_0b68: stelem.ref
-			IL_0b69: dup
-			IL_0b6a: ldc.i4.s 11
-			IL_0b6c: ldloc.s 12
-			IL_0b6e: stelem.ref
-			IL_0b6f: dup
-			IL_0b70: ldc.i4.s 12
-			IL_0b72: ldloc.s 13
-			IL_0b74: stelem.ref
-			IL_0b75: dup
-			IL_0b76: ldc.i4.s 13
-			IL_0b78: ldloc.s 14
-			IL_0b7a: stelem.ref
-			IL_0b7b: dup
-			IL_0b7c: ldc.i4.s 14
-			IL_0b7e: ldloc.s 15
-			IL_0b80: stelem.ref
-			IL_0b81: dup
-			IL_0b82: ldc.i4.s 15
-			IL_0b84: ldloc.s 16
-			IL_0b86: stelem.ref
-			IL_0b87: dup
-			IL_0b88: ldc.i4.s 16
-			IL_0b8a: ldloc.s 17
-			IL_0b8c: stelem.ref
-			IL_0b8d: dup
-			IL_0b8e: ldc.i4.s 17
-			IL_0b90: ldloc.s 18
-			IL_0b92: stelem.ref
-			IL_0b93: dup
-			IL_0b94: ldc.i4.s 18
-			IL_0b96: ldloc.s 19
-			IL_0b98: stelem.ref
-			IL_0b99: dup
-			IL_0b9a: ldc.i4.s 19
-			IL_0b9c: ldloc.s 20
-			IL_0b9e: stelem.ref
-			IL_0b9f: dup
-			IL_0ba0: ldc.i4.s 20
-			IL_0ba2: ldloc.s 21
-			IL_0ba4: stelem.ref
-			IL_0ba5: dup
-			IL_0ba6: ldc.i4.s 21
-			IL_0ba8: ldloc.s 22
-			IL_0baa: stelem.ref
-			IL_0bab: dup
-			IL_0bac: ldc.i4.s 22
-			IL_0bae: ldloc.s 23
-			IL_0bb0: box [System.Runtime]System.Boolean
-			IL_0bb5: stelem.ref
-			IL_0bb6: dup
-			IL_0bb7: ldc.i4.s 23
-			IL_0bb9: ldloc.s 24
-			IL_0bbb: stelem.ref
-			IL_0bbc: dup
-			IL_0bbd: ldc.i4.s 24
-			IL_0bbf: ldloc.s 25
-			IL_0bc1: stelem.ref
-			IL_0bc2: dup
-			IL_0bc3: ldc.i4.s 25
-			IL_0bc5: ldloc.s 26
-			IL_0bc7: stelem.ref
-			IL_0bc8: dup
-			IL_0bc9: ldc.i4.s 26
-			IL_0bcb: ldloc.s 27
-			IL_0bcd: stelem.ref
-			IL_0bce: dup
-			IL_0bcf: ldc.i4.s 27
-			IL_0bd1: ldloc.s 28
-			IL_0bd3: stelem.ref
-			IL_0bd4: dup
-			IL_0bd5: ldc.i4.s 28
-			IL_0bd7: ldloc.s 29
-			IL_0bd9: stelem.ref
-			IL_0bda: dup
-			IL_0bdb: ldc.i4.s 29
-			IL_0bdd: ldloc.s 30
-			IL_0bdf: stelem.ref
-			IL_0be0: dup
-			IL_0be1: ldc.i4.s 30
-			IL_0be3: ldloc.s 31
-			IL_0be5: stelem.ref
-			IL_0be6: dup
-			IL_0be7: ldc.i4.s 31
-			IL_0be9: ldloc.s 32
-			IL_0beb: stelem.ref
-			IL_0bec: dup
-			IL_0bed: ldc.i4.s 32
-			IL_0bef: ldloc.s 33
-			IL_0bf1: stelem.ref
-			IL_0bf2: pop
-			IL_0bf3: ldloc.0
-			IL_0bf4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bf9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bfe: ret
+			IL_0b4a: ldc.i4.s 10
+			IL_0b4c: ldloc.s 11
+			IL_0b4e: stelem.ref
+			IL_0b4f: dup
+			IL_0b50: ldc.i4.s 11
+			IL_0b52: ldloc.s 12
+			IL_0b54: stelem.ref
+			IL_0b55: dup
+			IL_0b56: ldc.i4.s 12
+			IL_0b58: ldloc.s 13
+			IL_0b5a: stelem.ref
+			IL_0b5b: dup
+			IL_0b5c: ldc.i4.s 13
+			IL_0b5e: ldloc.s 14
+			IL_0b60: stelem.ref
+			IL_0b61: dup
+			IL_0b62: ldc.i4.s 14
+			IL_0b64: ldloc.s 15
+			IL_0b66: stelem.ref
+			IL_0b67: dup
+			IL_0b68: ldc.i4.s 15
+			IL_0b6a: ldloc.s 16
+			IL_0b6c: stelem.ref
+			IL_0b6d: dup
+			IL_0b6e: ldc.i4.s 16
+			IL_0b70: ldloc.s 17
+			IL_0b72: stelem.ref
+			IL_0b73: dup
+			IL_0b74: ldc.i4.s 17
+			IL_0b76: ldloc.s 18
+			IL_0b78: stelem.ref
+			IL_0b79: dup
+			IL_0b7a: ldc.i4.s 18
+			IL_0b7c: ldloc.s 19
+			IL_0b7e: stelem.ref
+			IL_0b7f: dup
+			IL_0b80: ldc.i4.s 19
+			IL_0b82: ldloc.s 20
+			IL_0b84: stelem.ref
+			IL_0b85: dup
+			IL_0b86: ldc.i4.s 20
+			IL_0b88: ldloc.s 21
+			IL_0b8a: stelem.ref
+			IL_0b8b: dup
+			IL_0b8c: ldc.i4.s 21
+			IL_0b8e: ldloc.s 22
+			IL_0b90: stelem.ref
+			IL_0b91: dup
+			IL_0b92: ldc.i4.s 22
+			IL_0b94: ldloc.s 23
+			IL_0b96: box [System.Runtime]System.Boolean
+			IL_0b9b: stelem.ref
+			IL_0b9c: dup
+			IL_0b9d: ldc.i4.s 23
+			IL_0b9f: ldloc.s 24
+			IL_0ba1: stelem.ref
+			IL_0ba2: dup
+			IL_0ba3: ldc.i4.s 24
+			IL_0ba5: ldloc.s 25
+			IL_0ba7: stelem.ref
+			IL_0ba8: dup
+			IL_0ba9: ldc.i4.s 25
+			IL_0bab: ldloc.s 26
+			IL_0bad: stelem.ref
+			IL_0bae: dup
+			IL_0baf: ldc.i4.s 26
+			IL_0bb1: ldloc.s 27
+			IL_0bb3: stelem.ref
+			IL_0bb4: dup
+			IL_0bb5: ldc.i4.s 27
+			IL_0bb7: ldloc.s 28
+			IL_0bb9: stelem.ref
+			IL_0bba: dup
+			IL_0bbb: ldc.i4.s 28
+			IL_0bbd: ldloc.s 29
+			IL_0bbf: stelem.ref
+			IL_0bc0: dup
+			IL_0bc1: ldc.i4.s 29
+			IL_0bc3: ldloc.s 30
+			IL_0bc5: stelem.ref
+			IL_0bc6: dup
+			IL_0bc7: ldc.i4.s 30
+			IL_0bc9: ldloc.s 31
+			IL_0bcb: stelem.ref
+			IL_0bcc: dup
+			IL_0bcd: ldc.i4.s 31
+			IL_0bcf: ldloc.s 32
+			IL_0bd1: stelem.ref
+			IL_0bd2: dup
+			IL_0bd3: ldc.i4.s 32
+			IL_0bd5: ldloc.s 33
+			IL_0bd7: stelem.ref
+			IL_0bd8: pop
+			IL_0bd9: ldloc.0
+			IL_0bda: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0bdf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0be4: ret
 
-			IL_0bff: ldloc.0
-			IL_0c00: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_0c05: stloc.s 26
-			IL_0c07: ldloc.s 26
-			IL_0c09: stloc.s 8
-			IL_0c0b: ldloc.s 16
-			IL_0c0d: stloc.s 26
-			IL_0c0f: ldloc.s 26
-			IL_0c11: stloc.s 10
+			IL_0be5: ldloc.0
+			IL_0be6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_0beb: stloc.s 21
+			IL_0bed: ldloc.s 21
+			IL_0bef: stloc.s 8
+			IL_0bf1: ldloc.s 16
+			IL_0bf3: stloc.s 21
+			IL_0bf5: ldloc.s 21
+			IL_0bf7: stloc.s 10
 
-			IL_0c13: ldloc.s 9
-			IL_0c15: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0c1a: ldc.i4.0
-			IL_0c1b: ceq
-			IL_0c1d: stloc.s 23
-			IL_0c1f: ldloc.s 23
-			IL_0c21: brfalse IL_0cb3
+			IL_0bf9: ldloc.s 9
+			IL_0bfb: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0c00: ldc.i4.0
+			IL_0c01: ceq
+			IL_0c03: stloc.s 23
+			IL_0c05: ldloc.s 23
+			IL_0c07: brfalse IL_0c99
 
-			IL_0c26: volatile.
-			IL_0c28: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-			IL_0c2d: brfalse IL_0c42
+			IL_0c0c: volatile.
+			IL_0c0e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0c13: brfalse IL_0c28
 
-			IL_0c32: ldloc.1
-			IL_0c33: ldstr "section"
-			IL_0c38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c3d: br IL_0c57
+			IL_0c18: ldloc.1
+			IL_0c19: ldstr "section"
+			IL_0c1e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c23: br IL_0c3d
 
-			IL_0c42: ldloc.1
-			IL_0c43: ldstr "section"
-			IL_0c48: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:205"
-			IL_0c4d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-			IL_0c52: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0c28: ldloc.1
+			IL_0c29: ldstr "section"
+			IL_0c2e: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:200"
+			IL_0c33: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+			IL_0c38: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0c57: stloc.s 26
-			IL_0c59: ldloc.s 26
-			IL_0c5b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0c60: stloc.s 27
-			IL_0c62: ldstr "Could not infer an element id for section '"
-			IL_0c67: ldloc.s 27
-			IL_0c69: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c6e: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0c73: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0c78: stloc.s 27
-			IL_0c7a: ldloc.s 27
-			IL_0c7c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0c81: stloc.s 17
-			IL_0c83: ldloc.0
-			IL_0c84: ldc.i4.m1
-			IL_0c85: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c8a: ldloc.0
-			IL_0c8b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c90: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0c95: ldarg.0
-			IL_0c96: ldc.i4.1
-			IL_0c97: newarr [System.Runtime]System.Object
-			IL_0c9c: dup
-			IL_0c9d: ldc.i4.0
-			IL_0c9e: ldloc.s 17
-			IL_0ca0: stelem.ref
-			IL_0ca1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0ca6: pop
-			IL_0ca7: ldloc.0
-			IL_0ca8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0cad: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0cb2: ret
+			IL_0c3d: stloc.s 21
+			IL_0c3f: ldloc.s 21
+			IL_0c41: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0c46: stloc.s 26
+			IL_0c48: ldstr "Could not infer an element id for section '"
+			IL_0c4d: ldloc.s 26
+			IL_0c4f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c54: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0c59: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0c5e: stloc.s 26
+			IL_0c60: ldloc.s 26
+			IL_0c62: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0c67: stloc.s 17
+			IL_0c69: ldloc.0
+			IL_0c6a: ldc.i4.m1
+			IL_0c6b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c70: ldloc.0
+			IL_0c71: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c76: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0c7b: ldarg.0
+			IL_0c7c: ldc.i4.1
+			IL_0c7d: newarr [System.Runtime]System.Object
+			IL_0c82: dup
+			IL_0c83: ldc.i4.0
+			IL_0c84: ldloc.s 17
+			IL_0c86: stelem.ref
+			IL_0c87: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c8c: pop
+			IL_0c8d: ldloc.0
+			IL_0c8e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c93: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c98: ret
 
-			IL_0cb3: ldarg.0
-			IL_0cb4: ldc.i4.1
-			IL_0cb5: ldelem.ref
-			IL_0cb6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0cbb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0cc0: ldc.i4.1
-			IL_0cc1: newarr [System.Runtime]System.Object
-			IL_0cc6: dup
-			IL_0cc7: ldc.i4.0
-			IL_0cc8: ldarg.0
-			IL_0cc9: ldc.i4.1
-			IL_0cca: ldelem.ref
-			IL_0ccb: stelem.ref
-			IL_0ccc: stloc.s 21
-			IL_0cce: ldloc.s 21
-			IL_0cd0: ldloc.s 8
-			IL_0cd2: ldloc.s 9
-			IL_0cd4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0cd9: stloc.s 18
-			IL_0cdb: ldarg.0
-			IL_0cdc: ldc.i4.1
-			IL_0cdd: ldelem.ref
-			IL_0cde: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ce3: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0ce8: stloc.s 31
-			IL_0cea: ldstr "process"
-			IL_0cef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0cf4: stloc.s 26
-			IL_0cf6: ldloc.s 26
-			IL_0cf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0cfd: stloc.s 26
-			IL_0cff: volatile.
-			IL_0d01: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_0d06: brfalse IL_0d1c
+			IL_0c99: ldc.i4.1
+			IL_0c9a: newarr [System.Runtime]System.Object
+			IL_0c9f: dup
+			IL_0ca0: ldc.i4.0
+			IL_0ca1: ldarg.0
+			IL_0ca2: ldc.i4.1
+			IL_0ca3: ldelem.ref
+			IL_0ca4: stelem.ref
+			IL_0ca5: stloc.s 22
+			IL_0ca7: ldloc.s 22
+			IL_0ca9: ldc.i4.0
+			IL_0caa: ldelem.ref
+			IL_0cab: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0cb0: ldnull
+			IL_0cb1: ldloc.s 8
+			IL_0cb3: ldloc.s 9
+			IL_0cb5: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0cba: stloc.s 18
+			IL_0cbc: ldarg.0
+			IL_0cbd: ldc.i4.1
+			IL_0cbe: ldelem.ref
+			IL_0cbf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0cc4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0cc9: stloc.s 31
+			IL_0ccb: ldstr "process"
+			IL_0cd0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0cd5: stloc.s 21
+			IL_0cd7: ldloc.s 21
+			IL_0cd9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0cde: stloc.s 21
+			IL_0ce0: volatile.
+			IL_0ce2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0ce7: brfalse IL_0cfd
 
-			IL_0d0b: ldloc.s 26
-			IL_0d0d: ldstr "cwd"
-			IL_0d12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0d17: br IL_0d32
+			IL_0cec: ldloc.s 21
+			IL_0cee: ldstr "cwd"
+			IL_0cf3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0cf8: br IL_0d13
 
-			IL_0d1c: ldloc.s 26
-			IL_0d1e: ldstr "cwd"
-			IL_0d23: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:224"
-			IL_0d28: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-			IL_0d2d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0cfd: ldloc.s 21
+			IL_0cff: ldstr "cwd"
+			IL_0d04: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:218"
+			IL_0d09: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+			IL_0d0e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0d32: stloc.s 26
-			IL_0d34: volatile.
-			IL_0d36: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_0d3b: brfalse IL_0d50
+			IL_0d13: stloc.s 21
+			IL_0d15: volatile.
+			IL_0d17: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0d1c: brfalse IL_0d31
 
-			IL_0d40: ldloc.1
-			IL_0d41: ldstr "outFile"
-			IL_0d46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d4b: br IL_0d65
+			IL_0d21: ldloc.1
+			IL_0d22: ldstr "outFile"
+			IL_0d27: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d2c: br IL_0d46
 
-			IL_0d50: ldloc.1
-			IL_0d51: ldstr "outFile"
-			IL_0d56: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:226"
-			IL_0d5b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_0d60: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0d31: ldloc.1
+			IL_0d32: ldstr "outFile"
+			IL_0d37: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:220"
+			IL_0d3c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0d41: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0d65: stloc.s 22
-			IL_0d67: ldloc.s 31
-			IL_0d69: ldc.i4.2
-			IL_0d6a: newarr [System.Runtime]System.Object
-			IL_0d6f: dup
-			IL_0d70: ldc.i4.0
-			IL_0d71: ldloc.s 26
-			IL_0d73: stelem.ref
-			IL_0d74: dup
-			IL_0d75: ldc.i4.1
-			IL_0d76: ldloc.s 22
-			IL_0d78: stelem.ref
-			IL_0d79: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0d7e: stloc.s 19
-			IL_0d80: ldarg.0
-			IL_0d81: ldc.i4.1
-			IL_0d82: ldelem.ref
-			IL_0d83: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0d88: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0d8d: ldc.i4.1
-			IL_0d8e: newarr [System.Runtime]System.Object
-			IL_0d93: dup
-			IL_0d94: ldc.i4.0
-			IL_0d95: ldarg.0
-			IL_0d96: ldc.i4.1
-			IL_0d97: ldelem.ref
-			IL_0d98: stelem.ref
-			IL_0d99: stloc.s 21
-			IL_0d9b: volatile.
-			IL_0d9d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-			IL_0da2: brfalse IL_0db8
+			IL_0d46: stloc.s 27
+			IL_0d48: ldloc.s 31
+			IL_0d4a: ldc.i4.2
+			IL_0d4b: newarr [System.Runtime]System.Object
+			IL_0d50: dup
+			IL_0d51: ldc.i4.0
+			IL_0d52: ldloc.s 21
+			IL_0d54: stelem.ref
+			IL_0d55: dup
+			IL_0d56: ldc.i4.1
+			IL_0d57: ldloc.s 27
+			IL_0d59: stelem.ref
+			IL_0d5a: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0d5f: stloc.s 19
+			IL_0d61: volatile.
+			IL_0d63: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_0d68: brfalse IL_0d7e
 
-			IL_0da7: ldloc.s 18
-			IL_0da9: ldstr "html"
-			IL_0dae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0db3: br IL_0dce
+			IL_0d6d: ldloc.s 18
+			IL_0d6f: ldstr "html"
+			IL_0d74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d79: br IL_0d94
 
-			IL_0db8: ldloc.s 18
-			IL_0dba: ldstr "html"
-			IL_0dbf: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:233"
-			IL_0dc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-			IL_0dc9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0d7e: ldloc.s 18
+			IL_0d80: ldstr "html"
+			IL_0d85: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:225"
+			IL_0d8a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+			IL_0d8f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0dce: stloc.s 22
-			IL_0dd0: volatile.
-			IL_0dd2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
-			IL_0dd7: brfalse IL_0dec
+			IL_0d94: stloc.s 27
+			IL_0d96: volatile.
+			IL_0d98: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_0d9d: brfalse IL_0db2
 
-			IL_0ddc: ldloc.1
-			IL_0ddd: ldstr "section"
-			IL_0de2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0de7: br IL_0e01
+			IL_0da2: ldloc.1
+			IL_0da3: ldstr "section"
+			IL_0da8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dad: br IL_0dc7
 
-			IL_0dec: ldloc.1
-			IL_0ded: ldstr "section"
-			IL_0df2: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:236"
-			IL_0df7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
-			IL_0dfc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0db2: ldloc.1
+			IL_0db3: ldstr "section"
+			IL_0db8: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:228"
+			IL_0dbd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+			IL_0dc2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e01: stloc.s 26
-			IL_0e03: ldloc.s 26
-			IL_0e05: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0e0a: stloc.s 27
-			IL_0e0c: ldstr "ECMA-262 "
-			IL_0e11: ldloc.s 27
-			IL_0e13: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0e18: stloc.s 27
-			IL_0e1a: ldloc.s 21
-			IL_0e1c: ldloc.s 22
-			IL_0e1e: ldloc.s 27
-			IL_0e20: ldloc.s 10
-			IL_0e22: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0e27: stloc.s 20
-			IL_0e29: ldarg.0
-			IL_0e2a: ldc.i4.1
-			IL_0e2b: ldelem.ref
-			IL_0e2c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0e31: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0e36: stloc.s 32
-			IL_0e38: ldloc.s 32
-			IL_0e3a: ldloc.s 19
-			IL_0e3c: ldloc.s 20
-			IL_0e3e: ldstr "utf8"
-			IL_0e43: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0e48: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0e4d: stloc.s 33
-			IL_0e4f: ldarg.0
-			IL_0e50: ldc.i4.1
-			IL_0e51: ldelem.ref
-			IL_0e52: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0e57: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0e5c: ldc.i4.1
-			IL_0e5d: newarr [System.Runtime]System.Object
-			IL_0e62: dup
-			IL_0e63: ldc.i4.0
-			IL_0e64: ldarg.0
-			IL_0e65: ldc.i4.1
-			IL_0e66: ldelem.ref
-			IL_0e67: stelem.ref
-			IL_0e68: stloc.s 21
-			IL_0e6a: volatile.
-			IL_0e6c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
-			IL_0e71: brfalse IL_0e86
+			IL_0dc7: stloc.s 21
+			IL_0dc9: ldloc.s 21
+			IL_0dcb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0dd0: stloc.s 26
+			IL_0dd2: ldstr "ECMA-262 "
+			IL_0dd7: ldloc.s 26
+			IL_0dd9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0dde: stloc.s 26
+			IL_0de0: ldnull
+			IL_0de1: ldloc.s 27
+			IL_0de3: ldloc.s 26
+			IL_0de5: ldloc.s 10
+			IL_0de7: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+			IL_0dec: stloc.s 20
+			IL_0dee: ldarg.0
+			IL_0def: ldc.i4.1
+			IL_0df0: ldelem.ref
+			IL_0df1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0df6: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0dfb: stloc.s 32
+			IL_0dfd: ldloc.s 32
+			IL_0dff: ldloc.s 19
+			IL_0e01: ldloc.s 20
+			IL_0e03: ldstr "utf8"
+			IL_0e08: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0e0d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0e12: stloc.s 33
+			IL_0e14: volatile.
+			IL_0e16: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_0e1b: brfalse IL_0e30
 
-			IL_0e76: ldloc.1
-			IL_0e77: ldstr "section"
-			IL_0e7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e81: br IL_0e9b
+			IL_0e20: ldloc.1
+			IL_0e21: ldstr "section"
+			IL_0e26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e2b: br IL_0e45
 
-			IL_0e86: ldloc.1
-			IL_0e87: ldstr "section"
-			IL_0e8c: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:251"
-			IL_0e91: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
-			IL_0e96: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0e30: ldloc.1
+			IL_0e31: ldstr "section"
+			IL_0e36: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:242"
+			IL_0e3b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+			IL_0e40: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0e9b: stloc.s 22
-			IL_0e9d: ldloc.s 22
-			IL_0e9f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ea4: stloc.s 27
-			IL_0ea6: ldstr "Extracted section "
-			IL_0eab: ldloc.s 27
-			IL_0ead: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0eb2: ldstr " (id="
-			IL_0eb7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ebc: ldloc.s 9
-			IL_0ebe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ec3: stloc.s 27
-			IL_0ec5: ldloc.s 27
-			IL_0ec7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ecc: ldstr ", tag="
-			IL_0ed1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ed6: volatile.
-			IL_0ed8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0edd: brfalse IL_0ef3
+			IL_0e45: stloc.s 27
+			IL_0e47: ldloc.s 27
+			IL_0e49: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0e4e: stloc.s 26
+			IL_0e50: ldstr "Extracted section "
+			IL_0e55: ldloc.s 26
+			IL_0e57: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0e5c: ldstr " (id="
+			IL_0e61: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0e66: ldloc.s 9
+			IL_0e68: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0e6d: stloc.s 26
+			IL_0e6f: ldloc.s 26
+			IL_0e71: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0e76: ldstr ", tag="
+			IL_0e7b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0e80: volatile.
+			IL_0e82: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0e87: brfalse IL_0e9d
 
-			IL_0ee2: ldloc.s 18
-			IL_0ee4: ldstr "tagName"
-			IL_0ee9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0eee: br IL_0f09
+			IL_0e8c: ldloc.s 18
+			IL_0e8e: ldstr "tagName"
+			IL_0e93: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e98: br IL_0eb3
 
-			IL_0ef3: ldloc.s 18
-			IL_0ef5: ldstr "tagName"
-			IL_0efa: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:261"
-			IL_0eff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0f04: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0e9d: ldloc.s 18
+			IL_0e9f: ldstr "tagName"
+			IL_0ea4: ldstr "Compile_Scripts_ExtractEcma262SectionHtml_TestHarness:<TwoPhaseDummy_M26>:__js_call__:252"
+			IL_0ea9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0eae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0f09: stloc.s 22
-			IL_0f0b: ldloc.s 22
-			IL_0f0d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0f12: stloc.s 27
-			IL_0f14: ldloc.s 27
-			IL_0f16: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0f1b: ldstr ") -> "
-			IL_0f20: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0f25: ldloc.s 19
-			IL_0f27: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0f2c: stloc.s 27
-			IL_0f2e: ldloc.s 27
-			IL_0f30: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0f35: stloc.s 27
-			IL_0f37: ldloc.s 21
-			IL_0f39: ldloc.s 27
-			IL_0f3b: ldloc.s 19
-			IL_0f3d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0f42: stloc.s 22
-			IL_0f44: ldloc.s 33
-			IL_0f46: ldloc.s 22
-			IL_0f48: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0f4d: pop
-			IL_0f4e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0f53: stloc.s 33
-			IL_0f55: ldarg.0
-			IL_0f56: ldc.i4.1
-			IL_0f57: ldelem.ref
-			IL_0f58: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0f5d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0f62: stloc.s 22
-			IL_0f64: ldc.i4.1
-			IL_0f65: newarr [System.Runtime]System.Object
-			IL_0f6a: dup
-			IL_0f6b: ldc.i4.0
-			IL_0f6c: ldarg.0
-			IL_0f6d: ldc.i4.1
-			IL_0f6e: ldelem.ref
-			IL_0f6f: stelem.ref
-			IL_0f70: stloc.s 21
-			IL_0f72: ldarg.0
-			IL_0f73: ldc.i4.1
-			IL_0f74: ldelem.ref
-			IL_0f75: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0f7a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0f7f: stloc.s 32
-			IL_0f81: ldloc.s 32
-			IL_0f83: ldloc.s 19
-			IL_0f85: ldstr "utf8"
-			IL_0f8a: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0f8f: stloc.s 26
-			IL_0f91: ldloc.s 22
-			IL_0f93: ldloc.s 21
-			IL_0f95: ldloc.s 26
-			IL_0f97: ldloc.s 19
-			IL_0f99: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0f9e: stloc.s 26
-			IL_0fa0: ldloc.s 33
-			IL_0fa2: ldloc.s 26
-			IL_0fa4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0fa9: pop
-			IL_0faa: ldloc.0
-			IL_0fab: ldc.i4.m1
-			IL_0fac: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0fb1: ldloc.0
-			IL_0fb2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0fb7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0fbc: ldarg.0
-			IL_0fbd: ldc.i4.1
-			IL_0fbe: newarr [System.Runtime]System.Object
-			IL_0fc3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0fc8: pop
-			IL_0fc9: ldloc.0
-			IL_0fca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0fcf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0fd4: ret
+			IL_0eb3: stloc.s 27
+			IL_0eb5: ldloc.s 27
+			IL_0eb7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ebc: stloc.s 26
+			IL_0ebe: ldloc.s 26
+			IL_0ec0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ec5: ldstr ") -> "
+			IL_0eca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ecf: ldloc.s 19
+			IL_0ed1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ed6: stloc.s 26
+			IL_0ed8: ldloc.s 26
+			IL_0eda: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0edf: stloc.s 26
+			IL_0ee1: ldnull
+			IL_0ee2: ldloc.s 26
+			IL_0ee4: ldloc.s 19
+			IL_0ee6: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0eeb: stloc.s 27
+			IL_0eed: ldloc.s 33
+			IL_0eef: ldloc.s 27
+			IL_0ef1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ef6: pop
+			IL_0ef7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0efc: stloc.s 33
+			IL_0efe: ldarg.0
+			IL_0eff: ldc.i4.1
+			IL_0f00: ldelem.ref
+			IL_0f01: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0f06: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0f0b: stloc.s 32
+			IL_0f0d: ldloc.s 32
+			IL_0f0f: ldloc.s 19
+			IL_0f11: ldstr "utf8"
+			IL_0f16: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0f1b: stloc.s 27
+			IL_0f1d: ldnull
+			IL_0f1e: ldloc.s 27
+			IL_0f20: ldloc.s 19
+			IL_0f22: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0f27: stloc.s 27
+			IL_0f29: ldloc.s 33
+			IL_0f2b: ldloc.s 27
+			IL_0f2d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0f32: pop
+			IL_0f33: ldloc.0
+			IL_0f34: ldc.i4.m1
+			IL_0f35: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0f3a: ldloc.0
+			IL_0f3b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0f40: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0f45: ldarg.0
+			IL_0f46: ldc.i4.1
+			IL_0f47: newarr [System.Runtime]System.Object
+			IL_0f4c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0f51: pop
+			IL_0f52: ldloc.0
+			IL_0f53: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0f58: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0f5d: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -911,7 +911,7 @@
 				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 12
-			// Code size: 401 (0x191)
+			// Code size: 367 (0x16f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -920,8 +920,7 @@
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[5] bool,
-				[6] object[],
-				[7] string
+				[6] string
 			)
 
 			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.Date::Construct()
@@ -989,86 +988,70 @@
 			IL_00bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_00c1: stloc.s 5
 			IL_00c3: ldloc.s 5
-			IL_00c5: brfalse IL_0136
+			IL_00c5: brfalse IL_0123
 
-			IL_00ca: ldarg.0
-			IL_00cb: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-			IL_00d0: ldc.i4.1
-			IL_00d1: newarr [System.Runtime]System.Object
-			IL_00d6: dup
-			IL_00d7: ldc.i4.0
-			IL_00d8: ldarg.0
-			IL_00d9: stelem.ref
-			IL_00da: stloc.s 6
-			IL_00dc: volatile.
-			IL_00de: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-			IL_00e3: brfalse IL_00f8
+			IL_00ca: volatile.
+			IL_00cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_00d1: brfalse IL_00e6
 
-			IL_00e8: ldarg.2
-			IL_00e9: ldstr "nodeVersionTarget"
-			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f3: br IL_010d
+			IL_00d6: ldarg.2
+			IL_00d7: ldstr "nodeVersionTarget"
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e1: br IL_00fb
 
-			IL_00f8: ldarg.2
-			IL_00f9: ldstr "nodeVersionTarget"
-			IL_00fe: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M8>:__js_call__:32"
-			IL_0103: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_00e6: ldarg.2
+			IL_00e7: ldstr "nodeVersionTarget"
+			IL_00ec: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M8>:__js_call__:30"
+			IL_00f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_010d: stloc.3
-			IL_010e: ldloc.s 6
-			IL_0110: ldloc.3
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0116: stloc.3
-			IL_0117: ldloc.3
-			IL_0118: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_011d: stloc.s 7
-			IL_011f: ldstr "Target: "
-			IL_0124: ldloc.s 7
-			IL_0126: call string [System.Runtime]System.String::Concat(string, string)
-			IL_012b: stloc.s 7
-			IL_012d: ldloc.1
-			IL_012e: ldloc.s 7
-			IL_0130: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0135: pop
+			IL_00fb: stloc.3
+			IL_00fc: ldnull
+			IL_00fd: ldloc.3
+			IL_00fe: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+			IL_0103: stloc.3
+			IL_0104: ldloc.3
+			IL_0105: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_010a: stloc.s 6
+			IL_010c: ldstr "Target: "
+			IL_0111: ldloc.s 6
+			IL_0113: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0118: stloc.s 6
+			IL_011a: ldloc.1
+			IL_011b: ldloc.s 6
+			IL_011d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0122: pop
 
-			IL_0136: ldarg.0
-			IL_0137: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-			IL_013c: ldc.i4.1
-			IL_013d: newarr [System.Runtime]System.Object
-			IL_0142: dup
-			IL_0143: ldc.i4.0
-			IL_0144: ldarg.0
-			IL_0145: stelem.ref
-			IL_0146: ldloc.0
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_014c: stloc.3
-			IL_014d: ldloc.3
-			IL_014e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0153: stloc.s 7
-			IL_0155: ldstr "Generated: "
-			IL_015a: ldloc.s 7
-			IL_015c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0161: stloc.s 7
-			IL_0163: ldloc.1
-			IL_0164: ldloc.s 7
-			IL_0166: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_016b: pop
-			IL_016c: ldloc.1
-			IL_016d: ldstr ""
-			IL_0172: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0177: pop
-			IL_0178: ldloc.1
-			IL_0179: ldc.i4.1
-			IL_017a: newarr [System.Runtime]System.Object
-			IL_017f: dup
-			IL_0180: ldc.i4.0
-			IL_0181: ldstr "\n"
-			IL_0186: stelem.ref
-			IL_0187: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_018c: stloc.s 7
-			IL_018e: ldloc.s 7
-			IL_0190: ret
+			IL_0123: ldnull
+			IL_0124: ldloc.0
+			IL_0125: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+			IL_012a: stloc.3
+			IL_012b: ldloc.3
+			IL_012c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0131: stloc.s 6
+			IL_0133: ldstr "Generated: "
+			IL_0138: ldloc.s 6
+			IL_013a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_013f: stloc.s 6
+			IL_0141: ldloc.1
+			IL_0142: ldloc.s 6
+			IL_0144: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0149: pop
+			IL_014a: ldloc.1
+			IL_014b: ldstr ""
+			IL_0150: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0155: pop
+			IL_0156: ldloc.1
+			IL_0157: ldc.i4.1
+			IL_0158: newarr [System.Runtime]System.Object
+			IL_015d: dup
+			IL_015e: ldc.i4.0
+			IL_015f: ldstr "\n"
+			IL_0164: stelem.ref
+			IL_0165: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_016a: stloc.s 6
+			IL_016c: ldloc.s 6
+			IL_016e: ret
 		} // end of method renderHeader::__js_call__
 
 	} // end of class renderHeader
@@ -1192,45 +1175,24 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 59 (0x3b)
+				// Code size: 27 (0x1b)
 				.maxstack 8
 				.locals init (
-					[0] object[],
-					[1] object,
-					[2] string
+					[0] object,
+					[1] string
 				)
 
-				IL_0000: ldarg.0
-				IL_0001: ldc.i4.0
-				IL_0002: ldelem.ref
-				IL_0003: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-				IL_0008: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-				IL_000d: ldc.i4.2
-				IL_000e: newarr [System.Runtime]System.Object
-				IL_0013: dup
-				IL_0014: ldc.i4.0
-				IL_0015: ldarg.0
-				IL_0016: ldc.i4.0
-				IL_0017: ldelem.ref
-				IL_0018: stelem.ref
-				IL_0019: dup
-				IL_001a: ldc.i4.1
-				IL_001b: ldarg.0
-				IL_001c: ldc.i4.1
-				IL_001d: ldelem.ref
-				IL_001e: stelem.ref
-				IL_001f: stloc.0
-				IL_0020: ldloc.0
-				IL_0021: ldarg.2
-				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0027: stloc.1
-				IL_0028: ldloc.1
-				IL_0029: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_002e: stloc.2
-				IL_002f: ldstr "- "
-				IL_0034: ldloc.2
-				IL_0035: call string [System.Runtime]System.String::Concat(string, string)
-				IL_003a: ret
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+				IL_0007: stloc.0
+				IL_0008: ldloc.0
+				IL_0009: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000e: stloc.1
+				IL_000f: ldstr "- "
+				IL_0014: ldloc.1
+				IL_0015: call string [System.Runtime]System.String::Concat(string, string)
+				IL_001a: ret
 			} // end of method ArrowFunction_L42C20::__js_call__
 
 		} // end of class ArrowFunction_L42C20
@@ -1376,125 +1338,116 @@
 				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 12
-			// Code size: 282 (0x11a)
+			// Code size: 266 (0x10a)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/Scope,
 				[1] object,
-				[2] object[],
-				[3] object,
-				[4] bool,
+				[2] object,
+				[3] bool,
+				[4] object[],
 				[5] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::asArray
-			IL_000c: ldc.i4.1
-			IL_000d: newarr [System.Runtime]System.Object
-			IL_0012: dup
-			IL_0013: ldc.i4.0
-			IL_0014: ldarg.0
-			IL_0015: stelem.ref
-			IL_0016: stloc.2
-			IL_0017: ldloc.2
-			IL_0018: ldarg.2
-			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_001e: stloc.1
-			IL_001f: volatile.
-			IL_0021: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-			IL_0026: brfalse IL_003b
+			IL_0006: ldnull
+			IL_0007: ldarg.2
+			IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/asArray::__js_call__(object, object)
+			IL_000d: stloc.1
+			IL_000e: volatile.
+			IL_0010: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_0015: brfalse IL_002a
 
-			IL_002b: ldloc.1
-			IL_002c: ldstr "length"
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0036: br IL_0050
+			IL_001a: ldloc.1
+			IL_001b: ldstr "length"
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0025: br IL_003f
 
-			IL_003b: ldloc.1
-			IL_003c: ldstr "length"
-			IL_0041: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M9>:__js_call__:9"
-			IL_0046: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_002a: ldloc.1
+			IL_002b: ldstr "length"
+			IL_0030: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M9>:__js_call__:8"
+			IL_0035: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0050: stloc.3
-			IL_0051: ldloc.3
-			IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0057: ldc.i4.0
-			IL_0058: ceq
-			IL_005a: stloc.s 4
-			IL_005c: ldloc.s 4
-			IL_005e: brfalse IL_0069
+			IL_003f: stloc.2
+			IL_0040: ldloc.2
+			IL_0041: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0046: ldc.i4.0
+			IL_0047: ceq
+			IL_0049: stloc.3
+			IL_004a: ldloc.3
+			IL_004b: brfalse IL_0056
 
-			IL_0063: ldstr ""
-			IL_0068: ret
+			IL_0050: ldstr ""
+			IL_0055: ret
 
-			IL_0069: ldloc.1
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006f: stloc.3
-			IL_0070: ldc.i4.2
-			IL_0071: newarr [System.Runtime]System.Object
-			IL_0076: dup
-			IL_0077: ldc.i4.0
-			IL_0078: ldarg.0
-			IL_0079: stelem.ref
-			IL_007a: dup
-			IL_007b: ldc.i4.1
-			IL_007c: ldloc.0
-			IL_007d: stelem.ref
-			IL_007e: stloc.2
-			IL_007f: ldloc.2
-			IL_0080: ldc.i4.0
-			IL_0081: ldelem.ref
-			IL_0082: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_0087: ldloc.2
-			IL_0088: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object[])
-			IL_008d: ldc.i4.1
-			IL_008e: conv.r8
-			IL_008f: ldstr ""
-			IL_0094: ldc.i4.0
-			IL_0095: ldc.i4.0
-			IL_0096: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_009b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20/FunctionObject>(!!0)
-			IL_00a0: stloc.s 5
-			IL_00a2: volatile.
-			IL_00a4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-			IL_00a9: brfalse IL_00c0
+			IL_0056: ldloc.1
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005c: stloc.2
+			IL_005d: ldc.i4.2
+			IL_005e: newarr [System.Runtime]System.Object
+			IL_0063: dup
+			IL_0064: ldc.i4.0
+			IL_0065: ldarg.0
+			IL_0066: stelem.ref
+			IL_0067: dup
+			IL_0068: ldc.i4.1
+			IL_0069: ldloc.0
+			IL_006a: stelem.ref
+			IL_006b: stloc.s 4
+			IL_006d: ldloc.s 4
+			IL_006f: ldc.i4.0
+			IL_0070: ldelem.ref
+			IL_0071: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_0076: ldloc.s 4
+			IL_0078: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object[])
+			IL_007d: ldc.i4.1
+			IL_007e: conv.r8
+			IL_007f: ldstr ""
+			IL_0084: ldc.i4.0
+			IL_0085: ldc.i4.0
+			IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20/FunctionObject>(!!0)
+			IL_0090: stloc.s 5
+			IL_0092: volatile.
+			IL_0094: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_0099: brfalse IL_00b0
 
-			IL_00ae: ldloc.3
-			IL_00af: ldstr "map"
-			IL_00b4: ldloc.s 5
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00bb: br IL_00d7
+			IL_009e: ldloc.2
+			IL_009f: ldstr "map"
+			IL_00a4: ldloc.s 5
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ab: br IL_00c7
 
-			IL_00c0: ldloc.3
-			IL_00c1: ldstr "map"
-			IL_00c6: ldloc.s 5
-			IL_00c8: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M9>:__js_call__:20"
-			IL_00cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_00b0: ldloc.2
+			IL_00b1: ldstr "map"
+			IL_00b6: ldloc.s 5
+			IL_00b8: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M9>:__js_call__:19"
+			IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_00d7: stloc.3
-			IL_00d8: ldloc.3
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00de: volatile.
-			IL_00e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-			IL_00e5: brfalse IL_00fe
+			IL_00c7: stloc.2
+			IL_00c8: ldloc.2
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ce: volatile.
+			IL_00d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_00d5: brfalse IL_00ee
 
-			IL_00ea: ldstr "join"
-			IL_00ef: ldstr "\n"
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f9: br IL_0117
+			IL_00da: ldstr "join"
+			IL_00df: ldstr "\n"
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e9: br IL_0107
 
-			IL_00fe: ldstr "join"
-			IL_0103: ldstr "\n"
-			IL_0108: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M9>:__js_call__:23"
-			IL_010d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_00ee: ldstr "join"
+			IL_00f3: ldstr "\n"
+			IL_00f8: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M9>:__js_call__:22"
+			IL_00fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0117: stloc.3
-			IL_0118: ldloc.3
-			IL_0119: ret
+			IL_0107: stloc.2
+			IL_0108: ldloc.2
+			IL_0109: ret
 		} // end of method renderImplementation::__js_call__
 
 	} // end of class renderImplementation
@@ -1684,7 +1637,7 @@
 				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 12
-			// Code size: 854 (0x356)
+			// Code size: 835 (0x343)
 			.maxstack 10
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1703,8 +1656,7 @@
 				[13] string,
 				[14] object,
 				[15] string,
-				[16] object,
-				[17] object[]
+				[16] object
 			)
 
 			IL_0000: ldarg.2
@@ -1791,7 +1743,7 @@
 					IL_00c5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_00ca: stloc.s 6
 					IL_00cc: ldloc.s 6
-					IL_00ce: brtrue IL_0323
+					IL_00ce: brtrue IL_0310
 
 					IL_00d3: ldloc.s 8
 					IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -1934,95 +1886,86 @@
 					IL_0275: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_027a: stloc.s 6
 					IL_027c: ldloc.s 6
-					IL_027e: brfalse IL_02e3
+					IL_027e: brfalse IL_02d0
 
-					IL_0283: ldarg.0
-					IL_0284: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
-					IL_0289: ldc.i4.1
-					IL_028a: newarr [System.Runtime]System.Object
-					IL_028f: dup
-					IL_0290: ldc.i4.0
-					IL_0291: ldarg.0
-					IL_0292: stelem.ref
-					IL_0293: stloc.s 17
-					IL_0295: volatile.
-					IL_0297: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-					IL_029c: brfalse IL_02b2
+					IL_0283: volatile.
+					IL_0285: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+					IL_028a: brfalse IL_02a0
 
-					IL_02a1: ldloc.s 4
-					IL_02a3: ldstr "docs"
-					IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_02ad: br IL_02c8
+					IL_028f: ldloc.s 4
+					IL_0291: ldstr "docs"
+					IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_029b: br IL_02b6
 
-					IL_02b2: ldloc.s 4
-					IL_02b4: ldstr "docs"
-					IL_02b9: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M10>:__js_call__:99"
-					IL_02be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-					IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_02a0: ldloc.s 4
+					IL_02a2: ldstr "docs"
+					IL_02a7: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M10>:__js_call__:97"
+					IL_02ac: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+					IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_02c8: stloc.s 8
-					IL_02ca: ldloc.s 17
-					IL_02cc: ldloc.s 8
-					IL_02ce: ldstr "docs"
-					IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-					IL_02d8: stloc.s 8
-					IL_02da: ldloc.s 8
-					IL_02dc: stloc.s 5
-					IL_02de: br IL_02ea
+					IL_02b6: stloc.s 8
+					IL_02b8: ldnull
+					IL_02b9: ldloc.s 8
+					IL_02bb: ldstr "docs"
+					IL_02c0: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
+					IL_02c5: stloc.s 8
+					IL_02c7: ldloc.s 8
+					IL_02c9: stloc.s 5
+					IL_02cb: br IL_02d7
 
-					IL_02e3: ldstr ""
-					IL_02e8: stloc.s 5
+					IL_02d0: ldstr ""
+					IL_02d5: stloc.s 5
 
-					IL_02ea: ldloc.s 5
-					IL_02ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_02f1: stloc.s 15
-					IL_02f3: ldloc.s 13
-					IL_02f5: ldloc.s 15
-					IL_02f7: call string [System.Runtime]System.String::Concat(string, string)
-					IL_02fc: ldstr " |"
-					IL_0301: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0306: stloc.s 15
-					IL_0308: ldloc.0
-					IL_0309: ldloc.s 15
-					IL_030b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0310: pop
-					IL_0311: br IL_00b9
+					IL_02d7: ldloc.s 5
+					IL_02d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_02de: stloc.s 15
+					IL_02e0: ldloc.s 13
+					IL_02e2: ldloc.s 15
+					IL_02e4: call string [System.Runtime]System.String::Concat(string, string)
+					IL_02e9: ldstr " |"
+					IL_02ee: call string [System.Runtime]System.String::Concat(string, string)
+					IL_02f3: stloc.s 15
+					IL_02f5: ldloc.0
+					IL_02f6: ldloc.s 15
+					IL_02f8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02fd: pop
+					IL_02fe: br IL_00b9
 				// end loop
-				IL_0316: ldloc.1
-				IL_0317: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_031c: ldc.i4.1
-				IL_031d: stloc.3
-				IL_031e: leave IL_033d
+				IL_0303: ldloc.1
+				IL_0304: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0309: ldc.i4.1
+				IL_030a: stloc.3
+				IL_030b: leave IL_032a
 
-				IL_0323: ldc.i4.1
-				IL_0324: stloc.2
-				IL_0325: leave IL_033d
+				IL_0310: ldc.i4.1
+				IL_0311: stloc.2
+				IL_0312: leave IL_032a
 			} // end .try
 			finally
 			{
-				IL_032a: ldloc.2
-				IL_032b: brtrue IL_033c
+				IL_0317: ldloc.2
+				IL_0318: brtrue IL_0329
 
-				IL_0330: ldloc.3
-				IL_0331: brtrue IL_033c
+				IL_031d: ldloc.3
+				IL_031e: brtrue IL_0329
 
-				IL_0336: ldloc.1
-				IL_0337: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_0323: ldloc.1
+				IL_0324: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_033c: endfinally
+				IL_0329: endfinally
 			} // end handler
 
-			IL_033d: ldloc.0
-			IL_033e: ldc.i4.1
-			IL_033f: newarr [System.Runtime]System.Object
-			IL_0344: dup
-			IL_0345: ldc.i4.0
-			IL_0346: ldstr "\n"
-			IL_034b: stelem.ref
-			IL_034c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0351: stloc.s 15
-			IL_0353: ldloc.s 15
-			IL_0355: ret
+			IL_032a: ldloc.0
+			IL_032b: ldc.i4.1
+			IL_032c: newarr [System.Runtime]System.Object
+			IL_0331: dup
+			IL_0332: ldc.i4.0
+			IL_0333: ldstr "\n"
+			IL_0338: stelem.ref
+			IL_0339: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_033e: stloc.s 15
+			IL_0340: ldloc.s 15
+			IL_0342: ret
 		} // end of method renderApisTable::__js_call__
 
 	} // end of class renderApisTable
@@ -2252,7 +2195,7 @@
 				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1150 (0x47e)
+			// Code size: 1089 (0x441)
 			.maxstack 12
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -2276,10 +2219,8 @@
 				[18] object,
 				[19] object,
 				[20] object,
-				[21] object[],
-				[22] object,
-				[23] object,
-				[24] string
+				[21] object,
+				[22] string
 			)
 
 			IL_0000: ldc.i4.0
@@ -2320,7 +2261,7 @@
 					IL_0042: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_0047: stloc.s 13
 					IL_0049: ldloc.s 13
-					IL_004b: brtrue IL_044b
+					IL_004b: brtrue IL_040e
 
 					IL_0050: ldloc.s 17
 					IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -2412,315 +2353,286 @@
 					IL_014e: ldloc.s 13
 					IL_0150: brfalse IL_015a
 
-					IL_0155: br IL_0439
+					IL_0155: br IL_03fc
 
-					IL_015a: ldarg.0
-					IL_015b: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-					IL_0160: stloc.s 17
-					IL_0162: ldc.i4.1
-					IL_0163: newarr [System.Runtime]System.Object
-					IL_0168: dup
-					IL_0169: ldc.i4.0
-					IL_016a: ldarg.0
-					IL_016b: stelem.ref
-					IL_016c: stloc.s 21
-					IL_016e: volatile.
-					IL_0170: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-					IL_0175: brfalse IL_018b
+					IL_015a: volatile.
+					IL_015c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+					IL_0161: brfalse IL_0177
 
-					IL_017a: ldloc.s 4
-					IL_017c: ldstr "name"
-					IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0186: br IL_01a1
+					IL_0166: ldloc.s 4
+					IL_0168: ldstr "name"
+					IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0172: br IL_018d
 
-					IL_018b: ldloc.s 4
-					IL_018d: ldstr "name"
-					IL_0192: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:56"
-					IL_0197: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
-					IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_0177: ldloc.s 4
+					IL_0179: ldstr "name"
+					IL_017e: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:54"
+					IL_0183: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_42
+					IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_01a1: stloc.s 22
-					IL_01a3: ldloc.s 22
-					IL_01a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01aa: stloc.s 13
-					IL_01ac: ldloc.s 13
-					IL_01ae: brtrue IL_01bf
+					IL_018d: stloc.s 17
+					IL_018f: ldloc.s 17
+					IL_0191: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0196: stloc.s 13
+					IL_0198: ldloc.s 13
+					IL_019a: brtrue IL_01ab
 
-					IL_01b3: ldstr ""
-					IL_01b8: stloc.s 23
-					IL_01ba: br IL_01c3
+					IL_019f: ldstr ""
+					IL_01a4: stloc.s 21
+					IL_01a6: br IL_01af
 
-					IL_01bf: ldloc.s 22
-					IL_01c1: stloc.s 23
+					IL_01ab: ldloc.s 17
+					IL_01ad: stloc.s 21
 
-					IL_01c3: ldloc.s 17
-					IL_01c5: ldloc.s 21
-					IL_01c7: ldloc.s 23
-					IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_01ce: stloc.s 17
-					IL_01d0: ldloc.s 17
-					IL_01d2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_01d7: stloc.s 24
-					IL_01d9: ldstr "- "
-					IL_01de: ldloc.s 24
-					IL_01e0: call string [System.Runtime]System.String::Concat(string, string)
-					IL_01e5: stloc.s 24
-					IL_01e7: ldloc.0
-					IL_01e8: ldloc.s 24
-					IL_01ea: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01ef: pop
-					IL_01f0: volatile.
-					IL_01f2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-					IL_01f7: brfalse IL_020d
+					IL_01af: ldnull
+					IL_01b0: ldloc.s 21
+					IL_01b2: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+					IL_01b7: stloc.s 17
+					IL_01b9: ldloc.s 17
+					IL_01bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_01c0: stloc.s 22
+					IL_01c2: ldstr "- "
+					IL_01c7: ldloc.s 22
+					IL_01c9: call string [System.Runtime]System.String::Concat(string, string)
+					IL_01ce: stloc.s 22
+					IL_01d0: ldloc.0
+					IL_01d1: ldloc.s 22
+					IL_01d3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01d8: pop
+					IL_01d9: volatile.
+					IL_01db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+					IL_01e0: brfalse IL_01f6
 
-					IL_01fc: ldloc.s 4
-					IL_01fe: ldstr "tests"
-					IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0208: br IL_0223
+					IL_01e5: ldloc.s 4
+					IL_01e7: ldstr "tests"
+					IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01f1: br IL_020c
 
-					IL_020d: ldloc.s 4
-					IL_020f: ldstr "tests"
-					IL_0214: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:71"
-					IL_0219: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
-					IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_01f6: ldloc.s 4
+					IL_01f8: ldstr "tests"
+					IL_01fd: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:70"
+					IL_0202: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_43
+					IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_0223: stloc.s 17
-					IL_0225: ldloc.s 17
-					IL_0227: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-					IL_022c: stloc.s 5
-					IL_022e: ldc.i4.0
-					IL_022f: stloc.s 6
-					IL_0231: ldc.i4.0
-					IL_0232: stloc.s 7
+					IL_020c: stloc.s 17
+					IL_020e: ldloc.s 17
+					IL_0210: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+					IL_0215: stloc.s 5
+					IL_0217: ldc.i4.0
+					IL_0218: stloc.s 6
+					IL_021a: ldc.i4.0
+					IL_021b: stloc.s 7
 					.try
 					{
-						// loop start (head: IL_0234)
-							IL_0234: ldc.i4.1
-							IL_0235: stloc.s 6
-							IL_0237: ldloc.s 5
-							IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-							IL_023e: stloc.s 17
-							IL_0240: ldloc.s 17
-							IL_0242: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-							IL_0247: stloc.s 13
-							IL_0249: ldloc.s 13
-							IL_024b: brtrue IL_041b
+						// loop start (head: IL_021d)
+							IL_021d: ldc.i4.1
+							IL_021e: stloc.s 6
+							IL_0220: ldloc.s 5
+							IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+							IL_0227: stloc.s 17
+							IL_0229: ldloc.s 17
+							IL_022b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+							IL_0230: stloc.s 13
+							IL_0232: ldloc.s 13
+							IL_0234: brtrue IL_03de
 
-							IL_0250: ldloc.s 17
-							IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-							IL_0257: stloc.s 17
-							IL_0259: ldc.i4.0
-							IL_025a: stloc.s 6
-							IL_025c: ldloc.s 17
-							IL_025e: stloc.s 8
-							IL_0260: volatile.
-							IL_0262: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-							IL_0267: brfalse IL_027d
+							IL_0239: ldloc.s 17
+							IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+							IL_0240: stloc.s 17
+							IL_0242: ldc.i4.0
+							IL_0243: stloc.s 6
+							IL_0245: ldloc.s 17
+							IL_0247: stloc.s 8
+							IL_0249: volatile.
+							IL_024b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+							IL_0250: brfalse IL_0266
 
-							IL_026c: ldloc.s 8
-							IL_026e: ldstr "name"
-							IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0278: br IL_0293
+							IL_0255: ldloc.s 8
+							IL_0257: ldstr "name"
+							IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_0261: br IL_027c
 
-							IL_027d: ldloc.s 8
-							IL_027f: ldstr "name"
-							IL_0284: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:89"
-							IL_0289: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
-							IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+							IL_0266: ldloc.s 8
+							IL_0268: ldstr "name"
+							IL_026d: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:88"
+							IL_0272: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_44
+							IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-							IL_0293: stloc.s 17
-							IL_0295: ldloc.s 17
-							IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_029c: stloc.s 13
-							IL_029e: ldloc.s 13
-							IL_02a0: brfalse IL_0300
+							IL_027c: stloc.s 17
+							IL_027e: ldloc.s 17
+							IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_0285: stloc.s 13
+							IL_0287: ldloc.s 13
+							IL_0289: brfalse IL_02d6
 
-							IL_02a5: ldarg.0
-							IL_02a6: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_02ab: ldc.i4.1
-							IL_02ac: newarr [System.Runtime]System.Object
-							IL_02b1: dup
-							IL_02b2: ldc.i4.0
-							IL_02b3: ldarg.0
-							IL_02b4: stelem.ref
-							IL_02b5: stloc.s 21
-							IL_02b7: volatile.
-							IL_02b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-							IL_02be: brfalse IL_02d4
+							IL_028e: volatile.
+							IL_0290: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+							IL_0295: brfalse IL_02ab
 
-							IL_02c3: ldloc.s 8
-							IL_02c5: ldstr "name"
-							IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02cf: br IL_02ea
+							IL_029a: ldloc.s 8
+							IL_029c: ldstr "name"
+							IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02a6: br IL_02c1
 
-							IL_02d4: ldloc.s 8
-							IL_02d6: ldstr "name"
-							IL_02db: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:95"
-							IL_02e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
-							IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+							IL_02ab: ldloc.s 8
+							IL_02ad: ldstr "name"
+							IL_02b2: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:92"
+							IL_02b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_45
+							IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-							IL_02ea: stloc.s 17
-							IL_02ec: ldloc.s 21
-							IL_02ee: ldloc.s 17
-							IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_02f5: stloc.s 17
-							IL_02f7: ldloc.s 17
-							IL_02f9: stloc.s 9
-							IL_02fb: br IL_0307
+							IL_02c1: stloc.s 17
+							IL_02c3: ldnull
+							IL_02c4: ldloc.s 17
+							IL_02c6: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+							IL_02cb: stloc.s 17
+							IL_02cd: ldloc.s 17
+							IL_02cf: stloc.s 9
+							IL_02d1: br IL_02dd
 
-							IL_0300: ldstr ""
-							IL_0305: stloc.s 9
+							IL_02d6: ldstr ""
+							IL_02db: stloc.s 9
 
-							IL_0307: ldloc.s 9
-							IL_0309: stloc.s 10
-							IL_030b: volatile.
-							IL_030d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-							IL_0312: brfalse IL_0328
+							IL_02dd: ldloc.s 9
+							IL_02df: stloc.s 10
+							IL_02e1: volatile.
+							IL_02e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+							IL_02e8: brfalse IL_02fe
 
-							IL_0317: ldloc.s 8
-							IL_0319: ldstr "file"
-							IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0323: br IL_033e
+							IL_02ed: ldloc.s 8
+							IL_02ef: ldstr "file"
+							IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02f9: br IL_0314
 
-							IL_0328: ldloc.s 8
-							IL_032a: ldstr "file"
-							IL_032f: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:106"
-							IL_0334: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
-							IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+							IL_02fe: ldloc.s 8
+							IL_0300: ldstr "file"
+							IL_0305: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:104"
+							IL_030a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_46
+							IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-							IL_033e: stloc.s 17
-							IL_0340: ldloc.s 17
-							IL_0342: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_0347: stloc.s 13
-							IL_0349: ldloc.s 13
-							IL_034b: brfalse IL_03cc
+							IL_0314: stloc.s 17
+							IL_0316: ldloc.s 17
+							IL_0318: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_031d: stloc.s 13
+							IL_031f: ldloc.s 13
+							IL_0321: brfalse IL_038f
 
-							IL_0350: ldarg.0
-							IL_0351: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_0356: ldc.i4.1
-							IL_0357: newarr [System.Runtime]System.Object
-							IL_035c: dup
-							IL_035d: ldc.i4.0
-							IL_035e: ldarg.0
-							IL_035f: stelem.ref
-							IL_0360: stloc.s 21
-							IL_0362: volatile.
-							IL_0364: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-							IL_0369: brfalse IL_037f
+							IL_0326: volatile.
+							IL_0328: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+							IL_032d: brfalse IL_0343
 
-							IL_036e: ldloc.s 8
-							IL_0370: ldstr "file"
-							IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_037a: br IL_0395
+							IL_0332: ldloc.s 8
+							IL_0334: ldstr "file"
+							IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_033e: br IL_0359
 
-							IL_037f: ldloc.s 8
-							IL_0381: ldstr "file"
-							IL_0386: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:113"
-							IL_038b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
-							IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+							IL_0343: ldloc.s 8
+							IL_0345: ldstr "file"
+							IL_034a: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M11>:__js_call__:109"
+							IL_034f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_47
+							IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-							IL_0395: stloc.s 17
-							IL_0397: ldloc.s 21
-							IL_0399: ldloc.s 17
-							IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_03a0: stloc.s 17
-							IL_03a2: ldloc.s 17
-							IL_03a4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_03a9: stloc.s 24
-							IL_03ab: ldstr " ("
-							IL_03b0: ldloc.s 24
-							IL_03b2: call string [System.Runtime]System.String::Concat(string, string)
-							IL_03b7: ldstr ")"
-							IL_03bc: call string [System.Runtime]System.String::Concat(string, string)
-							IL_03c1: stloc.s 24
-							IL_03c3: ldloc.s 24
-							IL_03c5: stloc.s 11
-							IL_03c7: br IL_03d3
+							IL_0359: stloc.s 17
+							IL_035b: ldnull
+							IL_035c: ldloc.s 17
+							IL_035e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+							IL_0363: stloc.s 17
+							IL_0365: ldloc.s 17
+							IL_0367: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_036c: stloc.s 22
+							IL_036e: ldstr " ("
+							IL_0373: ldloc.s 22
+							IL_0375: call string [System.Runtime]System.String::Concat(string, string)
+							IL_037a: ldstr ")"
+							IL_037f: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0384: stloc.s 22
+							IL_0386: ldloc.s 22
+							IL_0388: stloc.s 11
+							IL_038a: br IL_0396
 
-							IL_03cc: ldstr ""
-							IL_03d1: stloc.s 11
+							IL_038f: ldstr ""
+							IL_0394: stloc.s 11
 
-							IL_03d3: ldloc.s 11
-							IL_03d5: stloc.s 12
-							IL_03d7: ldloc.s 10
-							IL_03d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_03de: stloc.s 24
-							IL_03e0: ldstr "  - "
-							IL_03e5: ldloc.s 24
-							IL_03e7: call string [System.Runtime]System.String::Concat(string, string)
-							IL_03ec: ldloc.s 12
-							IL_03ee: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_03f3: stloc.s 24
-							IL_03f5: ldloc.s 24
-							IL_03f7: call string [System.Runtime]System.String::Concat(string, string)
-							IL_03fc: stloc.s 24
-							IL_03fe: ldloc.0
-							IL_03ff: ldloc.s 24
-							IL_0401: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-							IL_0406: pop
-							IL_0407: br IL_0234
+							IL_0396: ldloc.s 11
+							IL_0398: stloc.s 12
+							IL_039a: ldloc.s 10
+							IL_039c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_03a1: stloc.s 22
+							IL_03a3: ldstr "  - "
+							IL_03a8: ldloc.s 22
+							IL_03aa: call string [System.Runtime]System.String::Concat(string, string)
+							IL_03af: ldloc.s 12
+							IL_03b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_03b6: stloc.s 22
+							IL_03b8: ldloc.s 22
+							IL_03ba: call string [System.Runtime]System.String::Concat(string, string)
+							IL_03bf: stloc.s 22
+							IL_03c1: ldloc.0
+							IL_03c2: ldloc.s 22
+							IL_03c4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+							IL_03c9: pop
+							IL_03ca: br IL_021d
 						// end loop
-						IL_040c: ldloc.s 5
-						IL_040e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-						IL_0413: ldc.i4.1
-						IL_0414: stloc.s 7
-						IL_0416: leave IL_0439
+						IL_03cf: ldloc.s 5
+						IL_03d1: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+						IL_03d6: ldc.i4.1
+						IL_03d7: stloc.s 7
+						IL_03d9: leave IL_03fc
 
-						IL_041b: ldc.i4.1
-						IL_041c: stloc.s 6
-						IL_041e: leave IL_0439
+						IL_03de: ldc.i4.1
+						IL_03df: stloc.s 6
+						IL_03e1: leave IL_03fc
 					} // end .try
 					finally
 					{
-						IL_0423: ldloc.s 6
-						IL_0425: brtrue IL_0438
+						IL_03e6: ldloc.s 6
+						IL_03e8: brtrue IL_03fb
 
-						IL_042a: ldloc.s 7
-						IL_042c: brtrue IL_0438
+						IL_03ed: ldloc.s 7
+						IL_03ef: brtrue IL_03fb
 
-						IL_0431: ldloc.s 5
-						IL_0433: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+						IL_03f4: ldloc.s 5
+						IL_03f6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-						IL_0438: endfinally
+						IL_03fb: endfinally
 					} // end handler
 
-					IL_0439: br IL_0036
+					IL_03fc: br IL_0036
 				// end loop
-				IL_043e: ldloc.1
-				IL_043f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0444: ldc.i4.1
-				IL_0445: stloc.3
-				IL_0446: leave IL_0465
+				IL_0401: ldloc.1
+				IL_0402: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_0407: ldc.i4.1
+				IL_0408: stloc.3
+				IL_0409: leave IL_0428
 
-				IL_044b: ldc.i4.1
-				IL_044c: stloc.2
-				IL_044d: leave IL_0465
+				IL_040e: ldc.i4.1
+				IL_040f: stloc.2
+				IL_0410: leave IL_0428
 			} // end .try
 			finally
 			{
-				IL_0452: ldloc.2
-				IL_0453: brtrue IL_0464
+				IL_0415: ldloc.2
+				IL_0416: brtrue IL_0427
 
-				IL_0458: ldloc.3
-				IL_0459: brtrue IL_0464
+				IL_041b: ldloc.3
+				IL_041c: brtrue IL_0427
 
-				IL_045e: ldloc.1
-				IL_045f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_0421: ldloc.1
+				IL_0422: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0464: endfinally
+				IL_0427: endfinally
 			} // end handler
 
-			IL_0465: ldloc.0
-			IL_0466: ldc.i4.1
-			IL_0467: newarr [System.Runtime]System.Object
-			IL_046c: dup
-			IL_046d: ldc.i4.0
-			IL_046e: ldstr "\n"
-			IL_0473: stelem.ref
-			IL_0474: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0479: stloc.s 24
-			IL_047b: ldloc.s 24
-			IL_047d: ret
+			IL_0428: ldloc.0
+			IL_0429: ldc.i4.1
+			IL_042a: newarr [System.Runtime]System.Object
+			IL_042f: dup
+			IL_0430: ldc.i4.0
+			IL_0431: ldstr "\n"
+			IL_0436: stelem.ref
+			IL_0437: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_043c: stloc.s 22
+			IL_043e: ldloc.s 22
+			IL_0440: ret
 		} // end of method renderApiTests::__js_call__
 
 	} // end of class renderApiTests
@@ -2969,7 +2881,7 @@
 				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1114 (0x45a)
+			// Code size: 1049 (0x419)
 			.maxstack 10
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -2985,10 +2897,8 @@
 				[10] object,
 				[11] object,
 				[12] string,
-				[13] object[],
-				[14] object,
-				[15] object,
-				[16] object
+				[13] object,
+				[14] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -3053,7 +2963,7 @@
 					IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_0094: stloc.s 8
 					IL_0096: ldloc.s 8
-					IL_0098: brtrue IL_0427
+					IL_0098: brtrue IL_03e6
 
 					IL_009d: ldloc.s 7
 					IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -3134,278 +3044,245 @@
 					IL_0191: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_0196: stloc.s 8
 					IL_0198: ldloc.s 8
-					IL_019a: brfalse IL_0211
+					IL_019a: brfalse IL_01ff
 
-					IL_019f: ldarg.0
-					IL_01a0: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
-					IL_01a5: ldc.i4.1
-					IL_01a6: newarr [System.Runtime]System.Object
-					IL_01ab: dup
-					IL_01ac: ldc.i4.0
-					IL_01ad: ldarg.0
-					IL_01ae: stelem.ref
-					IL_01af: stloc.s 13
-					IL_01b1: volatile.
-					IL_01b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-					IL_01b8: brfalse IL_01ce
+					IL_019f: volatile.
+					IL_01a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+					IL_01a6: brfalse IL_01bc
 
-					IL_01bd: ldloc.s 4
-					IL_01bf: ldstr "docs"
-					IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01c9: br IL_01e4
+					IL_01ab: ldloc.s 4
+					IL_01ad: ldstr "docs"
+					IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01b7: br IL_01d2
 
-					IL_01ce: ldloc.s 4
-					IL_01d0: ldstr "docs"
-					IL_01d5: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:61"
-					IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
-					IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_01bc: ldloc.s 4
+					IL_01be: ldstr "docs"
+					IL_01c3: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:59"
+					IL_01c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_52
+					IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_01e4: stloc.s 7
-					IL_01e6: ldloc.s 13
-					IL_01e8: ldloc.s 7
-					IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_01ef: stloc.s 7
-					IL_01f1: ldloc.s 7
-					IL_01f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_01f8: stloc.s 12
-					IL_01fa: ldstr "Docs: "
-					IL_01ff: ldloc.s 12
-					IL_0201: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0206: stloc.s 12
-					IL_0208: ldloc.0
-					IL_0209: ldloc.s 12
-					IL_020b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0210: pop
+					IL_01d2: stloc.s 7
+					IL_01d4: ldnull
+					IL_01d5: ldloc.s 7
+					IL_01d7: ldnull
+					IL_01d8: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
+					IL_01dd: stloc.s 7
+					IL_01df: ldloc.s 7
+					IL_01e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_01e6: stloc.s 12
+					IL_01e8: ldstr "Docs: "
+					IL_01ed: ldloc.s 12
+					IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
+					IL_01f4: stloc.s 12
+					IL_01f6: ldloc.0
+					IL_01f7: ldloc.s 12
+					IL_01f9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01fe: pop
 
-					IL_0211: volatile.
-					IL_0213: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-					IL_0218: brfalse IL_022e
+					IL_01ff: volatile.
+					IL_0201: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+					IL_0206: brfalse IL_021c
 
-					IL_021d: ldloc.s 4
-					IL_021f: ldstr "implementation"
-					IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0229: br IL_0244
+					IL_020b: ldloc.s 4
+					IL_020d: ldstr "implementation"
+					IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0217: br IL_0232
 
-					IL_022e: ldloc.s 4
-					IL_0230: ldstr "implementation"
-					IL_0235: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:69"
-					IL_023a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
-					IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_021c: ldloc.s 4
+					IL_021e: ldstr "implementation"
+					IL_0223: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:69"
+					IL_0228: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_53
+					IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_0244: stloc.s 7
-					IL_0246: ldloc.s 7
-					IL_0248: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_024d: stloc.s 8
-					IL_024f: ldloc.s 8
-					IL_0251: brfalse IL_02bd
+					IL_0232: stloc.s 7
+					IL_0234: ldloc.s 7
+					IL_0236: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_023b: stloc.s 8
+					IL_023d: ldloc.s 8
+					IL_023f: brfalse IL_029e
 
-					IL_0256: ldloc.0
-					IL_0257: ldstr "Implementation:"
-					IL_025c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0261: pop
-					IL_0262: ldarg.0
-					IL_0263: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
-					IL_0268: ldc.i4.1
-					IL_0269: newarr [System.Runtime]System.Object
-					IL_026e: dup
-					IL_026f: ldc.i4.0
-					IL_0270: ldarg.0
-					IL_0271: stelem.ref
-					IL_0272: stloc.s 13
-					IL_0274: volatile.
-					IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-					IL_027b: brfalse IL_0291
+					IL_0244: ldloc.0
+					IL_0245: ldstr "Implementation:"
+					IL_024a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_024f: pop
+					IL_0250: volatile.
+					IL_0252: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+					IL_0257: brfalse IL_026d
 
-					IL_0280: ldloc.s 4
-					IL_0282: ldstr "implementation"
-					IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_028c: br IL_02a7
+					IL_025c: ldloc.s 4
+					IL_025e: ldstr "implementation"
+					IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0268: br IL_0283
 
-					IL_0291: ldloc.s 4
-					IL_0293: ldstr "implementation"
-					IL_0298: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:79"
-					IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
-					IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_026d: ldloc.s 4
+					IL_026f: ldstr "implementation"
+					IL_0274: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:77"
+					IL_0279: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_54
+					IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_02a7: stloc.s 7
-					IL_02a9: ldloc.s 13
-					IL_02ab: ldloc.s 7
-					IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_02b2: stloc.s 7
-					IL_02b4: ldloc.0
-					IL_02b5: ldloc.s 7
-					IL_02b7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02bc: pop
+					IL_0283: stloc.s 7
+					IL_0285: ldarg.0
+					IL_0286: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+					IL_028b: ldnull
+					IL_028c: ldloc.s 7
+					IL_028e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+					IL_0293: stloc.s 7
+					IL_0295: ldloc.0
+					IL_0296: ldloc.s 7
+					IL_0298: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_029d: pop
 
-					IL_02bd: ldloc.0
-					IL_02be: ldstr ""
-					IL_02c3: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02c8: pop
-					IL_02c9: ldarg.0
-					IL_02ca: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApisTable
-					IL_02cf: stloc.s 7
-					IL_02d1: ldc.i4.1
-					IL_02d2: newarr [System.Runtime]System.Object
-					IL_02d7: dup
-					IL_02d8: ldc.i4.0
-					IL_02d9: ldarg.0
-					IL_02da: stelem.ref
-					IL_02db: stloc.s 13
-					IL_02dd: volatile.
-					IL_02df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-					IL_02e4: brfalse IL_02fa
+					IL_029e: ldloc.0
+					IL_029f: ldstr ""
+					IL_02a4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02a9: pop
+					IL_02aa: volatile.
+					IL_02ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+					IL_02b1: brfalse IL_02c7
 
-					IL_02e9: ldloc.s 4
-					IL_02eb: ldstr "apis"
-					IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_02f5: br IL_0310
+					IL_02b6: ldloc.s 4
+					IL_02b8: ldstr "apis"
+					IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_02c2: br IL_02dd
 
-					IL_02fa: ldloc.s 4
-					IL_02fc: ldstr "apis"
-					IL_0301: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:90"
-					IL_0306: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-					IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_02c7: ldloc.s 4
+					IL_02c9: ldstr "apis"
+					IL_02ce: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:87"
+					IL_02d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+					IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_0310: stloc.s 14
-					IL_0312: ldloc.s 14
-					IL_0314: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0319: stloc.s 8
-					IL_031b: ldloc.s 8
-					IL_031d: brtrue IL_0333
+					IL_02dd: stloc.s 7
+					IL_02df: ldloc.s 7
+					IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02e6: stloc.s 8
+					IL_02e8: ldloc.s 8
+					IL_02ea: brtrue IL_0300
 
-					IL_0322: ldc.i4.0
-					IL_0323: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0328: stloc.s 9
-					IL_032a: ldloc.s 9
-					IL_032c: stloc.s 15
-					IL_032e: br IL_0337
+					IL_02ef: ldc.i4.0
+					IL_02f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_02f5: stloc.s 9
+					IL_02f7: ldloc.s 9
+					IL_02f9: stloc.s 13
+					IL_02fb: br IL_0304
 
-					IL_0333: ldloc.s 14
-					IL_0335: stloc.s 15
+					IL_0300: ldloc.s 7
+					IL_0302: stloc.s 13
 
-					IL_0337: ldloc.s 7
-					IL_0339: ldloc.s 13
-					IL_033b: ldloc.s 15
-					IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0342: stloc.s 5
-					IL_0344: ldloc.s 5
-					IL_0346: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_034b: stloc.s 8
-					IL_034d: ldloc.s 8
-					IL_034f: brfalse IL_0369
+					IL_0304: ldarg.0
+					IL_0305: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+					IL_030a: ldnull
+					IL_030b: ldloc.s 13
+					IL_030d: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+					IL_0312: stloc.s 5
+					IL_0314: ldloc.s 5
+					IL_0316: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_031b: stloc.s 8
+					IL_031d: ldloc.s 8
+					IL_031f: brfalse IL_0339
 
-					IL_0354: ldloc.0
-					IL_0355: ldloc.s 5
-					IL_0357: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_035c: pop
-					IL_035d: ldloc.0
-					IL_035e: ldstr ""
-					IL_0363: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0368: pop
+					IL_0324: ldloc.0
+					IL_0325: ldloc.s 5
+					IL_0327: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_032c: pop
+					IL_032d: ldloc.0
+					IL_032e: ldstr ""
+					IL_0333: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0338: pop
 
-					IL_0369: ldarg.0
-					IL_036a: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApiTests
-					IL_036f: stloc.s 7
-					IL_0371: ldc.i4.1
-					IL_0372: newarr [System.Runtime]System.Object
-					IL_0377: dup
-					IL_0378: ldc.i4.0
-					IL_0379: ldarg.0
-					IL_037a: stelem.ref
-					IL_037b: stloc.s 13
-					IL_037d: volatile.
-					IL_037f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-					IL_0384: brfalse IL_039a
+					IL_0339: volatile.
+					IL_033b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+					IL_0340: brfalse IL_0356
 
-					IL_0389: ldloc.s 4
-					IL_038b: ldstr "apis"
-					IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0395: br IL_03b0
+					IL_0345: ldloc.s 4
+					IL_0347: ldstr "apis"
+					IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0351: br IL_036c
 
-					IL_039a: ldloc.s 4
-					IL_039c: ldstr "apis"
-					IL_03a1: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:114"
-					IL_03a6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-					IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_0356: ldloc.s 4
+					IL_0358: ldstr "apis"
+					IL_035d: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M12>:__js_call__:110"
+					IL_0362: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+					IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_03b0: stloc.s 14
-					IL_03b2: ldloc.s 14
-					IL_03b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_03b9: stloc.s 8
-					IL_03bb: ldloc.s 8
-					IL_03bd: brtrue IL_03d3
+					IL_036c: stloc.s 7
+					IL_036e: ldloc.s 7
+					IL_0370: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0375: stloc.s 8
+					IL_0377: ldloc.s 8
+					IL_0379: brtrue IL_038f
 
-					IL_03c2: ldc.i4.0
-					IL_03c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_03c8: stloc.s 9
-					IL_03ca: ldloc.s 9
-					IL_03cc: stloc.s 16
-					IL_03ce: br IL_03d7
+					IL_037e: ldc.i4.0
+					IL_037f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0384: stloc.s 9
+					IL_0386: ldloc.s 9
+					IL_0388: stloc.s 14
+					IL_038a: br IL_0393
 
-					IL_03d3: ldloc.s 14
-					IL_03d5: stloc.s 16
+					IL_038f: ldloc.s 7
+					IL_0391: stloc.s 14
 
-					IL_03d7: ldloc.s 7
-					IL_03d9: ldloc.s 13
-					IL_03db: ldloc.s 16
-					IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_03e2: stloc.s 6
-					IL_03e4: ldloc.s 6
-					IL_03e6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_03eb: stloc.s 8
-					IL_03ed: ldloc.s 8
-					IL_03ef: brfalse IL_0415
+					IL_0393: ldarg.0
+					IL_0394: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+					IL_0399: ldnull
+					IL_039a: ldloc.s 14
+					IL_039c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+					IL_03a1: stloc.s 6
+					IL_03a3: ldloc.s 6
+					IL_03a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_03aa: stloc.s 8
+					IL_03ac: ldloc.s 8
+					IL_03ae: brfalse IL_03d4
 
-					IL_03f4: ldloc.0
-					IL_03f5: ldstr "Tests:"
-					IL_03fa: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_03ff: pop
-					IL_0400: ldloc.0
-					IL_0401: ldloc.s 6
-					IL_0403: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0408: pop
-					IL_0409: ldloc.0
-					IL_040a: ldstr ""
-					IL_040f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0414: pop
+					IL_03b3: ldloc.0
+					IL_03b4: ldstr "Tests:"
+					IL_03b9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_03be: pop
+					IL_03bf: ldloc.0
+					IL_03c0: ldloc.s 6
+					IL_03c2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_03c7: pop
+					IL_03c8: ldloc.0
+					IL_03c9: ldstr ""
+					IL_03ce: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_03d3: pop
 
-					IL_0415: br IL_0083
+					IL_03d4: br IL_0083
 				// end loop
-				IL_041a: ldloc.1
-				IL_041b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0420: ldc.i4.1
-				IL_0421: stloc.3
-				IL_0422: leave IL_0441
+				IL_03d9: ldloc.1
+				IL_03da: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_03df: ldc.i4.1
+				IL_03e0: stloc.3
+				IL_03e1: leave IL_0400
 
-				IL_0427: ldc.i4.1
-				IL_0428: stloc.2
-				IL_0429: leave IL_0441
+				IL_03e6: ldc.i4.1
+				IL_03e7: stloc.2
+				IL_03e8: leave IL_0400
 			} // end .try
 			finally
 			{
-				IL_042e: ldloc.2
-				IL_042f: brtrue IL_0440
+				IL_03ed: ldloc.2
+				IL_03ee: brtrue IL_03ff
 
-				IL_0434: ldloc.3
-				IL_0435: brtrue IL_0440
+				IL_03f3: ldloc.3
+				IL_03f4: brtrue IL_03ff
 
-				IL_043a: ldloc.1
-				IL_043b: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_03f9: ldloc.1
+				IL_03fa: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_0440: endfinally
+				IL_03ff: endfinally
 			} // end handler
 
-			IL_0441: ldloc.0
-			IL_0442: ldc.i4.1
-			IL_0443: newarr [System.Runtime]System.Object
-			IL_0448: dup
-			IL_0449: ldc.i4.0
-			IL_044a: ldstr "\n"
-			IL_044f: stelem.ref
-			IL_0450: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0455: stloc.s 12
-			IL_0457: ldloc.s 12
-			IL_0459: ret
+			IL_0400: ldloc.0
+			IL_0401: ldc.i4.1
+			IL_0402: newarr [System.Runtime]System.Object
+			IL_0407: dup
+			IL_0408: ldc.i4.0
+			IL_0409: ldstr "\n"
+			IL_040e: stelem.ref
+			IL_040f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0414: stloc.s 12
+			IL_0416: ldloc.s 12
+			IL_0418: ret
 		} // end of method renderModules::__js_call__
 
 	} // end of class renderModules
@@ -3694,7 +3571,7 @@
 				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1726 (0x6be)
+			// Code size: 1657 (0x679)
 			.maxstack 12
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -3716,9 +3593,8 @@
 				[16] object,
 				[17] object,
 				[18] string,
-				[19] object[],
-				[20] object,
-				[21] object
+				[19] object,
+				[20] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -3783,7 +3659,7 @@
 					IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_0094: stloc.s 14
 					IL_0096: ldloc.s 14
-					IL_0098: brtrue IL_068b
+					IL_0098: brtrue IL_0646
 
 					IL_009d: ldloc.s 13
 					IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -3864,483 +3740,450 @@
 					IL_0191: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_0196: stloc.s 14
 					IL_0198: ldloc.s 14
-					IL_019a: brfalse IL_0211
+					IL_019a: brfalse IL_01ff
 
-					IL_019f: ldarg.0
-					IL_01a0: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
-					IL_01a5: ldc.i4.1
-					IL_01a6: newarr [System.Runtime]System.Object
-					IL_01ab: dup
-					IL_01ac: ldc.i4.0
-					IL_01ad: ldarg.0
-					IL_01ae: stelem.ref
-					IL_01af: stloc.s 19
-					IL_01b1: volatile.
-					IL_01b3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-					IL_01b8: brfalse IL_01ce
+					IL_019f: volatile.
+					IL_01a1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+					IL_01a6: brfalse IL_01bc
 
-					IL_01bd: ldloc.s 4
-					IL_01bf: ldstr "docs"
-					IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01c9: br IL_01e4
+					IL_01ab: ldloc.s 4
+					IL_01ad: ldstr "docs"
+					IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01b7: br IL_01d2
 
-					IL_01ce: ldloc.s 4
-					IL_01d0: ldstr "docs"
-					IL_01d5: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:61"
-					IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-					IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_01bc: ldloc.s 4
+					IL_01be: ldstr "docs"
+					IL_01c3: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:59"
+					IL_01c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+					IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_01e4: stloc.s 13
-					IL_01e6: ldloc.s 19
-					IL_01e8: ldloc.s 13
-					IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_01ef: stloc.s 13
-					IL_01f1: ldloc.s 13
-					IL_01f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_01f8: stloc.s 18
-					IL_01fa: ldstr "Docs: "
-					IL_01ff: ldloc.s 18
-					IL_0201: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0206: stloc.s 18
-					IL_0208: ldloc.0
-					IL_0209: ldloc.s 18
-					IL_020b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0210: pop
+					IL_01d2: stloc.s 13
+					IL_01d4: ldnull
+					IL_01d5: ldloc.s 13
+					IL_01d7: ldnull
+					IL_01d8: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
+					IL_01dd: stloc.s 13
+					IL_01df: ldloc.s 13
+					IL_01e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_01e6: stloc.s 18
+					IL_01e8: ldstr "Docs: "
+					IL_01ed: ldloc.s 18
+					IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
+					IL_01f4: stloc.s 18
+					IL_01f6: ldloc.0
+					IL_01f7: ldloc.s 18
+					IL_01f9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01fe: pop
 
-					IL_0211: volatile.
-					IL_0213: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-					IL_0218: brfalse IL_022e
+					IL_01ff: volatile.
+					IL_0201: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+					IL_0206: brfalse IL_021c
 
-					IL_021d: ldloc.s 4
-					IL_021f: ldstr "implementation"
-					IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0229: br IL_0244
+					IL_020b: ldloc.s 4
+					IL_020d: ldstr "implementation"
+					IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0217: br IL_0232
 
-					IL_022e: ldloc.s 4
-					IL_0230: ldstr "implementation"
-					IL_0235: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:69"
-					IL_023a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-					IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_021c: ldloc.s 4
+					IL_021e: ldstr "implementation"
+					IL_0223: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:69"
+					IL_0228: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+					IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_0244: stloc.s 13
-					IL_0246: ldloc.s 13
-					IL_0248: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_024d: stloc.s 14
-					IL_024f: ldloc.s 14
-					IL_0251: brfalse IL_02bd
+					IL_0232: stloc.s 13
+					IL_0234: ldloc.s 13
+					IL_0236: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_023b: stloc.s 14
+					IL_023d: ldloc.s 14
+					IL_023f: brfalse IL_029e
 
-					IL_0256: ldloc.0
-					IL_0257: ldstr "Implementation:"
-					IL_025c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0261: pop
-					IL_0262: ldarg.0
-					IL_0263: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
-					IL_0268: ldc.i4.1
-					IL_0269: newarr [System.Runtime]System.Object
-					IL_026e: dup
-					IL_026f: ldc.i4.0
-					IL_0270: ldarg.0
-					IL_0271: stelem.ref
-					IL_0272: stloc.s 19
-					IL_0274: volatile.
-					IL_0276: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-					IL_027b: brfalse IL_0291
+					IL_0244: ldloc.0
+					IL_0245: ldstr "Implementation:"
+					IL_024a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_024f: pop
+					IL_0250: volatile.
+					IL_0252: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+					IL_0257: brfalse IL_026d
 
-					IL_0280: ldloc.s 4
-					IL_0282: ldstr "implementation"
-					IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_028c: br IL_02a7
+					IL_025c: ldloc.s 4
+					IL_025e: ldstr "implementation"
+					IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0268: br IL_0283
 
-					IL_0291: ldloc.s 4
-					IL_0293: ldstr "implementation"
-					IL_0298: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:79"
-					IL_029d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-					IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_026d: ldloc.s 4
+					IL_026f: ldstr "implementation"
+					IL_0274: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:77"
+					IL_0279: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+					IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_02a7: stloc.s 13
-					IL_02a9: ldloc.s 19
-					IL_02ab: ldloc.s 13
-					IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_02b2: stloc.s 13
-					IL_02b4: ldloc.0
-					IL_02b5: ldloc.s 13
-					IL_02b7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02bc: pop
+					IL_0283: stloc.s 13
+					IL_0285: ldarg.0
+					IL_0286: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+					IL_028b: ldnull
+					IL_028c: ldloc.s 13
+					IL_028e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+					IL_0293: stloc.s 13
+					IL_0295: ldloc.0
+					IL_0296: ldloc.s 13
+					IL_0298: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_029d: pop
 
-					IL_02bd: volatile.
-					IL_02bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-					IL_02c4: brfalse IL_02da
+					IL_029e: volatile.
+					IL_02a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+					IL_02a5: brfalse IL_02bb
 
-					IL_02c9: ldloc.s 4
-					IL_02cb: ldstr "notes"
-					IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_02d5: br IL_02f0
+					IL_02aa: ldloc.s 4
+					IL_02ac: ldstr "notes"
+					IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_02b6: br IL_02d1
 
-					IL_02da: ldloc.s 4
-					IL_02dc: ldstr "notes"
-					IL_02e1: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:85"
-					IL_02e6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-					IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_02bb: ldloc.s 4
+					IL_02bd: ldstr "notes"
+					IL_02c2: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:84"
+					IL_02c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+					IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_02f0: stloc.s 13
-					IL_02f2: ldloc.s 13
-					IL_02f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02f9: stloc.s 14
-					IL_02fb: ldloc.s 14
-					IL_02fd: brfalse IL_034c
+					IL_02d1: stloc.s 13
+					IL_02d3: ldloc.s 13
+					IL_02d5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02da: stloc.s 14
+					IL_02dc: ldloc.s 14
+					IL_02de: brfalse IL_032d
 
-					IL_0302: ldloc.0
-					IL_0303: ldstr "Notes:"
-					IL_0308: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_030d: pop
-					IL_030e: volatile.
-					IL_0310: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-					IL_0315: brfalse IL_032b
+					IL_02e3: ldloc.0
+					IL_02e4: ldstr "Notes:"
+					IL_02e9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02ee: pop
+					IL_02ef: volatile.
+					IL_02f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+					IL_02f6: brfalse IL_030c
 
-					IL_031a: ldloc.s 4
-					IL_031c: ldstr "notes"
-					IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0326: br IL_0341
+					IL_02fb: ldloc.s 4
+					IL_02fd: ldstr "notes"
+					IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0307: br IL_0322
 
-					IL_032b: ldloc.s 4
-					IL_032d: ldstr "notes"
-					IL_0332: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:93"
-					IL_0337: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-					IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_030c: ldloc.s 4
+					IL_030e: ldstr "notes"
+					IL_0313: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:92"
+					IL_0318: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+					IL_031d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_0341: stloc.s 13
-					IL_0343: ldloc.0
-					IL_0344: ldloc.s 13
-					IL_0346: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_034b: pop
+					IL_0322: stloc.s 13
+					IL_0324: ldloc.0
+					IL_0325: ldloc.s 13
+					IL_0327: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_032c: pop
 
-					IL_034c: volatile.
-					IL_034e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-					IL_0353: brfalse IL_0369
+					IL_032d: volatile.
+					IL_032f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+					IL_0334: brfalse IL_034a
 
-					IL_0358: ldloc.s 4
-					IL_035a: ldstr "tests"
-					IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0364: br IL_037f
+					IL_0339: ldloc.s 4
+					IL_033b: ldstr "tests"
+					IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0345: br IL_0360
 
-					IL_0369: ldloc.s 4
-					IL_036b: ldstr "tests"
-					IL_0370: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:98"
-					IL_0375: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-					IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_034a: ldloc.s 4
+					IL_034c: ldstr "tests"
+					IL_0351: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:97"
+					IL_0356: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+					IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_037f: stloc.s 13
-					IL_0381: ldloc.s 13
-					IL_0383: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0388: stloc.s 14
-					IL_038a: ldloc.s 14
-					IL_038c: brfalse IL_0404
+					IL_0360: stloc.s 13
+					IL_0362: ldloc.s 13
+					IL_0364: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0369: stloc.s 14
+					IL_036b: ldloc.s 14
+					IL_036d: brfalse IL_03e5
 
-					IL_0391: volatile.
-					IL_0393: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-					IL_0398: brfalse IL_03ae
+					IL_0372: volatile.
+					IL_0374: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+					IL_0379: brfalse IL_038f
 
-					IL_039d: ldloc.s 4
-					IL_039f: ldstr "tests"
-					IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_03a9: br IL_03c4
+					IL_037e: ldloc.s 4
+					IL_0380: ldstr "tests"
+					IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_038a: br IL_03a5
 
-					IL_03ae: ldloc.s 4
-					IL_03b0: ldstr "tests"
-					IL_03b5: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:102"
-					IL_03ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-					IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_038f: ldloc.s 4
+					IL_0391: ldstr "tests"
+					IL_0396: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:101"
+					IL_039b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+					IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_03c4: stloc.s 20
-					IL_03c6: volatile.
-					IL_03c8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-					IL_03cd: brfalse IL_03e3
+					IL_03a5: stloc.s 19
+					IL_03a7: volatile.
+					IL_03a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+					IL_03ae: brfalse IL_03c4
 
-					IL_03d2: ldloc.s 20
-					IL_03d4: ldstr "length"
-					IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_03de: br IL_03f9
+					IL_03b3: ldloc.s 19
+					IL_03b5: ldstr "length"
+					IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_03bf: br IL_03da
 
-					IL_03e3: ldloc.s 20
-					IL_03e5: ldstr "length"
-					IL_03ea: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:104"
-					IL_03ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-					IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_03c4: ldloc.s 19
+					IL_03c6: ldstr "length"
+					IL_03cb: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:103"
+					IL_03d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+					IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_03f9: stloc.s 20
-					IL_03fb: ldloc.s 20
-					IL_03fd: stloc.s 21
-					IL_03ff: br IL_0408
+					IL_03da: stloc.s 19
+					IL_03dc: ldloc.s 19
+					IL_03de: stloc.s 20
+					IL_03e0: br IL_03e9
 
-					IL_0404: ldloc.s 13
-					IL_0406: stloc.s 21
+					IL_03e5: ldloc.s 13
+					IL_03e7: stloc.s 20
 
-					IL_0408: ldloc.s 21
-					IL_040a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_040f: stloc.s 14
-					IL_0411: ldloc.s 14
-					IL_0413: brfalse IL_066d
+					IL_03e9: ldloc.s 20
+					IL_03eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_03f0: stloc.s 14
+					IL_03f2: ldloc.s 14
+					IL_03f4: brfalse IL_0628
 
-					IL_0418: ldloc.0
-					IL_0419: ldstr "Tests:"
-					IL_041e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0423: pop
-					IL_0424: volatile.
-					IL_0426: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-					IL_042b: brfalse IL_0441
+					IL_03f9: ldloc.0
+					IL_03fa: ldstr "Tests:"
+					IL_03ff: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0404: pop
+					IL_0405: volatile.
+					IL_0407: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+					IL_040c: brfalse IL_0422
 
-					IL_0430: ldloc.s 4
-					IL_0432: ldstr "tests"
-					IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_043c: br IL_0457
+					IL_0411: ldloc.s 4
+					IL_0413: ldstr "tests"
+					IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_041d: br IL_0438
 
-					IL_0441: ldloc.s 4
-					IL_0443: ldstr "tests"
-					IL_0448: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:117"
-					IL_044d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-					IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+					IL_0422: ldloc.s 4
+					IL_0424: ldstr "tests"
+					IL_0429: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:116"
+					IL_042e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+					IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-					IL_0457: stloc.s 13
-					IL_0459: ldloc.s 13
-					IL_045b: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-					IL_0460: stloc.s 5
-					IL_0462: ldc.i4.0
-					IL_0463: stloc.s 6
-					IL_0465: ldc.i4.0
-					IL_0466: stloc.s 7
+					IL_0438: stloc.s 13
+					IL_043a: ldloc.s 13
+					IL_043c: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+					IL_0441: stloc.s 5
+					IL_0443: ldc.i4.0
+					IL_0444: stloc.s 6
+					IL_0446: ldc.i4.0
+					IL_0447: stloc.s 7
 					.try
 					{
-						// loop start (head: IL_0468)
-							IL_0468: ldc.i4.1
-							IL_0469: stloc.s 6
-							IL_046b: ldloc.s 5
-							IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-							IL_0472: stloc.s 13
-							IL_0474: ldloc.s 13
-							IL_0476: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-							IL_047b: stloc.s 14
-							IL_047d: ldloc.s 14
-							IL_047f: brtrue IL_064f
+						// loop start (head: IL_0449)
+							IL_0449: ldc.i4.1
+							IL_044a: stloc.s 6
+							IL_044c: ldloc.s 5
+							IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+							IL_0453: stloc.s 13
+							IL_0455: ldloc.s 13
+							IL_0457: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+							IL_045c: stloc.s 14
+							IL_045e: ldloc.s 14
+							IL_0460: brtrue IL_060a
 
-							IL_0484: ldloc.s 13
-							IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-							IL_048b: stloc.s 13
-							IL_048d: ldc.i4.0
-							IL_048e: stloc.s 6
-							IL_0490: ldloc.s 13
-							IL_0492: stloc.s 8
-							IL_0494: volatile.
-							IL_0496: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-							IL_049b: brfalse IL_04b1
+							IL_0465: ldloc.s 13
+							IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+							IL_046c: stloc.s 13
+							IL_046e: ldc.i4.0
+							IL_046f: stloc.s 6
+							IL_0471: ldloc.s 13
+							IL_0473: stloc.s 8
+							IL_0475: volatile.
+							IL_0477: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+							IL_047c: brfalse IL_0492
 
-							IL_04a0: ldloc.s 8
-							IL_04a2: ldstr "name"
-							IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_04ac: br IL_04c7
+							IL_0481: ldloc.s 8
+							IL_0483: ldstr "name"
+							IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_048d: br IL_04a8
 
-							IL_04b1: ldloc.s 8
-							IL_04b3: ldstr "name"
-							IL_04b8: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:135"
-							IL_04bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-							IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+							IL_0492: ldloc.s 8
+							IL_0494: ldstr "name"
+							IL_0499: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:134"
+							IL_049e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+							IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-							IL_04c7: stloc.s 13
-							IL_04c9: ldloc.s 13
-							IL_04cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_04d0: stloc.s 14
-							IL_04d2: ldloc.s 14
-							IL_04d4: brfalse IL_0534
+							IL_04a8: stloc.s 13
+							IL_04aa: ldloc.s 13
+							IL_04ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_04b1: stloc.s 14
+							IL_04b3: ldloc.s 14
+							IL_04b5: brfalse IL_0502
 
-							IL_04d9: ldarg.0
-							IL_04da: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_04df: ldc.i4.1
-							IL_04e0: newarr [System.Runtime]System.Object
-							IL_04e5: dup
-							IL_04e6: ldc.i4.0
-							IL_04e7: ldarg.0
-							IL_04e8: stelem.ref
-							IL_04e9: stloc.s 19
-							IL_04eb: volatile.
-							IL_04ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-							IL_04f2: brfalse IL_0508
+							IL_04ba: volatile.
+							IL_04bc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+							IL_04c1: brfalse IL_04d7
 
-							IL_04f7: ldloc.s 8
-							IL_04f9: ldstr "name"
-							IL_04fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0503: br IL_051e
+							IL_04c6: ldloc.s 8
+							IL_04c8: ldstr "name"
+							IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_04d2: br IL_04ed
 
-							IL_0508: ldloc.s 8
-							IL_050a: ldstr "name"
-							IL_050f: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:141"
-							IL_0514: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-							IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+							IL_04d7: ldloc.s 8
+							IL_04d9: ldstr "name"
+							IL_04de: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:138"
+							IL_04e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+							IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-							IL_051e: stloc.s 13
-							IL_0520: ldloc.s 19
-							IL_0522: ldloc.s 13
-							IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_0529: stloc.s 13
-							IL_052b: ldloc.s 13
-							IL_052d: stloc.s 9
-							IL_052f: br IL_053b
+							IL_04ed: stloc.s 13
+							IL_04ef: ldnull
+							IL_04f0: ldloc.s 13
+							IL_04f2: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+							IL_04f7: stloc.s 13
+							IL_04f9: ldloc.s 13
+							IL_04fb: stloc.s 9
+							IL_04fd: br IL_0509
 
-							IL_0534: ldstr ""
-							IL_0539: stloc.s 9
+							IL_0502: ldstr ""
+							IL_0507: stloc.s 9
 
-							IL_053b: ldloc.s 9
-							IL_053d: stloc.s 10
-							IL_053f: volatile.
-							IL_0541: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-							IL_0546: brfalse IL_055c
+							IL_0509: ldloc.s 9
+							IL_050b: stloc.s 10
+							IL_050d: volatile.
+							IL_050f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+							IL_0514: brfalse IL_052a
 
-							IL_054b: ldloc.s 8
-							IL_054d: ldstr "file"
-							IL_0552: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0557: br IL_0572
+							IL_0519: ldloc.s 8
+							IL_051b: ldstr "file"
+							IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_0525: br IL_0540
 
-							IL_055c: ldloc.s 8
-							IL_055e: ldstr "file"
-							IL_0563: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:152"
-							IL_0568: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-							IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+							IL_052a: ldloc.s 8
+							IL_052c: ldstr "file"
+							IL_0531: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:150"
+							IL_0536: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+							IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-							IL_0572: stloc.s 13
-							IL_0574: ldloc.s 13
-							IL_0576: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_057b: stloc.s 14
-							IL_057d: ldloc.s 14
-							IL_057f: brfalse IL_0600
+							IL_0540: stloc.s 13
+							IL_0542: ldloc.s 13
+							IL_0544: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_0549: stloc.s 14
+							IL_054b: ldloc.s 14
+							IL_054d: brfalse IL_05bb
 
-							IL_0584: ldarg.0
-							IL_0585: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
-							IL_058a: ldc.i4.1
-							IL_058b: newarr [System.Runtime]System.Object
-							IL_0590: dup
-							IL_0591: ldc.i4.0
-							IL_0592: ldarg.0
-							IL_0593: stelem.ref
-							IL_0594: stloc.s 19
-							IL_0596: volatile.
-							IL_0598: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-							IL_059d: brfalse IL_05b3
+							IL_0552: volatile.
+							IL_0554: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+							IL_0559: brfalse IL_056f
 
-							IL_05a2: ldloc.s 8
-							IL_05a4: ldstr "file"
-							IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_05ae: br IL_05c9
+							IL_055e: ldloc.s 8
+							IL_0560: ldstr "file"
+							IL_0565: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_056a: br IL_0585
 
-							IL_05b3: ldloc.s 8
-							IL_05b5: ldstr "file"
-							IL_05ba: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:159"
-							IL_05bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-							IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+							IL_056f: ldloc.s 8
+							IL_0571: ldstr "file"
+							IL_0576: ldstr "Compile_Scripts_GenerateNodeSupportMd:<TwoPhaseDummy_M13>:__js_call__:155"
+							IL_057b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+							IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-							IL_05c9: stloc.s 13
-							IL_05cb: ldloc.s 19
-							IL_05cd: ldloc.s 13
-							IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-							IL_05d4: stloc.s 13
-							IL_05d6: ldloc.s 13
-							IL_05d8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_05dd: stloc.s 18
-							IL_05df: ldstr " ("
+							IL_0585: stloc.s 13
+							IL_0587: ldnull
+							IL_0588: ldloc.s 13
+							IL_058a: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+							IL_058f: stloc.s 13
+							IL_0591: ldloc.s 13
+							IL_0593: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0598: stloc.s 18
+							IL_059a: ldstr " ("
+							IL_059f: ldloc.s 18
+							IL_05a1: call string [System.Runtime]System.String::Concat(string, string)
+							IL_05a6: ldstr ")"
+							IL_05ab: call string [System.Runtime]System.String::Concat(string, string)
+							IL_05b0: stloc.s 18
+							IL_05b2: ldloc.s 18
+							IL_05b4: stloc.s 11
+							IL_05b6: br IL_05c2
+
+							IL_05bb: ldstr ""
+							IL_05c0: stloc.s 11
+
+							IL_05c2: ldloc.s 11
+							IL_05c4: stloc.s 12
+							IL_05c6: ldloc.s 10
+							IL_05c8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_05cd: stloc.s 18
+							IL_05cf: ldstr "- "
+							IL_05d4: ldloc.s 18
+							IL_05d6: call string [System.Runtime]System.String::Concat(string, string)
+							IL_05db: ldloc.s 12
+							IL_05dd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_05e2: stloc.s 18
 							IL_05e4: ldloc.s 18
 							IL_05e6: call string [System.Runtime]System.String::Concat(string, string)
-							IL_05eb: ldstr ")"
-							IL_05f0: call string [System.Runtime]System.String::Concat(string, string)
-							IL_05f5: stloc.s 18
-							IL_05f7: ldloc.s 18
-							IL_05f9: stloc.s 11
-							IL_05fb: br IL_0607
-
-							IL_0600: ldstr ""
-							IL_0605: stloc.s 11
-
-							IL_0607: ldloc.s 11
-							IL_0609: stloc.s 12
-							IL_060b: ldloc.s 10
-							IL_060d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0612: stloc.s 18
-							IL_0614: ldstr "- "
-							IL_0619: ldloc.s 18
-							IL_061b: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0620: ldloc.s 12
-							IL_0622: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0627: stloc.s 18
-							IL_0629: ldloc.s 18
-							IL_062b: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0630: stloc.s 18
-							IL_0632: ldloc.0
-							IL_0633: ldloc.s 18
-							IL_0635: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-							IL_063a: pop
-							IL_063b: br IL_0468
+							IL_05eb: stloc.s 18
+							IL_05ed: ldloc.0
+							IL_05ee: ldloc.s 18
+							IL_05f0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+							IL_05f5: pop
+							IL_05f6: br IL_0449
 						// end loop
-						IL_0640: ldloc.s 5
-						IL_0642: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-						IL_0647: ldc.i4.1
-						IL_0648: stloc.s 7
-						IL_064a: leave IL_066d
+						IL_05fb: ldloc.s 5
+						IL_05fd: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+						IL_0602: ldc.i4.1
+						IL_0603: stloc.s 7
+						IL_0605: leave IL_0628
 
-						IL_064f: ldc.i4.1
-						IL_0650: stloc.s 6
-						IL_0652: leave IL_066d
+						IL_060a: ldc.i4.1
+						IL_060b: stloc.s 6
+						IL_060d: leave IL_0628
 					} // end .try
 					finally
 					{
-						IL_0657: ldloc.s 6
-						IL_0659: brtrue IL_066c
+						IL_0612: ldloc.s 6
+						IL_0614: brtrue IL_0627
 
-						IL_065e: ldloc.s 7
-						IL_0660: brtrue IL_066c
+						IL_0619: ldloc.s 7
+						IL_061b: brtrue IL_0627
 
-						IL_0665: ldloc.s 5
-						IL_0667: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+						IL_0620: ldloc.s 5
+						IL_0622: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-						IL_066c: endfinally
+						IL_0627: endfinally
 					} // end handler
 
-					IL_066d: ldloc.0
-					IL_066e: ldstr ""
-					IL_0673: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0678: pop
-					IL_0679: br IL_0083
+					IL_0628: ldloc.0
+					IL_0629: ldstr ""
+					IL_062e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0633: pop
+					IL_0634: br IL_0083
 				// end loop
-				IL_067e: ldloc.1
-				IL_067f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0684: ldc.i4.1
-				IL_0685: stloc.3
-				IL_0686: leave IL_06a5
+				IL_0639: ldloc.1
+				IL_063a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_063f: ldc.i4.1
+				IL_0640: stloc.3
+				IL_0641: leave IL_0660
 
-				IL_068b: ldc.i4.1
-				IL_068c: stloc.2
-				IL_068d: leave IL_06a5
+				IL_0646: ldc.i4.1
+				IL_0647: stloc.2
+				IL_0648: leave IL_0660
 			} // end .try
 			finally
 			{
-				IL_0692: ldloc.2
-				IL_0693: brtrue IL_06a4
+				IL_064d: ldloc.2
+				IL_064e: brtrue IL_065f
 
-				IL_0698: ldloc.3
-				IL_0699: brtrue IL_06a4
+				IL_0653: ldloc.3
+				IL_0654: brtrue IL_065f
 
-				IL_069e: ldloc.1
-				IL_069f: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_0659: ldloc.1
+				IL_065a: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_06a4: endfinally
+				IL_065f: endfinally
 			} // end handler
 
-			IL_06a5: ldloc.0
-			IL_06a6: ldc.i4.1
-			IL_06a7: newarr [System.Runtime]System.Object
-			IL_06ac: dup
-			IL_06ad: ldc.i4.0
-			IL_06ae: ldstr "\n"
-			IL_06b3: stelem.ref
-			IL_06b4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_06b9: stloc.s 18
-			IL_06bb: ldloc.s 18
-			IL_06bd: ret
+			IL_0660: ldloc.0
+			IL_0661: ldc.i4.1
+			IL_0662: newarr [System.Runtime]System.Object
+			IL_0667: dup
+			IL_0668: ldc.i4.0
+			IL_0669: ldstr "\n"
+			IL_066e: stelem.ref
+			IL_066f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0674: stloc.s 18
+			IL_0676: ldloc.s 18
+			IL_0678: ret
 		} // end of method renderGlobals::__js_call__
 
 	} // end of class renderGlobals
@@ -4805,7 +4648,7 @@
 				74 61 54 6f 6b 65 6e 13 00 00 02
 			)
 			// Header size: 12
-			// Code size: 481 (0x1e1)
+			// Code size: 430 (0x1ae)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4892,138 +4735,111 @@
 			IL_0089: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
 			IL_008e: stloc.2
 			IL_008f: ldarg.0
-			IL_0090: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::readJson
-			IL_0095: ldc.i4.1
-			IL_0096: newarr [System.Runtime]System.Object
-			IL_009b: dup
-			IL_009c: ldc.i4.0
-			IL_009d: ldarg.0
-			IL_009e: stelem.ref
-			IL_009f: ldloc.1
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00a5: stloc.3
-			IL_00a6: ldc.i4.0
-			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00ac: stloc.s 4
-			IL_00ae: ldarg.0
-			IL_00af: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderHeader
-			IL_00b4: ldc.i4.1
-			IL_00b5: newarr [System.Runtime]System.Object
-			IL_00ba: dup
-			IL_00bb: ldc.i4.0
-			IL_00bc: ldarg.0
-			IL_00bd: stelem.ref
-			IL_00be: ldloc.3
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00c4: stloc.s 8
-			IL_00c6: ldloc.s 4
-			IL_00c8: ldloc.s 8
-			IL_00ca: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00cf: pop
-			IL_00d0: ldarg.0
-			IL_00d1: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderModules
-			IL_00d6: ldc.i4.1
-			IL_00d7: newarr [System.Runtime]System.Object
-			IL_00dc: dup
-			IL_00dd: ldc.i4.0
-			IL_00de: ldarg.0
-			IL_00df: stelem.ref
-			IL_00e0: ldloc.3
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00e6: stloc.s 8
-			IL_00e8: ldloc.s 4
-			IL_00ea: ldloc.s 8
-			IL_00ec: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00f1: pop
-			IL_00f2: ldarg.0
-			IL_00f3: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderGlobals
-			IL_00f8: ldc.i4.1
-			IL_00f9: newarr [System.Runtime]System.Object
-			IL_00fe: dup
-			IL_00ff: ldc.i4.0
-			IL_0100: ldarg.0
-			IL_0101: stelem.ref
-			IL_0102: ldloc.3
-			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0108: stloc.s 8
-			IL_010a: ldloc.s 4
-			IL_010c: ldloc.s 8
-			IL_010e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0113: pop
-			IL_0114: ldarg.0
-			IL_0115: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderLimitations
-			IL_011a: ldc.i4.1
-			IL_011b: newarr [System.Runtime]System.Object
-			IL_0120: dup
-			IL_0121: ldc.i4.0
-			IL_0122: ldarg.0
-			IL_0123: stelem.ref
-			IL_0124: ldloc.3
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_012a: stloc.s 5
-			IL_012c: ldloc.s 5
-			IL_012e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0133: stloc.s 9
-			IL_0135: ldloc.s 9
-			IL_0137: brfalse IL_0146
+			IL_0090: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_0095: ldnull
+			IL_0096: ldloc.1
+			IL_0097: call object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_009c: stloc.3
+			IL_009d: ldc.i4.0
+			IL_009e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00a3: stloc.s 4
+			IL_00a5: ldarg.0
+			IL_00a6: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_00ab: ldnull
+			IL_00ac: ldloc.3
+			IL_00ad: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_00b2: stloc.s 8
+			IL_00b4: ldloc.s 4
+			IL_00b6: ldloc.s 8
+			IL_00b8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00bd: pop
+			IL_00be: ldarg.0
+			IL_00bf: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_00c4: ldnull
+			IL_00c5: ldloc.3
+			IL_00c6: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_00cb: stloc.s 8
+			IL_00cd: ldloc.s 4
+			IL_00cf: ldloc.s 8
+			IL_00d1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00d6: pop
+			IL_00d7: ldarg.0
+			IL_00d8: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_00dd: ldnull
+			IL_00de: ldloc.3
+			IL_00df: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_00e4: stloc.s 8
+			IL_00e6: ldloc.s 4
+			IL_00e8: ldloc.s 8
+			IL_00ea: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00ef: pop
+			IL_00f0: ldnull
+			IL_00f1: ldloc.3
+			IL_00f2: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
+			IL_00f7: stloc.s 5
+			IL_00f9: ldloc.s 5
+			IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0100: stloc.s 9
+			IL_0102: ldloc.s 9
+			IL_0104: brfalse IL_0113
 
-			IL_013c: ldloc.s 4
-			IL_013e: ldloc.s 5
-			IL_0140: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0145: pop
+			IL_0109: ldloc.s 4
+			IL_010b: ldloc.s 5
+			IL_010d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0112: pop
 
-			IL_0146: ldloc.s 4
-			IL_0148: ldc.i4.1
-			IL_0149: newarr [System.Runtime]System.Object
-			IL_014e: dup
-			IL_014f: ldc.i4.0
-			IL_0150: ldstr "\n\n"
-			IL_0155: stelem.ref
-			IL_0156: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_015b: stloc.s 10
-			IL_015d: ldloc.s 10
-			IL_015f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_0164: stloc.s 10
-			IL_0166: ldstr "\\r?\\n"
-			IL_016b: ldstr "g"
-			IL_0170: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0175: stloc.s 11
-			IL_0177: ldloc.s 10
-			IL_0179: ldstr "replace"
-			IL_017e: ldloc.s 11
-			IL_0180: ldstr "\n"
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_018a: stloc.s 6
-			IL_018c: ldarg.0
-			IL_018d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_0192: stloc.s 12
-			IL_0194: ldloc.s 12
-			IL_0196: ldloc.2
-			IL_0197: ldloc.s 6
-			IL_0199: ldstr "utf8"
-			IL_019e: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01a8: stloc.s 13
-			IL_01aa: ldarg.0
-			IL_01ab: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_01b0: ldstr "relative"
-			IL_01b5: ldloc.0
-			IL_01b6: ldloc.2
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01bc: stloc.s 8
-			IL_01be: ldloc.s 8
-			IL_01c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c5: stloc.s 10
-			IL_01c7: ldstr "Wrote "
-			IL_01cc: ldloc.s 10
-			IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d3: stloc.s 10
-			IL_01d5: ldloc.s 13
-			IL_01d7: ldloc.s 10
-			IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01de: pop
-			IL_01df: ldnull
-			IL_01e0: ret
+			IL_0113: ldloc.s 4
+			IL_0115: ldc.i4.1
+			IL_0116: newarr [System.Runtime]System.Object
+			IL_011b: dup
+			IL_011c: ldc.i4.0
+			IL_011d: ldstr "\n\n"
+			IL_0122: stelem.ref
+			IL_0123: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0128: stloc.s 10
+			IL_012a: ldloc.s 10
+			IL_012c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0131: stloc.s 10
+			IL_0133: ldstr "\\r?\\n"
+			IL_0138: ldstr "g"
+			IL_013d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0142: stloc.s 11
+			IL_0144: ldloc.s 10
+			IL_0146: ldstr "replace"
+			IL_014b: ldloc.s 11
+			IL_014d: ldstr "\n"
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0157: stloc.s 6
+			IL_0159: ldarg.0
+			IL_015a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
+			IL_015f: stloc.s 12
+			IL_0161: ldloc.s 12
+			IL_0163: ldloc.2
+			IL_0164: ldloc.s 6
+			IL_0166: ldstr "utf8"
+			IL_016b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0170: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0175: stloc.s 13
+			IL_0177: ldarg.0
+			IL_0178: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_017d: ldstr "relative"
+			IL_0182: ldloc.0
+			IL_0183: ldloc.2
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0189: stloc.s 8
+			IL_018b: ldloc.s 8
+			IL_018d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0192: stloc.s 10
+			IL_0194: ldstr "Wrote "
+			IL_0199: ldloc.s 10
+			IL_019b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a0: stloc.s 10
+			IL_01a2: ldloc.s 13
+			IL_01a4: ldloc.s 10
+			IL_01a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01ab: pop
+			IL_01ac: ldnull
+			IL_01ad: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -5090,7 +4906,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 615 (0x267)
+		// Code size: 616 (0x268)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope,
@@ -5388,11 +5204,12 @@
 		IL_0257: nop
 		IL_0258: nop
 		IL_0259: nop
-		IL_025a: ldloc.1
-		IL_025b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0265: pop
-		IL_0266: ret
+		IL_025a: ldloc.0
+		IL_025b: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+		IL_0260: ldnull
+		IL_0261: call object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
+		IL_0266: pop
+		IL_0267: ret
 	} // end of method Compile_Scripts_GenerateNodeSupportMd::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_GenerateNodeSupportMd

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -3591,7 +3591,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3362 (0xd22)
+		// Code size: 3347 (0xd13)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_Helper_Cleanup/Scope,
@@ -3658,1087 +3658,1082 @@
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
-		IL_0031: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0036: stloc.s 27
-		IL_0038: ldloc.1
-		IL_0039: ldloc.s 27
-		IL_003b: ldc.r8 2
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004e: stloc.2
-		IL_004f: ldstr "Iterator"
-		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005e: stloc.s 28
-		IL_0060: volatile.
-		IL_0062: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-		IL_0067: brfalse IL_007c
+		IL_0031: ldloc.0
+		IL_0032: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0037: ldnull
+		IL_0038: ldc.r8 2
+		IL_0041: box [System.Runtime]System.Double
+		IL_0046: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_004b: stloc.2
+		IL_004c: ldstr "Iterator"
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005b: stloc.s 28
+		IL_005d: volatile.
+		IL_005f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+		IL_0064: brfalse IL_0079
 
-		IL_006c: ldloc.2
-		IL_006d: ldstr "iterable"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0077: br IL_0091
+		IL_0069: ldloc.2
+		IL_006a: ldstr "iterable"
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0074: br IL_008e
 
-		IL_007c: ldloc.2
-		IL_007d: ldstr "iterable"
-		IL_0082: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:18"
-		IL_0087: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0079: ldloc.2
+		IL_007a: ldstr "iterable"
+		IL_007f: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:18"
+		IL_0084: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_55
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0091: stloc.s 29
-		IL_0093: volatile.
-		IL_0095: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-		IL_009a: brfalse IL_00b2
+		IL_008e: stloc.s 29
+		IL_0090: volatile.
+		IL_0092: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_0097: brfalse IL_00af
 
-		IL_009f: ldloc.s 28
-		IL_00a1: ldstr "from"
-		IL_00a6: ldloc.s 29
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ad: br IL_00ca
+		IL_009c: ldloc.s 28
+		IL_009e: ldstr "from"
+		IL_00a3: ldloc.s 29
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00aa: br IL_00c7
 
-		IL_00b2: ldloc.s 28
-		IL_00b4: ldstr "from"
-		IL_00b9: ldloc.s 29
-		IL_00bb: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:19"
-		IL_00c0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_00af: ldloc.s 28
+		IL_00b1: ldstr "from"
+		IL_00b6: ldloc.s 29
+		IL_00b8: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:19"
+		IL_00bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_56
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_00ca: stloc.s 29
-		IL_00cc: ldloc.s 29
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d3: stloc.s 29
-		IL_00d5: ldc.i4.1
-		IL_00d6: newarr [System.Runtime]System.Object
-		IL_00db: dup
-		IL_00dc: ldc.i4.0
-		IL_00dd: ldloc.0
-		IL_00de: stelem.ref
-		IL_00df: stloc.s 27
-		IL_00e1: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject::.ctor()
-		IL_00e6: ldc.i4.1
-		IL_00e7: conv.r8
-		IL_00e8: ldstr ""
-		IL_00ed: ldc.i4.0
-		IL_00ee: ldc.i4.0
-		IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject>(!!0)
-		IL_00f9: stloc.s 30
-		IL_00fb: volatile.
-		IL_00fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-		IL_0102: brfalse IL_011a
+		IL_00c7: stloc.s 29
+		IL_00c9: ldloc.s 29
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d0: stloc.s 29
+		IL_00d2: ldc.i4.1
+		IL_00d3: newarr [System.Runtime]System.Object
+		IL_00d8: dup
+		IL_00d9: ldc.i4.0
+		IL_00da: ldloc.0
+		IL_00db: stelem.ref
+		IL_00dc: stloc.s 27
+		IL_00de: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject::.ctor()
+		IL_00e3: ldc.i4.1
+		IL_00e4: conv.r8
+		IL_00e5: ldstr ""
+		IL_00ea: ldc.i4.0
+		IL_00eb: ldc.i4.0
+		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56/FunctionObject>(!!0)
+		IL_00f6: stloc.s 30
+		IL_00f8: volatile.
+		IL_00fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+		IL_00ff: brfalse IL_0117
 
-		IL_0107: ldloc.s 29
-		IL_0109: ldstr "map"
-		IL_010e: ldloc.s 30
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0115: br IL_0132
+		IL_0104: ldloc.s 29
+		IL_0106: ldstr "map"
+		IL_010b: ldloc.s 30
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0112: br IL_012f
 
-		IL_011a: ldloc.s 29
-		IL_011c: ldstr "map"
-		IL_0121: ldloc.s 30
-		IL_0123: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:23"
-		IL_0128: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0117: ldloc.s 29
+		IL_0119: ldstr "map"
+		IL_011e: ldloc.s 30
+		IL_0120: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:23"
+		IL_0125: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_57
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0132: stloc.3
-		IL_0133: ldloc.3
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0139: volatile.
-		IL_013b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-		IL_0140: brfalse IL_0154
+		IL_012f: stloc.3
+		IL_0130: ldloc.3
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0136: volatile.
+		IL_0138: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+		IL_013d: brfalse IL_0151
 
-		IL_0145: ldstr "next"
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_014f: br IL_0168
+		IL_0142: ldstr "next"
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_014c: br IL_0165
 
-		IL_0154: ldstr "next"
-		IL_0159: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:27"
-		IL_015e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
-		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0151: ldstr "next"
+		IL_0156: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:27"
+		IL_015b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_58
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0168: pop
-		IL_0169: ldloc.3
-		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016f: volatile.
-		IL_0171: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-		IL_0176: brfalse IL_018a
+		IL_0165: pop
+		IL_0166: ldloc.3
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016c: volatile.
+		IL_016e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+		IL_0173: brfalse IL_0187
 
-		IL_017b: ldstr "next"
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0185: br IL_019e
+		IL_0178: ldstr "next"
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0182: br IL_019b
 
-		IL_018a: ldstr "next"
-		IL_018f: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:30"
-		IL_0194: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0187: ldstr "next"
+		IL_018c: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:30"
+		IL_0191: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_59
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_019e: pop
-		IL_019f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a4: stloc.s 31
-		IL_01a6: ldloc.3
-		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ac: volatile.
-		IL_01ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-		IL_01b3: brfalse IL_01c7
+		IL_019b: pop
+		IL_019c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a1: stloc.s 31
+		IL_01a3: ldloc.3
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a9: volatile.
+		IL_01ab: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+		IL_01b0: brfalse IL_01c4
 
-		IL_01b8: ldstr "next"
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01c2: br IL_01db
+		IL_01b5: ldstr "next"
+		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01bf: br IL_01d8
 
-		IL_01c7: ldstr "next"
-		IL_01cc: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:34"
-		IL_01d1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
-		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_01c4: ldstr "next"
+		IL_01c9: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:34"
+		IL_01ce: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_60
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_01db: stloc.s 29
-		IL_01dd: volatile.
-		IL_01df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-		IL_01e4: brfalse IL_01fa
+		IL_01d8: stloc.s 29
+		IL_01da: volatile.
+		IL_01dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+		IL_01e1: brfalse IL_01f7
 
-		IL_01e9: ldloc.s 29
-		IL_01eb: ldstr "done"
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f5: br IL_0210
+		IL_01e6: ldloc.s 29
+		IL_01e8: ldstr "done"
+		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01f2: br IL_020d
 
-		IL_01fa: ldloc.s 29
-		IL_01fc: ldstr "done"
-		IL_0201: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:36"
-		IL_0206: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
-		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01f7: ldloc.s 29
+		IL_01f9: ldstr "done"
+		IL_01fe: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:36"
+		IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_61
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0210: stloc.s 29
-		IL_0212: ldloc.s 31
-		IL_0214: ldloc.s 29
-		IL_0216: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_021b: pop
-		IL_021c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0221: stloc.s 31
-		IL_0223: ldloc.2
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0229: volatile.
-		IL_022b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-		IL_0230: brfalse IL_0244
+		IL_020d: stloc.s 29
+		IL_020f: ldloc.s 31
+		IL_0211: ldloc.s 29
+		IL_0213: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0218: pop
+		IL_0219: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_021e: stloc.s 31
+		IL_0220: ldloc.2
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0226: volatile.
+		IL_0228: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+		IL_022d: brfalse IL_0241
 
-		IL_0235: ldstr "getClosed"
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_023f: br IL_0258
+		IL_0232: ldstr "getClosed"
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_023c: br IL_0255
 
-		IL_0244: ldstr "getClosed"
-		IL_0249: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:41"
-		IL_024e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
-		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0241: ldstr "getClosed"
+		IL_0246: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:41"
+		IL_024b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_62
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0258: stloc.s 29
-		IL_025a: ldloc.s 31
-		IL_025c: ldloc.s 29
-		IL_025e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0263: pop
-		IL_0264: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0269: stloc.s 27
-		IL_026b: ldloc.1
-		IL_026c: ldloc.s 27
-		IL_026e: ldc.r8 2
-		IL_0277: box [System.Runtime]System.Double
-		IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0281: stloc.s 4
-		IL_0283: ldstr "Iterator"
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0292: stloc.s 29
-		IL_0294: volatile.
-		IL_0296: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-		IL_029b: brfalse IL_02b1
+		IL_0255: stloc.s 29
+		IL_0257: ldloc.s 31
+		IL_0259: ldloc.s 29
+		IL_025b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0260: pop
+		IL_0261: ldloc.0
+		IL_0262: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0267: ldnull
+		IL_0268: ldc.r8 2
+		IL_0271: box [System.Runtime]System.Double
+		IL_0276: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_027b: stloc.s 4
+		IL_027d: ldstr "Iterator"
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028c: stloc.s 29
+		IL_028e: volatile.
+		IL_0290: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_0295: brfalse IL_02ab
 
-		IL_02a0: ldloc.s 4
-		IL_02a2: ldstr "iterable"
-		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02ac: br IL_02c7
+		IL_029a: ldloc.s 4
+		IL_029c: ldstr "iterable"
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a6: br IL_02c1
 
-		IL_02b1: ldloc.s 4
-		IL_02b3: ldstr "iterable"
-		IL_02b8: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:54"
-		IL_02bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02ab: ldloc.s 4
+		IL_02ad: ldstr "iterable"
+		IL_02b2: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:54"
+		IL_02b7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_63
+		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02c7: stloc.s 28
-		IL_02c9: volatile.
-		IL_02cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_02d0: brfalse IL_02e8
+		IL_02c1: stloc.s 28
+		IL_02c3: volatile.
+		IL_02c5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_02ca: brfalse IL_02e2
 
-		IL_02d5: ldloc.s 29
-		IL_02d7: ldstr "from"
-		IL_02dc: ldloc.s 28
-		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e3: br IL_0300
+		IL_02cf: ldloc.s 29
+		IL_02d1: ldstr "from"
+		IL_02d6: ldloc.s 28
+		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02dd: br IL_02fa
 
-		IL_02e8: ldloc.s 29
-		IL_02ea: ldstr "from"
-		IL_02ef: ldloc.s 28
-		IL_02f1: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:55"
-		IL_02f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
-		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_02e2: ldloc.s 29
+		IL_02e4: ldstr "from"
+		IL_02e9: ldloc.s 28
+		IL_02eb: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:55"
+		IL_02f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_64
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0300: stloc.s 28
-		IL_0302: ldloc.s 28
-		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0309: stloc.s 28
-		IL_030b: ldc.i4.1
-		IL_030c: newarr [System.Runtime]System.Object
-		IL_0311: dup
-		IL_0312: ldc.i4.0
-		IL_0313: ldloc.0
-		IL_0314: stelem.ref
-		IL_0315: stloc.s 27
-		IL_0317: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject::.ctor()
-		IL_031c: ldc.i4.1
-		IL_031d: conv.r8
-		IL_031e: ldstr ""
-		IL_0323: ldc.i4.0
-		IL_0324: ldc.i4.0
-		IL_0325: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_032a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject>(!!0)
-		IL_032f: stloc.s 32
-		IL_0331: volatile.
-		IL_0333: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-		IL_0338: brfalse IL_0350
+		IL_02fa: stloc.s 28
+		IL_02fc: ldloc.s 28
+		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0303: stloc.s 28
+		IL_0305: ldc.i4.1
+		IL_0306: newarr [System.Runtime]System.Object
+		IL_030b: dup
+		IL_030c: ldc.i4.0
+		IL_030d: ldloc.0
+		IL_030e: stelem.ref
+		IL_030f: stloc.s 27
+		IL_0311: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject::.ctor()
+		IL_0316: ldc.i4.1
+		IL_0317: conv.r8
+		IL_0318: ldstr ""
+		IL_031d: ldc.i4.0
+		IL_031e: ldc.i4.0
+		IL_031f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0324: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68/FunctionObject>(!!0)
+		IL_0329: stloc.s 32
+		IL_032b: volatile.
+		IL_032d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_0332: brfalse IL_034a
 
-		IL_033d: ldloc.s 28
-		IL_033f: ldstr "map"
-		IL_0344: ldloc.s 32
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_034b: br IL_0368
+		IL_0337: ldloc.s 28
+		IL_0339: ldstr "map"
+		IL_033e: ldloc.s 32
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0345: br IL_0362
 
-		IL_0350: ldloc.s 28
-		IL_0352: ldstr "map"
-		IL_0357: ldloc.s 32
-		IL_0359: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:59"
-		IL_035e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
-		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_034a: ldloc.s 28
+		IL_034c: ldstr "map"
+		IL_0351: ldloc.s 32
+		IL_0353: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:59"
+		IL_0358: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_65
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0368: stloc.s 5
+		IL_0362: stloc.s 5
 		.try
 		{
-			IL_036a: nop
-			IL_036b: ldloc.s 5
-			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0372: volatile.
-			IL_0374: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_0379: brfalse IL_038d
+			IL_0364: nop
+			IL_0365: ldloc.s 5
+			IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036c: volatile.
+			IL_036e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0373: brfalse IL_0387
 
-			IL_037e: ldstr "next"
-			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0388: br IL_03a1
+			IL_0378: ldstr "next"
+			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0382: br IL_039b
 
-			IL_038d: ldstr "next"
-			IL_0392: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:66"
-			IL_0397: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
-			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0387: ldstr "next"
+			IL_038c: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:66"
+			IL_0391: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_66
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_03a1: pop
-			IL_03a2: leave IL_03de
+			IL_039b: pop
+			IL_039c: leave IL_03d8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03a7: stloc.s 6
-			IL_03a9: ldloc.s 6
-			IL_03ab: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03b0: dup
-			IL_03b1: brtrue IL_03c7
+			IL_03a1: stloc.s 6
+			IL_03a3: ldloc.s 6
+			IL_03a5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03aa: dup
+			IL_03ab: brtrue IL_03c1
 
-			IL_03b6: pop
-			IL_03b7: ldloc.s 6
-			IL_03b9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03be: dup
-			IL_03bf: brtrue IL_03d3
+			IL_03b0: pop
+			IL_03b1: ldloc.s 6
+			IL_03b3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03b8: dup
+			IL_03b9: brtrue IL_03cd
 
-			IL_03c4: pop
-			IL_03c5: rethrow
+			IL_03be: pop
+			IL_03bf: rethrow
 
-			IL_03c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03cc: stloc.s 7
-			IL_03ce: br IL_03d5
+			IL_03c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03c6: stloc.s 7
+			IL_03c8: br IL_03cf
 
-			IL_03d3: stloc.s 7
+			IL_03cd: stloc.s 7
 
-			IL_03d5: ldloc.s 7
-			IL_03d7: stloc.s 8
-			IL_03d9: leave IL_03de
+			IL_03cf: ldloc.s 7
+			IL_03d1: stloc.s 8
+			IL_03d3: leave IL_03d8
 		} // end handler
 
-		IL_03de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03e3: stloc.s 31
-		IL_03e5: ldloc.s 4
-		IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03ec: volatile.
-		IL_03ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-		IL_03f3: brfalse IL_0407
+		IL_03d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03dd: stloc.s 31
+		IL_03df: ldloc.s 4
+		IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03e6: volatile.
+		IL_03e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+		IL_03ed: brfalse IL_0401
 
-		IL_03f8: ldstr "getClosed"
-		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0402: br IL_041b
+		IL_03f2: ldstr "getClosed"
+		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_03fc: br IL_0415
 
-		IL_0407: ldstr "getClosed"
-		IL_040c: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:81"
-		IL_0411: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
-		IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0401: ldstr "getClosed"
+		IL_0406: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:81"
+		IL_040b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_67
+		IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_041b: stloc.s 28
-		IL_041d: ldloc.s 31
-		IL_041f: ldloc.s 28
-		IL_0421: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0426: pop
-		IL_0427: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_042c: stloc.s 27
-		IL_042e: ldloc.1
-		IL_042f: ldloc.s 27
-		IL_0431: ldc.r8 2
-		IL_043a: box [System.Runtime]System.Double
-		IL_043f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0444: stloc.s 9
-		IL_0446: ldstr "Iterator"
-		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0455: stloc.s 28
-		IL_0457: volatile.
-		IL_0459: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-		IL_045e: brfalse IL_0474
+		IL_0415: stloc.s 28
+		IL_0417: ldloc.s 31
+		IL_0419: ldloc.s 28
+		IL_041b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0420: pop
+		IL_0421: ldloc.0
+		IL_0422: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0427: ldnull
+		IL_0428: ldc.r8 2
+		IL_0431: box [System.Runtime]System.Double
+		IL_0436: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_043b: stloc.s 9
+		IL_043d: ldstr "Iterator"
+		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_044c: stloc.s 28
+		IL_044e: volatile.
+		IL_0450: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+		IL_0455: brfalse IL_046b
 
-		IL_0463: ldloc.s 9
-		IL_0465: ldstr "iterable"
-		IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_046f: br IL_048a
+		IL_045a: ldloc.s 9
+		IL_045c: ldstr "iterable"
+		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0466: br IL_0481
 
-		IL_0474: ldloc.s 9
-		IL_0476: ldstr "iterable"
-		IL_047b: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:94"
-		IL_0480: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
-		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_046b: ldloc.s 9
+		IL_046d: ldstr "iterable"
+		IL_0472: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:94"
+		IL_0477: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_68
+		IL_047c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_048a: stloc.s 29
-		IL_048c: volatile.
-		IL_048e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_0493: brfalse IL_04ab
+		IL_0481: stloc.s 29
+		IL_0483: volatile.
+		IL_0485: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_048a: brfalse IL_04a2
 
-		IL_0498: ldloc.s 28
-		IL_049a: ldstr "from"
-		IL_049f: ldloc.s 29
-		IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_04a6: br IL_04c3
+		IL_048f: ldloc.s 28
+		IL_0491: ldstr "from"
+		IL_0496: ldloc.s 29
+		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_049d: br IL_04ba
 
-		IL_04ab: ldloc.s 28
-		IL_04ad: ldstr "from"
-		IL_04b2: ldloc.s 29
-		IL_04b4: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:95"
-		IL_04b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
-		IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_04a2: ldloc.s 28
+		IL_04a4: ldstr "from"
+		IL_04a9: ldloc.s 29
+		IL_04ab: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:95"
+		IL_04b0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_69
+		IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
+		IL_04ba: stloc.s 29
+		IL_04bc: ldloc.s 29
+		IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_04c3: stloc.s 29
-		IL_04c5: ldloc.s 29
-		IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04cc: stloc.s 29
-		IL_04ce: ldc.i4.1
-		IL_04cf: newarr [System.Runtime]System.Object
-		IL_04d4: dup
-		IL_04d5: ldc.i4.0
-		IL_04d6: ldloc.0
-		IL_04d7: stelem.ref
-		IL_04d8: stloc.s 27
-		IL_04da: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject::.ctor()
-		IL_04df: ldc.i4.1
-		IL_04e0: conv.r8
-		IL_04e1: ldstr ""
-		IL_04e6: ldc.i4.0
-		IL_04e7: ldc.i4.0
-		IL_04e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject>(!!0)
-		IL_04f2: stloc.s 33
-		IL_04f4: volatile.
-		IL_04f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-		IL_04fb: brfalse IL_0513
+		IL_04c5: ldc.i4.1
+		IL_04c6: newarr [System.Runtime]System.Object
+		IL_04cb: dup
+		IL_04cc: ldc.i4.0
+		IL_04cd: ldloc.0
+		IL_04ce: stelem.ref
+		IL_04cf: stloc.s 27
+		IL_04d1: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject::.ctor()
+		IL_04d6: ldc.i4.1
+		IL_04d7: conv.r8
+		IL_04d8: ldstr ""
+		IL_04dd: ldc.i4.0
+		IL_04de: ldc.i4.0
+		IL_04df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77/FunctionObject>(!!0)
+		IL_04e9: stloc.s 33
+		IL_04eb: volatile.
+		IL_04ed: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_04f2: brfalse IL_050a
 
-		IL_0500: ldloc.s 29
-		IL_0502: ldstr "filter"
-		IL_0507: ldloc.s 33
-		IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_050e: br IL_052b
+		IL_04f7: ldloc.s 29
+		IL_04f9: ldstr "filter"
+		IL_04fe: ldloc.s 33
+		IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0505: br IL_0522
 
-		IL_0513: ldloc.s 29
-		IL_0515: ldstr "filter"
-		IL_051a: ldloc.s 33
-		IL_051c: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:99"
-		IL_0521: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
-		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_050a: ldloc.s 29
+		IL_050c: ldstr "filter"
+		IL_0511: ldloc.s 33
+		IL_0513: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:99"
+		IL_0518: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_70
+		IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_052b: stloc.s 10
+		IL_0522: stloc.s 10
 		.try
 		{
-			IL_052d: nop
-			IL_052e: ldloc.s 10
-			IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0535: volatile.
-			IL_0537: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_053c: brfalse IL_0550
+			IL_0524: nop
+			IL_0525: ldloc.s 10
+			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_052c: volatile.
+			IL_052e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_0533: brfalse IL_0547
 
-			IL_0541: ldstr "next"
-			IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_054b: br IL_0564
+			IL_0538: ldstr "next"
+			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0542: br IL_055b
 
-			IL_0550: ldstr "next"
-			IL_0555: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:106"
-			IL_055a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
-			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0547: ldstr "next"
+			IL_054c: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:106"
+			IL_0551: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_71
+			IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0564: pop
-			IL_0565: leave IL_05a1
+			IL_055b: pop
+			IL_055c: leave IL_0598
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_056a: stloc.s 11
-			IL_056c: ldloc.s 11
-			IL_056e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0573: dup
-			IL_0574: brtrue IL_058a
+			IL_0561: stloc.s 11
+			IL_0563: ldloc.s 11
+			IL_0565: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_056a: dup
+			IL_056b: brtrue IL_0581
 
-			IL_0579: pop
-			IL_057a: ldloc.s 11
-			IL_057c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0581: dup
-			IL_0582: brtrue IL_0596
+			IL_0570: pop
+			IL_0571: ldloc.s 11
+			IL_0573: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0578: dup
+			IL_0579: brtrue IL_058d
 
-			IL_0587: pop
-			IL_0588: rethrow
+			IL_057e: pop
+			IL_057f: rethrow
 
-			IL_058a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_058f: stloc.s 12
-			IL_0591: br IL_0598
+			IL_0581: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0586: stloc.s 12
+			IL_0588: br IL_058f
 
-			IL_0596: stloc.s 12
+			IL_058d: stloc.s 12
 
-			IL_0598: ldloc.s 12
-			IL_059a: stloc.s 13
-			IL_059c: leave IL_05a1
+			IL_058f: ldloc.s 12
+			IL_0591: stloc.s 13
+			IL_0593: leave IL_0598
 		} // end handler
 
-		IL_05a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05a6: stloc.s 31
-		IL_05a8: ldloc.s 9
-		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05af: volatile.
-		IL_05b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-		IL_05b6: brfalse IL_05ca
+		IL_0598: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_059d: stloc.s 31
+		IL_059f: ldloc.s 9
+		IL_05a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05a6: volatile.
+		IL_05a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+		IL_05ad: brfalse IL_05c1
 
-		IL_05bb: ldstr "getClosed"
-		IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_05c5: br IL_05de
+		IL_05b2: ldstr "getClosed"
+		IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05bc: br IL_05d5
 
-		IL_05ca: ldstr "getClosed"
-		IL_05cf: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:121"
-		IL_05d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
-		IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_05c1: ldstr "getClosed"
+		IL_05c6: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:121"
+		IL_05cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_72
+		IL_05d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_05de: stloc.s 29
-		IL_05e0: ldloc.s 31
-		IL_05e2: ldloc.s 29
-		IL_05e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05e9: pop
-		IL_05ea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05ef: stloc.s 27
-		IL_05f1: ldloc.1
-		IL_05f2: ldloc.s 27
-		IL_05f4: ldc.r8 3
-		IL_05fd: box [System.Runtime]System.Double
-		IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0607: stloc.s 14
-		IL_0609: ldstr "Iterator"
-		IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0618: stloc.s 29
-		IL_061a: volatile.
-		IL_061c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_0621: brfalse IL_0637
+		IL_05d5: stloc.s 29
+		IL_05d7: ldloc.s 31
+		IL_05d9: ldloc.s 29
+		IL_05db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05e0: pop
+		IL_05e1: ldloc.0
+		IL_05e2: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_05e7: ldnull
+		IL_05e8: ldc.r8 3
+		IL_05f1: box [System.Runtime]System.Double
+		IL_05f6: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_05fb: stloc.s 14
+		IL_05fd: ldstr "Iterator"
+		IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_060c: stloc.s 29
+		IL_060e: volatile.
+		IL_0610: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_0615: brfalse IL_062b
 
-		IL_0626: ldloc.s 14
-		IL_0628: ldstr "iterable"
-		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0632: br IL_064d
+		IL_061a: ldloc.s 14
+		IL_061c: ldstr "iterable"
+		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0626: br IL_0641
 
-		IL_0637: ldloc.s 14
-		IL_0639: ldstr "iterable"
-		IL_063e: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:134"
-		IL_0643: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_0648: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_062b: ldloc.s 14
+		IL_062d: ldstr "iterable"
+		IL_0632: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:134"
+		IL_0637: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_064d: stloc.s 28
-		IL_064f: volatile.
-		IL_0651: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_0656: brfalse IL_066e
+		IL_0641: stloc.s 28
+		IL_0643: volatile.
+		IL_0645: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_064a: brfalse IL_0662
 
-		IL_065b: ldloc.s 29
-		IL_065d: ldstr "from"
-		IL_0662: ldloc.s 28
-		IL_0664: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0669: br IL_0686
+		IL_064f: ldloc.s 29
+		IL_0651: ldstr "from"
+		IL_0656: ldloc.s 28
+		IL_0658: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_065d: br IL_067a
 
-		IL_066e: ldloc.s 29
-		IL_0670: ldstr "from"
-		IL_0675: ldloc.s 28
-		IL_0677: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:135"
-		IL_067c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0662: ldloc.s 29
+		IL_0664: ldstr "from"
+		IL_0669: ldloc.s 28
+		IL_066b: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:135"
+		IL_0670: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0686: stloc.s 28
-		IL_0688: ldloc.s 28
-		IL_068a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_068f: volatile.
-		IL_0691: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-		IL_0696: brfalse IL_06b8
+		IL_067a: stloc.s 28
+		IL_067c: ldloc.s 28
+		IL_067e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0683: volatile.
+		IL_0685: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_068a: brfalse IL_06ac
 
-		IL_069b: ldstr "take"
-		IL_06a0: ldc.r8 0.0
-		IL_06a9: box [System.Runtime]System.Double
-		IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06b3: br IL_06da
+		IL_068f: ldstr "take"
+		IL_0694: ldc.r8 0.0
+		IL_069d: box [System.Runtime]System.Double
+		IL_06a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06a7: br IL_06ce
 
-		IL_06b8: ldstr "take"
-		IL_06bd: ldc.r8 0.0
-		IL_06c6: box [System.Runtime]System.Double
-		IL_06cb: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:139"
-		IL_06d0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-		IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_06ac: ldstr "take"
+		IL_06b1: ldc.r8 0.0
+		IL_06ba: box [System.Runtime]System.Double
+		IL_06bf: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:139"
+		IL_06c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_06c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_06da: stloc.s 15
-		IL_06dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06e1: stloc.s 31
-		IL_06e3: ldloc.s 15
-		IL_06e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06ea: volatile.
-		IL_06ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-		IL_06f1: brfalse IL_0705
+		IL_06ce: stloc.s 15
+		IL_06d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06d5: stloc.s 31
+		IL_06d7: ldloc.s 15
+		IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06de: volatile.
+		IL_06e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+		IL_06e5: brfalse IL_06f9
 
-		IL_06f6: ldstr "next"
-		IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0700: br IL_0719
+		IL_06ea: ldstr "next"
+		IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_06f4: br IL_070d
 
-		IL_0705: ldstr "next"
-		IL_070a: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:144"
-		IL_070f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
-		IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_06f9: ldstr "next"
+		IL_06fe: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:144"
+		IL_0703: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_76
+		IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0719: stloc.s 28
-		IL_071b: volatile.
-		IL_071d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-		IL_0722: brfalse IL_0738
+		IL_070d: stloc.s 28
+		IL_070f: volatile.
+		IL_0711: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+		IL_0716: brfalse IL_072c
 
-		IL_0727: ldloc.s 28
-		IL_0729: ldstr "done"
-		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0733: br IL_074e
+		IL_071b: ldloc.s 28
+		IL_071d: ldstr "done"
+		IL_0722: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0727: br IL_0742
 
-		IL_0738: ldloc.s 28
-		IL_073a: ldstr "done"
-		IL_073f: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:146"
-		IL_0744: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
-		IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_072c: ldloc.s 28
+		IL_072e: ldstr "done"
+		IL_0733: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:146"
+		IL_0738: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_77
+		IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_074e: stloc.s 28
-		IL_0750: ldloc.s 31
-		IL_0752: ldloc.s 28
-		IL_0754: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0759: pop
-		IL_075a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_075f: stloc.s 31
-		IL_0761: ldloc.s 14
-		IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0768: volatile.
-		IL_076a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-		IL_076f: brfalse IL_0783
+		IL_0742: stloc.s 28
+		IL_0744: ldloc.s 31
+		IL_0746: ldloc.s 28
+		IL_0748: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_074d: pop
+		IL_074e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0753: stloc.s 31
+		IL_0755: ldloc.s 14
+		IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_075c: volatile.
+		IL_075e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+		IL_0763: brfalse IL_0777
 
-		IL_0774: ldstr "getClosed"
-		IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_077e: br IL_0797
+		IL_0768: ldstr "getClosed"
+		IL_076d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0772: br IL_078b
 
-		IL_0783: ldstr "getClosed"
-		IL_0788: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:151"
-		IL_078d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
-		IL_0792: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0777: ldstr "getClosed"
+		IL_077c: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:151"
+		IL_0781: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_78
+		IL_0786: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0797: stloc.s 28
-		IL_0799: ldloc.s 31
-		IL_079b: ldloc.s 28
-		IL_079d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07a2: pop
-		IL_07a3: ldloc.0
-		IL_07a4: ldc.r8 0.0
-		IL_07ad: box [System.Runtime]System.Double
-		IL_07b2: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_07b7: ldstr "Iterator"
-		IL_07bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_07c6: ldc.i4.1
-		IL_07c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_07cc: dup
-		IL_07cd: ldc.r8 1
-		IL_07d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_07db: stloc.s 34
-		IL_07dd: volatile.
-		IL_07df: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-		IL_07e4: brfalse IL_07fa
+		IL_078b: stloc.s 28
+		IL_078d: ldloc.s 31
+		IL_078f: ldloc.s 28
+		IL_0791: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0796: pop
+		IL_0797: ldloc.0
+		IL_0798: ldc.r8 0.0
+		IL_07a1: box [System.Runtime]System.Double
+		IL_07a6: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_07ab: ldstr "Iterator"
+		IL_07b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07ba: ldc.i4.1
+		IL_07bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_07c0: dup
+		IL_07c1: ldc.r8 1
+		IL_07ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_07cf: stloc.s 34
+		IL_07d1: volatile.
+		IL_07d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+		IL_07d8: brfalse IL_07ee
 
-		IL_07e9: ldstr "from"
-		IL_07ee: ldloc.s 34
-		IL_07f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_07f5: br IL_0810
+		IL_07dd: ldstr "from"
+		IL_07e2: ldloc.s 34
+		IL_07e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_07e9: br IL_0804
 
-		IL_07fa: ldstr "from"
-		IL_07ff: ldloc.s 34
-		IL_0801: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:163"
-		IL_0806: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
-		IL_080b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_07ee: ldstr "from"
+		IL_07f3: ldloc.s 34
+		IL_07f5: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:163"
+		IL_07fa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_79
+		IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0810: stloc.s 28
-		IL_0812: ldloc.s 28
-		IL_0814: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0819: stloc.s 28
-		IL_081b: ldc.i4.1
-		IL_081c: newarr [System.Runtime]System.Object
-		IL_0821: dup
-		IL_0822: ldc.i4.0
-		IL_0823: ldloc.0
-		IL_0824: stelem.ref
-		IL_0825: stloc.s 27
-		IL_0827: ldloc.s 27
-		IL_0829: ldc.i4.0
-		IL_082a: ldelem.ref
-		IL_082b: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0830: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
-		IL_0835: ldc.i4.1
-		IL_0836: conv.r8
-		IL_0837: ldstr ""
-		IL_083c: ldc.i4.0
-		IL_083d: ldc.i4.0
-		IL_083e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0843: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject>(!!0)
-		IL_0848: stloc.s 35
-		IL_084a: volatile.
-		IL_084c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-		IL_0851: brfalse IL_0869
+		IL_0804: stloc.s 28
+		IL_0806: ldloc.s 28
+		IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_080d: stloc.s 28
+		IL_080f: ldc.i4.1
+		IL_0810: newarr [System.Runtime]System.Object
+		IL_0815: dup
+		IL_0816: ldc.i4.0
+		IL_0817: ldloc.0
+		IL_0818: stelem.ref
+		IL_0819: stloc.s 27
+		IL_081b: ldloc.s 27
+		IL_081d: ldc.i4.0
+		IL_081e: ldelem.ref
+		IL_081f: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0824: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_0829: ldc.i4.1
+		IL_082a: conv.r8
+		IL_082b: ldstr ""
+		IL_0830: ldc.i4.0
+		IL_0831: ldc.i4.0
+		IL_0832: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0837: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionObject>(!!0)
+		IL_083c: stloc.s 35
+		IL_083e: volatile.
+		IL_0840: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+		IL_0845: brfalse IL_085d
 
-		IL_0856: ldloc.s 28
-		IL_0858: ldstr "flatMap"
-		IL_085d: ldloc.s 35
-		IL_085f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0864: br IL_0881
+		IL_084a: ldloc.s 28
+		IL_084c: ldstr "flatMap"
+		IL_0851: ldloc.s 35
+		IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0858: br IL_0875
 
-		IL_0869: ldloc.s 28
-		IL_086b: ldstr "flatMap"
-		IL_0870: ldloc.s 35
-		IL_0872: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:167"
-		IL_0877: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
-		IL_087c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_085d: ldloc.s 28
+		IL_085f: ldstr "flatMap"
+		IL_0864: ldloc.s 35
+		IL_0866: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:167"
+		IL_086b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_80
+		IL_0870: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0881: stloc.s 16
-		IL_0883: ldloc.s 16
-		IL_0885: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_088a: volatile.
-		IL_088c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-		IL_0891: brfalse IL_08a5
+		IL_0875: stloc.s 16
+		IL_0877: ldloc.s 16
+		IL_0879: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_087e: volatile.
+		IL_0880: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_0885: brfalse IL_0899
 
-		IL_0896: ldstr "next"
-		IL_089b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_08a0: br IL_08b9
+		IL_088a: ldstr "next"
+		IL_088f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0894: br IL_08ad
 
-		IL_08a5: ldstr "next"
-		IL_08aa: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:171"
-		IL_08af: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
-		IL_08b4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0899: ldstr "next"
+		IL_089e: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:171"
+		IL_08a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_81
+		IL_08a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_08b9: pop
-		IL_08ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08bf: stloc.s 31
-		IL_08c1: ldloc.s 16
-		IL_08c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_08c8: volatile.
-		IL_08ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-		IL_08cf: brfalse IL_08e3
+		IL_08ad: pop
+		IL_08ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08b3: stloc.s 31
+		IL_08b5: ldloc.s 16
+		IL_08b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_08bc: volatile.
+		IL_08be: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+		IL_08c3: brfalse IL_08d7
 
-		IL_08d4: ldstr "next"
-		IL_08d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_08de: br IL_08f7
+		IL_08c8: ldstr "next"
+		IL_08cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_08d2: br IL_08eb
 
-		IL_08e3: ldstr "next"
-		IL_08e8: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:175"
-		IL_08ed: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
-		IL_08f2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_08d7: ldstr "next"
+		IL_08dc: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:175"
+		IL_08e1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_82
+		IL_08e6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_08f7: stloc.s 28
-		IL_08f9: volatile.
-		IL_08fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-		IL_0900: brfalse IL_0916
+		IL_08eb: stloc.s 28
+		IL_08ed: volatile.
+		IL_08ef: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+		IL_08f4: brfalse IL_090a
 
-		IL_0905: ldloc.s 28
-		IL_0907: ldstr "done"
-		IL_090c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0911: br IL_092c
+		IL_08f9: ldloc.s 28
+		IL_08fb: ldstr "done"
+		IL_0900: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0905: br IL_0920
 
-		IL_0916: ldloc.s 28
-		IL_0918: ldstr "done"
-		IL_091d: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:177"
-		IL_0922: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
-		IL_0927: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_090a: ldloc.s 28
+		IL_090c: ldstr "done"
+		IL_0911: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:177"
+		IL_0916: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_83
+		IL_091b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_092c: stloc.s 28
-		IL_092e: ldloc.s 31
-		IL_0930: ldloc.s 28
-		IL_0932: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0937: pop
-		IL_0938: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_093d: stloc.s 31
-		IL_093f: ldloc.0
-		IL_0940: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_0945: stloc.s 28
-		IL_0947: ldloc.s 31
-		IL_0949: ldloc.s 28
-		IL_094b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0950: pop
-		IL_0951: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0956: stloc.s 27
-		IL_0958: ldloc.1
-		IL_0959: ldloc.s 27
-		IL_095b: ldc.r8 2
-		IL_0964: box [System.Runtime]System.Double
-		IL_0969: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_096e: stloc.s 17
-		IL_0970: ldstr "Iterator"
-		IL_0975: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_097a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_097f: stloc.s 28
-		IL_0981: volatile.
-		IL_0983: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-		IL_0988: brfalse IL_099e
+		IL_0920: stloc.s 28
+		IL_0922: ldloc.s 31
+		IL_0924: ldloc.s 28
+		IL_0926: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_092b: pop
+		IL_092c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0931: stloc.s 31
+		IL_0933: ldloc.0
+		IL_0934: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_0939: stloc.s 28
+		IL_093b: ldloc.s 31
+		IL_093d: ldloc.s 28
+		IL_093f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0944: pop
+		IL_0945: ldloc.0
+		IL_0946: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_094b: ldnull
+		IL_094c: ldc.r8 2
+		IL_0955: box [System.Runtime]System.Double
+		IL_095a: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_095f: stloc.s 17
+		IL_0961: ldstr "Iterator"
+		IL_0966: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_096b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0970: stloc.s 28
+		IL_0972: volatile.
+		IL_0974: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+		IL_0979: brfalse IL_098f
 
-		IL_098d: ldloc.s 17
-		IL_098f: ldstr "iterable"
-		IL_0994: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0999: br IL_09b4
+		IL_097e: ldloc.s 17
+		IL_0980: ldstr "iterable"
+		IL_0985: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_098a: br IL_09a5
 
-		IL_099e: ldloc.s 17
-		IL_09a0: ldstr "iterable"
-		IL_09a5: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:194"
-		IL_09aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
-		IL_09af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_098f: ldloc.s 17
+		IL_0991: ldstr "iterable"
+		IL_0996: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:194"
+		IL_099b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_84
+		IL_09a0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_09b4: stloc.s 29
-		IL_09b6: volatile.
-		IL_09b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-		IL_09bd: brfalse IL_09d5
+		IL_09a5: stloc.s 29
+		IL_09a7: volatile.
+		IL_09a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+		IL_09ae: brfalse IL_09c6
 
-		IL_09c2: ldloc.s 28
-		IL_09c4: ldstr "from"
-		IL_09c9: ldloc.s 29
-		IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_09d0: br IL_09ed
+		IL_09b3: ldloc.s 28
+		IL_09b5: ldstr "from"
+		IL_09ba: ldloc.s 29
+		IL_09bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_09c1: br IL_09de
 
-		IL_09d5: ldloc.s 28
-		IL_09d7: ldstr "from"
-		IL_09dc: ldloc.s 29
-		IL_09de: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:195"
-		IL_09e3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
-		IL_09e8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_09c6: ldloc.s 28
+		IL_09c8: ldstr "from"
+		IL_09cd: ldloc.s 29
+		IL_09cf: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:195"
+		IL_09d4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_85
+		IL_09d9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_09ed: stloc.s 29
-		IL_09ef: ldloc.s 29
-		IL_09f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_09f6: stloc.s 29
-		IL_09f8: ldc.i4.1
-		IL_09f9: newarr [System.Runtime]System.Object
-		IL_09fe: dup
-		IL_09ff: ldc.i4.0
-		IL_0a00: ldloc.0
-		IL_0a01: stelem.ref
-		IL_0a02: stloc.s 27
-		IL_0a04: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject::.ctor()
-		IL_0a09: ldc.i4.1
-		IL_0a0a: conv.r8
-		IL_0a0b: ldstr ""
-		IL_0a10: ldc.i4.0
-		IL_0a11: ldc.i4.0
-		IL_0a12: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0a17: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject>(!!0)
-		IL_0a1c: stloc.s 36
-		IL_0a1e: volatile.
-		IL_0a20: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-		IL_0a25: brfalse IL_0a3d
+		IL_09de: stloc.s 29
+		IL_09e0: ldloc.s 29
+		IL_09e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_09e7: stloc.s 29
+		IL_09e9: ldc.i4.1
+		IL_09ea: newarr [System.Runtime]System.Object
+		IL_09ef: dup
+		IL_09f0: ldc.i4.0
+		IL_09f1: ldloc.0
+		IL_09f2: stelem.ref
+		IL_09f3: stloc.s 27
+		IL_09f5: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject::.ctor()
+		IL_09fa: ldc.i4.1
+		IL_09fb: conv.r8
+		IL_09fc: ldstr ""
+		IL_0a01: ldc.i4.0
+		IL_0a02: ldc.i4.0
+		IL_0a03: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a08: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74/FunctionObject>(!!0)
+		IL_0a0d: stloc.s 36
+		IL_0a0f: volatile.
+		IL_0a11: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+		IL_0a16: brfalse IL_0a2e
 
-		IL_0a2a: ldloc.s 29
-		IL_0a2c: ldstr "flatMap"
-		IL_0a31: ldloc.s 36
-		IL_0a33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0a38: br IL_0a55
+		IL_0a1b: ldloc.s 29
+		IL_0a1d: ldstr "flatMap"
+		IL_0a22: ldloc.s 36
+		IL_0a24: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0a29: br IL_0a46
 
-		IL_0a3d: ldloc.s 29
-		IL_0a3f: ldstr "flatMap"
-		IL_0a44: ldloc.s 36
-		IL_0a46: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:199"
-		IL_0a4b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
-		IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0a2e: ldloc.s 29
+		IL_0a30: ldstr "flatMap"
+		IL_0a35: ldloc.s 36
+		IL_0a37: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:199"
+		IL_0a3c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_86
+		IL_0a41: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0a55: stloc.s 18
+		IL_0a46: stloc.s 18
 		.try
 		{
-			IL_0a57: nop
-			IL_0a58: ldloc.s 18
-			IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a5f: volatile.
-			IL_0a61: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_0a66: brfalse IL_0a7a
+			IL_0a48: nop
+			IL_0a49: ldloc.s 18
+			IL_0a4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a50: volatile.
+			IL_0a52: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0a57: brfalse IL_0a6b
+
+			IL_0a5c: ldstr "next"
+			IL_0a61: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0a66: br IL_0a7f
 
 			IL_0a6b: ldstr "next"
-			IL_0a70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0a75: br IL_0a8e
+			IL_0a70: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:206"
+			IL_0a75: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
+			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0a7a: ldstr "next"
-			IL_0a7f: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:206"
-			IL_0a84: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_87
-			IL_0a89: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
-
-			IL_0a8e: pop
-			IL_0a8f: leave IL_0acb
+			IL_0a7f: pop
+			IL_0a80: leave IL_0abc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0a94: stloc.s 19
-			IL_0a96: ldloc.s 19
-			IL_0a98: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0a9d: dup
-			IL_0a9e: brtrue IL_0ab4
+			IL_0a85: stloc.s 19
+			IL_0a87: ldloc.s 19
+			IL_0a89: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0a8e: dup
+			IL_0a8f: brtrue IL_0aa5
 
-			IL_0aa3: pop
-			IL_0aa4: ldloc.s 19
-			IL_0aa6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0aab: dup
-			IL_0aac: brtrue IL_0ac0
+			IL_0a94: pop
+			IL_0a95: ldloc.s 19
+			IL_0a97: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0a9c: dup
+			IL_0a9d: brtrue IL_0ab1
 
-			IL_0ab1: pop
-			IL_0ab2: rethrow
+			IL_0aa2: pop
+			IL_0aa3: rethrow
 
-			IL_0ab4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0ab9: stloc.s 20
-			IL_0abb: br IL_0ac2
+			IL_0aa5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0aaa: stloc.s 20
+			IL_0aac: br IL_0ab3
 
-			IL_0ac0: stloc.s 20
+			IL_0ab1: stloc.s 20
 
-			IL_0ac2: ldloc.s 20
-			IL_0ac4: stloc.s 21
-			IL_0ac6: leave IL_0acb
+			IL_0ab3: ldloc.s 20
+			IL_0ab5: stloc.s 21
+			IL_0ab7: leave IL_0abc
 		} // end handler
 
-		IL_0acb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0ad0: stloc.s 31
-		IL_0ad2: ldloc.s 17
-		IL_0ad4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0ad9: volatile.
-		IL_0adb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-		IL_0ae0: brfalse IL_0af4
+		IL_0abc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ac1: stloc.s 31
+		IL_0ac3: ldloc.s 17
+		IL_0ac5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0aca: volatile.
+		IL_0acc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+		IL_0ad1: brfalse IL_0ae5
+
+		IL_0ad6: ldstr "getClosed"
+		IL_0adb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0ae0: br IL_0af9
 
 		IL_0ae5: ldstr "getClosed"
-		IL_0aea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0aef: br IL_0b08
+		IL_0aea: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:221"
+		IL_0aef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
+		IL_0af4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0af4: ldstr "getClosed"
-		IL_0af9: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:221"
-		IL_0afe: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_88
-		IL_0b03: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0af9: stloc.s 29
+		IL_0afb: ldloc.s 31
+		IL_0afd: ldloc.s 29
+		IL_0aff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0b04: pop
+		IL_0b05: ldloc.0
+		IL_0b06: ldc.r8 0.0
+		IL_0b0f: box [System.Runtime]System.Double
+		IL_0b14: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_0b19: ldloc.0
+		IL_0b1a: ldc.r8 0.0
+		IL_0b23: box [System.Runtime]System.Double
+		IL_0b28: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_0b2d: ldstr "Iterator"
+		IL_0b32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b37: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0b3c: stloc.s 29
+		IL_0b3e: ldstr "iterator"
+		IL_0b43: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_0b48: stloc.s 28
+		IL_0b4a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0b4f: stloc.s 37
+		IL_0b51: ldc.i4.1
+		IL_0b52: newarr [System.Runtime]System.Object
+		IL_0b57: dup
+		IL_0b58: ldc.i4.0
+		IL_0b59: ldloc.0
+		IL_0b5a: stelem.ref
+		IL_0b5b: stloc.s 27
+		IL_0b5d: ldloc.s 37
+		IL_0b5f: ldloc.s 28
+		IL_0b61: ldloc.s 27
+		IL_0b63: ldc.i4.0
+		IL_0b64: ldelem.ref
+		IL_0b65: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0b6a: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_0b6f: ldc.i4.0
+		IL_0b70: conv.r8
+		IL_0b71: ldstr ""
+		IL_0b76: ldc.i4.0
+		IL_0b77: ldc.i4.0
+		IL_0b78: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b7d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0)
+		IL_0b82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_0b87: pop
+		IL_0b88: volatile.
+		IL_0b8a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+		IL_0b8f: brfalse IL_0ba7
 
-		IL_0b08: stloc.s 29
-		IL_0b0a: ldloc.s 31
-		IL_0b0c: ldloc.s 29
-		IL_0b0e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0b13: pop
-		IL_0b14: ldloc.0
-		IL_0b15: ldc.r8 0.0
-		IL_0b1e: box [System.Runtime]System.Double
-		IL_0b23: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_0b28: ldloc.0
-		IL_0b29: ldc.r8 0.0
-		IL_0b32: box [System.Runtime]System.Double
-		IL_0b37: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_0b3c: ldstr "Iterator"
-		IL_0b41: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0b4b: stloc.s 29
-		IL_0b4d: ldstr "iterator"
-		IL_0b52: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_0b57: stloc.s 28
-		IL_0b59: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0b5e: stloc.s 37
-		IL_0b60: ldc.i4.1
-		IL_0b61: newarr [System.Runtime]System.Object
-		IL_0b66: dup
-		IL_0b67: ldc.i4.0
-		IL_0b68: ldloc.0
-		IL_0b69: stelem.ref
-		IL_0b6a: stloc.s 27
-		IL_0b6c: ldloc.s 37
-		IL_0b6e: ldloc.s 28
-		IL_0b70: ldloc.s 27
-		IL_0b72: ldc.i4.0
-		IL_0b73: ldelem.ref
-		IL_0b74: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0b79: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
-		IL_0b7e: ldc.i4.0
-		IL_0b7f: conv.r8
-		IL_0b80: ldstr ""
-		IL_0b85: ldc.i4.0
-		IL_0b86: ldc.i4.0
-		IL_0b87: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b8c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0)
-		IL_0b91: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_0b96: pop
-		IL_0b97: volatile.
-		IL_0b99: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
-		IL_0b9e: brfalse IL_0bb6
+		IL_0b94: ldloc.s 29
+		IL_0b96: ldstr "from"
+		IL_0b9b: ldloc.s 37
+		IL_0b9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0ba2: br IL_0bbf
 
-		IL_0ba3: ldloc.s 29
-		IL_0ba5: ldstr "from"
-		IL_0baa: ldloc.s 37
-		IL_0bac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0bb1: br IL_0bce
+		IL_0ba7: ldloc.s 29
+		IL_0ba9: ldstr "from"
+		IL_0bae: ldloc.s 37
+		IL_0bb0: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:241"
+		IL_0bb5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
+		IL_0bba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0bb6: ldloc.s 29
-		IL_0bb8: ldstr "from"
-		IL_0bbd: ldloc.s 37
-		IL_0bbf: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:241"
-		IL_0bc4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_89
-		IL_0bc9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0bbf: stloc.s 29
+		IL_0bc1: ldloc.s 29
+		IL_0bc3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0bc8: stloc.s 29
+		IL_0bca: ldc.i4.1
+		IL_0bcb: newarr [System.Runtime]System.Object
+		IL_0bd0: dup
+		IL_0bd1: ldc.i4.0
+		IL_0bd2: ldloc.0
+		IL_0bd3: stelem.ref
+		IL_0bd4: stloc.s 27
+		IL_0bd6: ldloc.s 27
+		IL_0bd8: ldc.i4.0
+		IL_0bd9: ldelem.ref
+		IL_0bda: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0bdf: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_0be4: ldc.i4.1
+		IL_0be5: conv.r8
+		IL_0be6: ldstr ""
+		IL_0beb: ldc.i4.0
+		IL_0bec: ldc.i4.0
+		IL_0bed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0bf2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0)
+		IL_0bf7: stloc.s 38
+		IL_0bf9: volatile.
+		IL_0bfb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+		IL_0c00: brfalse IL_0c18
 
-		IL_0bce: stloc.s 29
-		IL_0bd0: ldloc.s 29
-		IL_0bd2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0bd7: stloc.s 29
-		IL_0bd9: ldc.i4.1
-		IL_0bda: newarr [System.Runtime]System.Object
-		IL_0bdf: dup
-		IL_0be0: ldc.i4.0
-		IL_0be1: ldloc.0
-		IL_0be2: stelem.ref
-		IL_0be3: stloc.s 27
-		IL_0be5: ldloc.s 27
-		IL_0be7: ldc.i4.0
-		IL_0be8: ldelem.ref
-		IL_0be9: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0bee: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
-		IL_0bf3: ldc.i4.1
-		IL_0bf4: conv.r8
-		IL_0bf5: ldstr ""
-		IL_0bfa: ldc.i4.0
-		IL_0bfb: ldc.i4.0
-		IL_0bfc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0c01: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionObject>(!!0)
-		IL_0c06: stloc.s 38
-		IL_0c08: volatile.
-		IL_0c0a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
-		IL_0c0f: brfalse IL_0c27
+		IL_0c05: ldloc.s 29
+		IL_0c07: ldstr "flatMap"
+		IL_0c0c: ldloc.s 38
+		IL_0c0e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0c13: br IL_0c30
 
-		IL_0c14: ldloc.s 29
-		IL_0c16: ldstr "flatMap"
-		IL_0c1b: ldloc.s 38
-		IL_0c1d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0c22: br IL_0c3f
+		IL_0c18: ldloc.s 29
+		IL_0c1a: ldstr "flatMap"
+		IL_0c1f: ldloc.s 38
+		IL_0c21: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:245"
+		IL_0c26: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
+		IL_0c2b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0c27: ldloc.s 29
-		IL_0c29: ldstr "flatMap"
-		IL_0c2e: ldloc.s 38
-		IL_0c30: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:245"
-		IL_0c35: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_90
-		IL_0c3a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
-
-		IL_0c3f: stloc.s 22
+		IL_0c30: stloc.s 22
 		.try
 		{
-			IL_0c41: nop
-			IL_0c42: ldloc.s 22
-			IL_0c44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c49: volatile.
-			IL_0c4b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0c50: brfalse IL_0c64
+			IL_0c32: nop
+			IL_0c33: ldloc.s 22
+			IL_0c35: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c3a: volatile.
+			IL_0c3c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0c41: brfalse IL_0c55
+
+			IL_0c46: ldstr "next"
+			IL_0c4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0c50: br IL_0c69
 
 			IL_0c55: ldstr "next"
-			IL_0c5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0c5f: br IL_0c78
+			IL_0c5a: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:252"
+			IL_0c5f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
+			IL_0c64: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0c64: ldstr "next"
-			IL_0c69: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:252"
-			IL_0c6e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_91
-			IL_0c73: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0c69: pop
+			IL_0c6a: ldloc.s 22
+			IL_0c6c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0c71: volatile.
+			IL_0c73: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_0c78: brfalse IL_0c8c
 
-			IL_0c78: pop
-			IL_0c79: ldloc.s 22
-			IL_0c7b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0c80: volatile.
-			IL_0c82: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
-			IL_0c87: brfalse IL_0c9b
+			IL_0c7d: ldstr "next"
+			IL_0c82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0c87: br IL_0ca0
 
 			IL_0c8c: ldstr "next"
-			IL_0c91: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0c96: br IL_0caf
+			IL_0c91: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:255"
+			IL_0c96: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
+			IL_0c9b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0c9b: ldstr "next"
-			IL_0ca0: ldstr "Iterator_Helper_Cleanup:Modules.Iterator_Helper_Cleanup:__js_module_init__:255"
-			IL_0ca5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_92
-			IL_0caa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
-
-			IL_0caf: pop
-			IL_0cb0: leave IL_0cec
+			IL_0ca0: pop
+			IL_0ca1: leave IL_0cdd
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0cb5: stloc.s 23
-			IL_0cb7: ldloc.s 23
-			IL_0cb9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0cbe: dup
-			IL_0cbf: brtrue IL_0cd5
+			IL_0ca6: stloc.s 23
+			IL_0ca8: ldloc.s 23
+			IL_0caa: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0caf: dup
+			IL_0cb0: brtrue IL_0cc6
 
-			IL_0cc4: pop
-			IL_0cc5: ldloc.s 23
-			IL_0cc7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0ccc: dup
-			IL_0ccd: brtrue IL_0ce1
+			IL_0cb5: pop
+			IL_0cb6: ldloc.s 23
+			IL_0cb8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0cbd: dup
+			IL_0cbe: brtrue IL_0cd2
 
-			IL_0cd2: pop
-			IL_0cd3: rethrow
+			IL_0cc3: pop
+			IL_0cc4: rethrow
 
-			IL_0cd5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0cda: stloc.s 24
-			IL_0cdc: br IL_0ce3
+			IL_0cc6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0ccb: stloc.s 24
+			IL_0ccd: br IL_0cd4
 
-			IL_0ce1: stloc.s 24
+			IL_0cd2: stloc.s 24
 
-			IL_0ce3: ldloc.s 24
-			IL_0ce5: stloc.s 25
-			IL_0ce7: leave IL_0cec
+			IL_0cd4: ldloc.s 24
+			IL_0cd6: stloc.s 25
+			IL_0cd8: leave IL_0cdd
 		} // end handler
 
-		IL_0cec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0cf1: stloc.s 31
-		IL_0cf3: ldloc.0
-		IL_0cf4: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_0cf9: stloc.s 29
-		IL_0cfb: ldloc.s 31
-		IL_0cfd: ldloc.s 29
-		IL_0cff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0d04: pop
-		IL_0d05: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0d0a: stloc.s 31
-		IL_0d0c: ldloc.0
-		IL_0d0d: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_0d12: stloc.s 29
-		IL_0d14: ldloc.s 31
-		IL_0d16: ldloc.s 29
-		IL_0d18: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0d1d: pop
-		IL_0d1e: ldnull
-		IL_0d1f: stloc.s 26
-		IL_0d21: ret
+		IL_0cdd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ce2: stloc.s 31
+		IL_0ce4: ldloc.0
+		IL_0ce5: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_0cea: stloc.s 29
+		IL_0cec: ldloc.s 31
+		IL_0cee: ldloc.s 29
+		IL_0cf0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0cf5: pop
+		IL_0cf6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0cfb: stloc.s 31
+		IL_0cfd: ldloc.0
+		IL_0cfe: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_0d03: stloc.s 29
+		IL_0d05: ldloc.s 31
+		IL_0d07: ldloc.s 29
+		IL_0d09: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0d0e: pop
+		IL_0d0f: ldnull
+		IL_0d10: stloc.s 26
+		IL_0d12: ret
 	} // end of method Iterator_Helper_Cleanup::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Cleanup

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Fround_SignedZero.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Fround_SignedZero.verified.txt
@@ -300,7 +300,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 156 (0x9c)
+		// Code size: 146 (0x92)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Fround_SignedZero/Scope,
@@ -354,21 +354,18 @@
 		IL_006e: pop
 		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0074: stloc.s 5
-		IL_0076: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_007b: stloc.s 4
-		IL_007d: ldloc.3
-		IL_007e: box [System.Runtime]System.Double
-		IL_0083: stloc.s 7
-		IL_0085: ldloc.1
-		IL_0086: ldloc.s 4
-		IL_0088: ldloc.s 7
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_008f: stloc.s 8
-		IL_0091: ldloc.s 5
-		IL_0093: ldloc.s 8
-		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009a: pop
-		IL_009b: ret
+		IL_0076: ldloc.3
+		IL_0077: box [System.Runtime]System.Double
+		IL_007c: stloc.s 7
+		IL_007e: ldnull
+		IL_007f: ldloc.3
+		IL_0080: call object Modules.Math_Fround_SignedZero/toStr::__js_call__(object, float64)
+		IL_0085: stloc.s 8
+		IL_0087: ldloc.s 5
+		IL_0089: ldloc.s 8
+		IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0090: pop
+		IL_0091: ret
 	} // end of method Math_Fround_SignedZero::__js_module_init__
 
 } // end of class Modules.Math_Fround_SignedZero

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Imul_Clz32_Basics.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Imul_Clz32_Basics.verified.txt
@@ -300,7 +300,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 368 (0x170)
+		// Code size: 359 (0x167)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Imul_Clz32_Basics/Scope,
@@ -387,42 +387,39 @@
 		IL_0102: ldstr " "
 		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 		IL_010c: stloc.s 10
-		IL_010e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0113: stloc.s 8
-		IL_0115: ldloc.s 4
-		IL_0117: box [System.Runtime]System.Double
-		IL_011c: stloc.s 11
-		IL_011e: ldloc.1
-		IL_011f: ldloc.s 8
-		IL_0121: ldloc.s 11
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0128: stloc.s 12
-		IL_012a: ldloc.s 10
-		IL_012c: ldloc.s 12
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0133: stloc.s 10
-		IL_0135: ldloc.s 9
-		IL_0137: ldloc.s 10
-		IL_0139: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013e: pop
-		IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0144: stloc.s 9
-		IL_0146: ldloc.s 5
+		IL_010e: ldloc.s 4
+		IL_0110: box [System.Runtime]System.Double
+		IL_0115: stloc.s 11
+		IL_0117: ldnull
+		IL_0118: ldloc.s 4
+		IL_011a: call object Modules.Math_Imul_Clz32_Basics/toStr::__js_call__(object, float64)
+		IL_011f: stloc.s 12
+		IL_0121: ldloc.s 10
+		IL_0123: ldloc.s 12
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_012a: stloc.s 10
+		IL_012c: ldloc.s 9
+		IL_012e: ldloc.s 10
+		IL_0130: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0135: pop
+		IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013b: stloc.s 9
+		IL_013d: ldloc.s 5
+		IL_013f: box [System.Runtime]System.Double
+		IL_0144: stloc.s 11
+		IL_0146: ldloc.s 6
 		IL_0148: box [System.Runtime]System.Double
-		IL_014d: stloc.s 11
-		IL_014f: ldloc.s 6
+		IL_014d: stloc.s 13
+		IL_014f: ldloc.s 7
 		IL_0151: box [System.Runtime]System.Double
-		IL_0156: stloc.s 13
-		IL_0158: ldloc.s 7
-		IL_015a: box [System.Runtime]System.Double
-		IL_015f: stloc.s 14
-		IL_0161: ldloc.s 9
-		IL_0163: ldloc.s 11
-		IL_0165: ldloc.s 13
-		IL_0167: ldloc.s 14
-		IL_0169: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_016e: pop
-		IL_016f: ret
+		IL_0156: stloc.s 14
+		IL_0158: ldloc.s 9
+		IL_015a: ldloc.s 11
+		IL_015c: ldloc.s 13
+		IL_015e: ldloc.s 14
+		IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0165: pop
+		IL_0166: ret
 	} // end of method Math_Imul_Clz32_Basics::__js_module_init__
 
 } // end of class Modules.Math_Imul_Clz32_Basics

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -711,7 +711,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 352 (0x160)
+				// Code size: 328 (0x148)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -835,27 +835,11 @@
 				IL_0138: ldc.i4.0
 				IL_0139: ldelem.ref
 				IL_013a: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-				IL_013f: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::runSilentFalse
-				IL_0144: stloc.1
-				IL_0145: ldloc.1
-				IL_0146: ldc.i4.2
-				IL_0147: newarr [System.Runtime]System.Object
-				IL_014c: dup
-				IL_014d: ldc.i4.0
-				IL_014e: ldarg.0
-				IL_014f: ldc.i4.0
-				IL_0150: ldelem.ref
-				IL_0151: stelem.ref
-				IL_0152: dup
-				IL_0153: ldc.i4.1
-				IL_0154: ldarg.0
-				IL_0155: ldc.i4.1
-				IL_0156: ldelem.ref
-				IL_0157: stelem.ref
-				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_015d: pop
-				IL_015e: ldnull
-				IL_015f: ret
+				IL_013f: ldnull
+				IL_0140: call object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
+				IL_0145: pop
+				IL_0146: ldnull
+				IL_0147: ret
 			} // end of method ArrowFunction_L31C23::__js_call__
 
 		} // end of class ArrowFunction_L31C23
@@ -2152,7 +2136,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 146 (0x92)
+		// Code size: 147 (0x93)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Silent/Scope,
@@ -2223,11 +2207,12 @@
 
 		IL_0083: nop
 		IL_0084: nop
-		IL_0085: ldloc.1
-		IL_0086: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0090: pop
-		IL_0091: ret
+		IL_0085: ldloc.0
+		IL_0086: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+		IL_008b: ldnull
+		IL_008c: call object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
+		IL_0091: pop
+		IL_0092: ret
 	} // end of method Require_ChildProcess_Fork_Silent::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Silent

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -6780,7 +6780,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1787 (0x6fb)
+		// Code size: 1616 (0x650)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_ErrorPaths/Scope,
@@ -6789,29 +6789,28 @@
 			[3] object[],
 			[4] class Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject,
 			[5] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
-			[6] object[],
-			[7] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28/FunctionObject,
-			[8] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35/FunctionObject,
-			[9] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33/FunctionObject,
-			[10] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40/FunctionObject,
-			[11] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27/FunctionObject,
-			[12] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29/FunctionObject,
-			[13] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35/FunctionObject,
-			[14] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39/FunctionObject,
-			[15] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36/FunctionObject,
-			[16] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30/FunctionObject,
-			[17] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36/FunctionObject,
-			[18] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37/FunctionObject,
-			[19] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36/FunctionObject,
-			[20] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33/FunctionObject,
-			[21] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36/FunctionObject,
-			[22] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30/FunctionObject,
-			[23] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34/FunctionObject,
-			[24] object,
-			[25] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[26] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject,
-			[27] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject,
-			[28] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject
+			[6] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28/FunctionObject,
+			[7] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35/FunctionObject,
+			[8] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33/FunctionObject,
+			[9] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40/FunctionObject,
+			[10] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27/FunctionObject,
+			[11] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29/FunctionObject,
+			[12] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35/FunctionObject,
+			[13] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39/FunctionObject,
+			[14] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36/FunctionObject,
+			[15] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30/FunctionObject,
+			[16] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36/FunctionObject,
+			[17] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37/FunctionObject,
+			[18] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36/FunctionObject,
+			[19] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33/FunctionObject,
+			[20] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36/FunctionObject,
+			[21] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30/FunctionObject,
+			[22] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34/FunctionObject,
+			[23] object,
+			[24] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[25] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject,
+			[26] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject,
+			[27] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Require_Crypto_ErrorPaths/Scope::.ctor()
@@ -6881,648 +6880,591 @@
 		IL_008f: ldloc.s 5
 		IL_0091: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
 		IL_0096: nop
-		IL_0097: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_009c: stloc.3
-		IL_009d: ldc.i4.1
-		IL_009e: newarr [System.Runtime]System.Object
-		IL_00a3: dup
-		IL_00a4: ldc.i4.0
-		IL_00a5: ldloc.0
-		IL_00a6: stelem.ref
-		IL_00a7: stloc.s 6
-		IL_00a9: ldloc.s 6
-		IL_00ab: ldc.i4.0
-		IL_00ac: ldelem.ref
-		IL_00ad: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_00b2: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_0097: ldc.i4.1
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldloc.0
+		IL_00a0: stelem.ref
+		IL_00a1: stloc.3
+		IL_00a2: ldloc.3
+		IL_00a3: ldc.i4.0
+		IL_00a4: ldelem.ref
+		IL_00a5: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_00aa: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_00af: ldc.i4.0
+		IL_00b0: conv.r8
+		IL_00b1: ldstr ""
+		IL_00b6: ldc.i4.0
 		IL_00b7: ldc.i4.0
-		IL_00b8: conv.r8
-		IL_00b9: ldstr ""
-		IL_00be: ldc.i4.0
-		IL_00bf: ldc.i4.0
-		IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28/FunctionObject>(!!0)
-		IL_00ca: stloc.s 7
-		IL_00cc: ldloc.1
-		IL_00cd: ldloc.3
-		IL_00ce: ldstr "algorithm type"
-		IL_00d3: ldloc.s 7
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00da: pop
-		IL_00db: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00e0: stloc.3
-		IL_00e1: ldc.i4.1
-		IL_00e2: newarr [System.Runtime]System.Object
-		IL_00e7: dup
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldloc.0
-		IL_00ea: stelem.ref
-		IL_00eb: stloc.s 6
-		IL_00ed: ldloc.s 6
-		IL_00ef: ldc.i4.0
-		IL_00f0: ldelem.ref
-		IL_00f1: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_00f6: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_00fb: ldc.i4.0
-		IL_00fc: conv.r8
-		IL_00fd: ldstr ""
-		IL_0102: ldc.i4.0
-		IL_0103: ldc.i4.0
-		IL_0104: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35/FunctionObject>(!!0)
-		IL_010e: stloc.s 8
-		IL_0110: ldloc.1
-		IL_0111: ldloc.3
-		IL_0112: ldstr "algorithm unsupported"
-		IL_0117: ldloc.s 8
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_011e: pop
-		IL_011f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0124: stloc.3
-		IL_0125: ldc.i4.1
-		IL_0126: newarr [System.Runtime]System.Object
-		IL_012b: dup
+		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28/FunctionObject>(!!0)
+		IL_00c2: stloc.s 6
+		IL_00c4: ldnull
+		IL_00c5: ldstr "algorithm type"
+		IL_00ca: ldloc.s 6
+		IL_00cc: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_00d1: pop
+		IL_00d2: ldc.i4.1
+		IL_00d3: newarr [System.Runtime]System.Object
+		IL_00d8: dup
+		IL_00d9: ldc.i4.0
+		IL_00da: ldloc.0
+		IL_00db: stelem.ref
+		IL_00dc: stloc.3
+		IL_00dd: ldloc.3
+		IL_00de: ldc.i4.0
+		IL_00df: ldelem.ref
+		IL_00e0: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_00e5: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_00ea: ldc.i4.0
+		IL_00eb: conv.r8
+		IL_00ec: ldstr ""
+		IL_00f1: ldc.i4.0
+		IL_00f2: ldc.i4.0
+		IL_00f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35/FunctionObject>(!!0)
+		IL_00fd: stloc.s 7
+		IL_00ff: ldnull
+		IL_0100: ldstr "algorithm unsupported"
+		IL_0105: ldloc.s 7
+		IL_0107: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_010c: pop
+		IL_010d: ldc.i4.1
+		IL_010e: newarr [System.Runtime]System.Object
+		IL_0113: dup
+		IL_0114: ldc.i4.0
+		IL_0115: ldloc.0
+		IL_0116: stelem.ref
+		IL_0117: stloc.3
+		IL_0118: ldloc.3
+		IL_0119: ldc.i4.0
+		IL_011a: ldelem.ref
+		IL_011b: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0120: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_0125: ldc.i4.0
+		IL_0126: conv.r8
+		IL_0127: ldstr ""
 		IL_012c: ldc.i4.0
-		IL_012d: ldloc.0
-		IL_012e: stelem.ref
-		IL_012f: stloc.s 6
-		IL_0131: ldloc.s 6
-		IL_0133: ldc.i4.0
-		IL_0134: ldelem.ref
-		IL_0135: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_013a: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_013f: ldc.i4.0
-		IL_0140: conv.r8
-		IL_0141: ldstr ""
-		IL_0146: ldc.i4.0
-		IL_0147: ldc.i4.0
-		IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_014d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33/FunctionObject>(!!0)
-		IL_0152: stloc.s 9
-		IL_0154: ldloc.1
-		IL_0155: ldloc.3
-		IL_0156: ldstr "hmac algorithm type"
-		IL_015b: ldloc.s 9
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0162: pop
-		IL_0163: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0168: stloc.3
-		IL_0169: ldc.i4.1
-		IL_016a: newarr [System.Runtime]System.Object
-		IL_016f: dup
-		IL_0170: ldc.i4.0
-		IL_0171: ldloc.0
-		IL_0172: stelem.ref
-		IL_0173: stloc.s 6
-		IL_0175: ldloc.s 6
-		IL_0177: ldc.i4.0
-		IL_0178: ldelem.ref
-		IL_0179: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_017e: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_0183: ldc.i4.0
-		IL_0184: conv.r8
-		IL_0185: ldstr ""
+		IL_012d: ldc.i4.0
+		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0133: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33/FunctionObject>(!!0)
+		IL_0138: stloc.s 8
+		IL_013a: ldnull
+		IL_013b: ldstr "hmac algorithm type"
+		IL_0140: ldloc.s 8
+		IL_0142: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_0147: pop
+		IL_0148: ldc.i4.1
+		IL_0149: newarr [System.Runtime]System.Object
+		IL_014e: dup
+		IL_014f: ldc.i4.0
+		IL_0150: ldloc.0
+		IL_0151: stelem.ref
+		IL_0152: stloc.3
+		IL_0153: ldloc.3
+		IL_0154: ldc.i4.0
+		IL_0155: ldelem.ref
+		IL_0156: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_015b: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_0160: ldc.i4.0
+		IL_0161: conv.r8
+		IL_0162: ldstr ""
+		IL_0167: ldc.i4.0
+		IL_0168: ldc.i4.0
+		IL_0169: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_016e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40/FunctionObject>(!!0)
+		IL_0173: stloc.s 9
+		IL_0175: ldnull
+		IL_0176: ldstr "hmac algorithm unsupported"
+		IL_017b: ldloc.s 9
+		IL_017d: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_0182: pop
+		IL_0183: ldc.i4.1
+		IL_0184: newarr [System.Runtime]System.Object
+		IL_0189: dup
 		IL_018a: ldc.i4.0
-		IL_018b: ldc.i4.0
-		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0191: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40/FunctionObject>(!!0)
-		IL_0196: stloc.s 10
-		IL_0198: ldloc.1
-		IL_0199: ldloc.3
-		IL_019a: ldstr "hmac algorithm unsupported"
-		IL_019f: ldloc.s 10
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01a6: pop
-		IL_01a7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01ac: stloc.3
-		IL_01ad: ldc.i4.1
-		IL_01ae: newarr [System.Runtime]System.Object
-		IL_01b3: dup
-		IL_01b4: ldc.i4.0
-		IL_01b5: ldloc.0
-		IL_01b6: stelem.ref
-		IL_01b7: stloc.s 6
-		IL_01b9: ldloc.s 6
-		IL_01bb: ldc.i4.0
-		IL_01bc: ldelem.ref
-		IL_01bd: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_01c2: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_01c7: ldc.i4.0
-		IL_01c8: conv.r8
-		IL_01c9: ldstr ""
-		IL_01ce: ldc.i4.0
-		IL_01cf: ldc.i4.0
-		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27/FunctionObject>(!!0)
-		IL_01da: stloc.s 11
-		IL_01dc: ldloc.1
-		IL_01dd: ldloc.3
-		IL_01de: ldstr "hmac key null"
-		IL_01e3: ldloc.s 11
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01ea: pop
-		IL_01eb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01f0: stloc.3
-		IL_01f1: ldc.i4.1
-		IL_01f2: newarr [System.Runtime]System.Object
-		IL_01f7: dup
-		IL_01f8: ldc.i4.0
-		IL_01f9: ldloc.0
-		IL_01fa: stelem.ref
-		IL_01fb: stloc.s 6
-		IL_01fd: ldloc.s 6
-		IL_01ff: ldc.i4.0
-		IL_0200: ldelem.ref
-		IL_0201: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0206: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_020b: ldc.i4.0
-		IL_020c: conv.r8
-		IL_020d: ldstr ""
-		IL_0212: ldc.i4.0
-		IL_0213: ldc.i4.0
-		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29/FunctionObject>(!!0)
-		IL_021e: stloc.s 12
-		IL_0220: ldloc.1
-		IL_0221: ldloc.3
-		IL_0222: ldstr "hmac key number"
-		IL_0227: ldloc.s 12
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_022e: pop
-		IL_022f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0234: stloc.3
-		IL_0235: ldc.i4.1
-		IL_0236: newarr [System.Runtime]System.Object
-		IL_023b: dup
-		IL_023c: ldc.i4.0
-		IL_023d: ldloc.0
-		IL_023e: stelem.ref
-		IL_023f: stloc.s 6
-		IL_0241: ldloc.s 6
-		IL_0243: ldc.i4.0
-		IL_0244: ldelem.ref
-		IL_0245: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_024a: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_024f: ldc.i4.0
-		IL_0250: conv.r8
-		IL_0251: ldstr ""
-		IL_0256: ldc.i4.0
-		IL_0257: ldc.i4.0
-		IL_0258: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_025d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35/FunctionObject>(!!0)
-		IL_0262: stloc.s 13
-		IL_0264: ldloc.1
-		IL_0265: ldloc.3
-		IL_0266: ldstr "pbkdf2 digest missing"
-		IL_026b: ldloc.s 13
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0272: pop
-		IL_0273: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0278: stloc.3
-		IL_0279: ldc.i4.1
-		IL_027a: newarr [System.Runtime]System.Object
-		IL_027f: dup
-		IL_0280: ldc.i4.0
-		IL_0281: ldloc.0
-		IL_0282: stelem.ref
-		IL_0283: stloc.s 6
-		IL_0285: ldloc.s 6
+		IL_018b: ldloc.0
+		IL_018c: stelem.ref
+		IL_018d: stloc.3
+		IL_018e: ldloc.3
+		IL_018f: ldc.i4.0
+		IL_0190: ldelem.ref
+		IL_0191: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0196: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_019b: ldc.i4.0
+		IL_019c: conv.r8
+		IL_019d: ldstr ""
+		IL_01a2: ldc.i4.0
+		IL_01a3: ldc.i4.0
+		IL_01a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27/FunctionObject>(!!0)
+		IL_01ae: stloc.s 10
+		IL_01b0: ldnull
+		IL_01b1: ldstr "hmac key null"
+		IL_01b6: ldloc.s 10
+		IL_01b8: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_01bd: pop
+		IL_01be: ldc.i4.1
+		IL_01bf: newarr [System.Runtime]System.Object
+		IL_01c4: dup
+		IL_01c5: ldc.i4.0
+		IL_01c6: ldloc.0
+		IL_01c7: stelem.ref
+		IL_01c8: stloc.3
+		IL_01c9: ldloc.3
+		IL_01ca: ldc.i4.0
+		IL_01cb: ldelem.ref
+		IL_01cc: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_01d1: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_01d6: ldc.i4.0
+		IL_01d7: conv.r8
+		IL_01d8: ldstr ""
+		IL_01dd: ldc.i4.0
+		IL_01de: ldc.i4.0
+		IL_01df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29/FunctionObject>(!!0)
+		IL_01e9: stloc.s 11
+		IL_01eb: ldnull
+		IL_01ec: ldstr "hmac key number"
+		IL_01f1: ldloc.s 11
+		IL_01f3: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_01f8: pop
+		IL_01f9: ldc.i4.1
+		IL_01fa: newarr [System.Runtime]System.Object
+		IL_01ff: dup
+		IL_0200: ldc.i4.0
+		IL_0201: ldloc.0
+		IL_0202: stelem.ref
+		IL_0203: stloc.3
+		IL_0204: ldloc.3
+		IL_0205: ldc.i4.0
+		IL_0206: ldelem.ref
+		IL_0207: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_020c: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_0211: ldc.i4.0
+		IL_0212: conv.r8
+		IL_0213: ldstr ""
+		IL_0218: ldc.i4.0
+		IL_0219: ldc.i4.0
+		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_021f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35/FunctionObject>(!!0)
+		IL_0224: stloc.s 12
+		IL_0226: ldnull
+		IL_0227: ldstr "pbkdf2 digest missing"
+		IL_022c: ldloc.s 12
+		IL_022e: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_0233: pop
+		IL_0234: ldc.i4.1
+		IL_0235: newarr [System.Runtime]System.Object
+		IL_023a: dup
+		IL_023b: ldc.i4.0
+		IL_023c: ldloc.0
+		IL_023d: stelem.ref
+		IL_023e: stloc.3
+		IL_023f: ldloc.3
+		IL_0240: ldc.i4.0
+		IL_0241: ldelem.ref
+		IL_0242: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0247: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_024c: ldc.i4.0
+		IL_024d: conv.r8
+		IL_024e: ldstr ""
+		IL_0253: ldc.i4.0
+		IL_0254: ldc.i4.0
+		IL_0255: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39/FunctionObject>(!!0)
+		IL_025f: stloc.s 13
+		IL_0261: ldnull
+		IL_0262: ldstr "pbkdf2 digest unsupported"
+		IL_0267: ldloc.s 13
+		IL_0269: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_026e: pop
+		IL_026f: ldc.i4.1
+		IL_0270: newarr [System.Runtime]System.Object
+		IL_0275: dup
+		IL_0276: ldc.i4.0
+		IL_0277: ldloc.0
+		IL_0278: stelem.ref
+		IL_0279: stloc.3
+		IL_027a: ldloc.3
+		IL_027b: ldc.i4.0
+		IL_027c: ldelem.ref
+		IL_027d: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0282: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
 		IL_0287: ldc.i4.0
-		IL_0288: ldelem.ref
-		IL_0289: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_028e: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_0293: ldc.i4.0
-		IL_0294: conv.r8
-		IL_0295: ldstr ""
-		IL_029a: ldc.i4.0
-		IL_029b: ldc.i4.0
-		IL_029c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39/FunctionObject>(!!0)
-		IL_02a6: stloc.s 14
-		IL_02a8: ldloc.1
-		IL_02a9: ldloc.3
-		IL_02aa: ldstr "pbkdf2 digest unsupported"
-		IL_02af: ldloc.s 14
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02b6: pop
-		IL_02b7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02bc: stloc.3
-		IL_02bd: ldc.i4.1
-		IL_02be: newarr [System.Runtime]System.Object
-		IL_02c3: dup
-		IL_02c4: ldc.i4.0
-		IL_02c5: ldloc.0
-		IL_02c6: stelem.ref
-		IL_02c7: stloc.s 6
-		IL_02c9: ldloc.s 6
-		IL_02cb: ldc.i4.0
-		IL_02cc: ldelem.ref
-		IL_02cd: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_02d2: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_02d7: ldc.i4.0
-		IL_02d8: conv.r8
-		IL_02d9: ldstr ""
-		IL_02de: ldc.i4.0
-		IL_02df: ldc.i4.0
-		IL_02e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36/FunctionObject>(!!0)
-		IL_02ea: stloc.s 15
-		IL_02ec: ldloc.1
-		IL_02ed: ldloc.3
-		IL_02ee: ldstr "pbkdf2 password number"
-		IL_02f3: ldloc.s 15
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02fa: pop
-		IL_02fb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0300: stloc.3
-		IL_0301: ldc.i4.1
-		IL_0302: newarr [System.Runtime]System.Object
-		IL_0307: dup
-		IL_0308: ldc.i4.0
-		IL_0309: ldloc.0
-		IL_030a: stelem.ref
-		IL_030b: stloc.s 6
-		IL_030d: ldloc.s 6
-		IL_030f: ldc.i4.0
-		IL_0310: ldelem.ref
-		IL_0311: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0316: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_031b: ldc.i4.0
-		IL_031c: conv.r8
-		IL_031d: ldstr ""
-		IL_0322: ldc.i4.0
-		IL_0323: ldc.i4.0
-		IL_0324: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0329: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30/FunctionObject>(!!0)
-		IL_032e: stloc.s 16
-		IL_0330: ldloc.1
-		IL_0331: ldloc.3
-		IL_0332: ldstr "pbkdf2 salt null"
-		IL_0337: ldloc.s 16
-		IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_033e: pop
-		IL_033f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0344: stloc.3
-		IL_0345: ldc.i4.1
-		IL_0346: newarr [System.Runtime]System.Object
-		IL_034b: dup
-		IL_034c: ldc.i4.0
-		IL_034d: ldloc.0
-		IL_034e: stelem.ref
-		IL_034f: stloc.s 6
-		IL_0351: ldloc.s 6
-		IL_0353: ldc.i4.0
-		IL_0354: ldelem.ref
-		IL_0355: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_035a: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_035f: ldc.i4.0
-		IL_0360: conv.r8
-		IL_0361: ldstr ""
-		IL_0366: ldc.i4.0
+		IL_0288: conv.r8
+		IL_0289: ldstr ""
+		IL_028e: ldc.i4.0
+		IL_028f: ldc.i4.0
+		IL_0290: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0295: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36/FunctionObject>(!!0)
+		IL_029a: stloc.s 14
+		IL_029c: ldnull
+		IL_029d: ldstr "pbkdf2 password number"
+		IL_02a2: ldloc.s 14
+		IL_02a4: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_02a9: pop
+		IL_02aa: ldc.i4.1
+		IL_02ab: newarr [System.Runtime]System.Object
+		IL_02b0: dup
+		IL_02b1: ldc.i4.0
+		IL_02b2: ldloc.0
+		IL_02b3: stelem.ref
+		IL_02b4: stloc.3
+		IL_02b5: ldloc.3
+		IL_02b6: ldc.i4.0
+		IL_02b7: ldelem.ref
+		IL_02b8: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_02bd: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_02c2: ldc.i4.0
+		IL_02c3: conv.r8
+		IL_02c4: ldstr ""
+		IL_02c9: ldc.i4.0
+		IL_02ca: ldc.i4.0
+		IL_02cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30/FunctionObject>(!!0)
+		IL_02d5: stloc.s 15
+		IL_02d7: ldnull
+		IL_02d8: ldstr "pbkdf2 salt null"
+		IL_02dd: ldloc.s 15
+		IL_02df: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_02e4: pop
+		IL_02e5: ldc.i4.1
+		IL_02e6: newarr [System.Runtime]System.Object
+		IL_02eb: dup
+		IL_02ec: ldc.i4.0
+		IL_02ed: ldloc.0
+		IL_02ee: stelem.ref
+		IL_02ef: stloc.3
+		IL_02f0: ldloc.3
+		IL_02f1: ldc.i4.0
+		IL_02f2: ldelem.ref
+		IL_02f3: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_02f8: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_02fd: ldc.i4.0
+		IL_02fe: conv.r8
+		IL_02ff: ldstr ""
+		IL_0304: ldc.i4.0
+		IL_0305: ldc.i4.0
+		IL_0306: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_030b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36/FunctionObject>(!!0)
+		IL_0310: stloc.s 16
+		IL_0312: ldnull
+		IL_0313: ldstr "pbkdf2 iterations type"
+		IL_0318: ldloc.s 16
+		IL_031a: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_031f: pop
+		IL_0320: ldc.i4.1
+		IL_0321: newarr [System.Runtime]System.Object
+		IL_0326: dup
+		IL_0327: ldc.i4.0
+		IL_0328: ldloc.0
+		IL_0329: stelem.ref
+		IL_032a: stloc.3
+		IL_032b: ldloc.3
+		IL_032c: ldc.i4.0
+		IL_032d: ldelem.ref
+		IL_032e: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0333: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_0338: ldc.i4.0
+		IL_0339: conv.r8
+		IL_033a: ldstr ""
+		IL_033f: ldc.i4.0
+		IL_0340: ldc.i4.0
+		IL_0341: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0346: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37/FunctionObject>(!!0)
+		IL_034b: stloc.s 17
+		IL_034d: ldnull
+		IL_034e: ldstr "pbkdf2 iterations float"
+		IL_0353: ldloc.s 17
+		IL_0355: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_035a: pop
+		IL_035b: ldc.i4.1
+		IL_035c: newarr [System.Runtime]System.Object
+		IL_0361: dup
+		IL_0362: ldc.i4.0
+		IL_0363: ldloc.0
+		IL_0364: stelem.ref
+		IL_0365: stloc.3
+		IL_0366: ldloc.3
 		IL_0367: ldc.i4.0
-		IL_0368: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_036d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36/FunctionObject>(!!0)
-		IL_0372: stloc.s 17
-		IL_0374: ldloc.1
-		IL_0375: ldloc.3
-		IL_0376: ldstr "pbkdf2 iterations type"
-		IL_037b: ldloc.s 17
-		IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0382: pop
-		IL_0383: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0388: stloc.3
-		IL_0389: ldc.i4.1
-		IL_038a: newarr [System.Runtime]System.Object
-		IL_038f: dup
-		IL_0390: ldc.i4.0
-		IL_0391: ldloc.0
-		IL_0392: stelem.ref
-		IL_0393: stloc.s 6
-		IL_0395: ldloc.s 6
-		IL_0397: ldc.i4.0
-		IL_0398: ldelem.ref
-		IL_0399: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_039e: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_03a3: ldc.i4.0
-		IL_03a4: conv.r8
-		IL_03a5: ldstr ""
-		IL_03aa: ldc.i4.0
-		IL_03ab: ldc.i4.0
-		IL_03ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37/FunctionObject>(!!0)
-		IL_03b6: stloc.s 18
-		IL_03b8: ldloc.1
-		IL_03b9: ldloc.3
-		IL_03ba: ldstr "pbkdf2 iterations float"
-		IL_03bf: ldloc.s 18
-		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_03c6: pop
-		IL_03c7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03cc: stloc.3
-		IL_03cd: ldc.i4.1
-		IL_03ce: newarr [System.Runtime]System.Object
-		IL_03d3: dup
-		IL_03d4: ldc.i4.0
-		IL_03d5: ldloc.0
-		IL_03d6: stelem.ref
-		IL_03d7: stloc.s 6
-		IL_03d9: ldloc.s 6
-		IL_03db: ldc.i4.0
-		IL_03dc: ldelem.ref
-		IL_03dd: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_03e2: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_03e7: ldc.i4.0
-		IL_03e8: conv.r8
-		IL_03e9: ldstr ""
-		IL_03ee: ldc.i4.0
-		IL_03ef: ldc.i4.0
-		IL_03f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36/FunctionObject>(!!0)
-		IL_03fa: stloc.s 19
-		IL_03fc: ldloc.1
-		IL_03fd: ldloc.3
-		IL_03fe: ldstr "pbkdf2 iterations zero"
-		IL_0403: ldloc.s 19
-		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_040a: pop
-		IL_040b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0410: stloc.3
-		IL_0411: ldc.i4.1
-		IL_0412: newarr [System.Runtime]System.Object
-		IL_0417: dup
+		IL_0368: ldelem.ref
+		IL_0369: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_036e: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_0373: ldc.i4.0
+		IL_0374: conv.r8
+		IL_0375: ldstr ""
+		IL_037a: ldc.i4.0
+		IL_037b: ldc.i4.0
+		IL_037c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0381: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36/FunctionObject>(!!0)
+		IL_0386: stloc.s 18
+		IL_0388: ldnull
+		IL_0389: ldstr "pbkdf2 iterations zero"
+		IL_038e: ldloc.s 18
+		IL_0390: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_0395: pop
+		IL_0396: ldc.i4.1
+		IL_0397: newarr [System.Runtime]System.Object
+		IL_039c: dup
+		IL_039d: ldc.i4.0
+		IL_039e: ldloc.0
+		IL_039f: stelem.ref
+		IL_03a0: stloc.3
+		IL_03a1: ldloc.3
+		IL_03a2: ldc.i4.0
+		IL_03a3: ldelem.ref
+		IL_03a4: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_03a9: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_03ae: ldc.i4.0
+		IL_03af: conv.r8
+		IL_03b0: ldstr ""
+		IL_03b5: ldc.i4.0
+		IL_03b6: ldc.i4.0
+		IL_03b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0)
+		IL_03c1: stloc.s 19
+		IL_03c3: ldnull
+		IL_03c4: ldstr "pbkdf2 keylen float"
+		IL_03c9: ldloc.s 19
+		IL_03cb: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_03d0: pop
+		IL_03d1: ldc.i4.1
+		IL_03d2: newarr [System.Runtime]System.Object
+		IL_03d7: dup
+		IL_03d8: ldc.i4.0
+		IL_03d9: ldloc.0
+		IL_03da: stelem.ref
+		IL_03db: stloc.3
+		IL_03dc: ldloc.3
+		IL_03dd: ldc.i4.0
+		IL_03de: ldelem.ref
+		IL_03df: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_03e4: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_03e9: ldc.i4.0
+		IL_03ea: conv.r8
+		IL_03eb: ldstr ""
+		IL_03f0: ldc.i4.0
+		IL_03f1: ldc.i4.0
+		IL_03f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36/FunctionObject>(!!0)
+		IL_03fc: stloc.s 20
+		IL_03fe: ldnull
+		IL_03ff: ldstr "pbkdf2 keylen negative"
+		IL_0404: ldloc.s 20
+		IL_0406: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_040b: pop
+		IL_040c: ldc.i4.1
+		IL_040d: newarr [System.Runtime]System.Object
+		IL_0412: dup
+		IL_0413: ldc.i4.0
+		IL_0414: ldloc.0
+		IL_0415: stelem.ref
+		IL_0416: stloc.3
+		IL_0417: ldloc.3
 		IL_0418: ldc.i4.0
-		IL_0419: ldloc.0
-		IL_041a: stelem.ref
-		IL_041b: stloc.s 6
-		IL_041d: ldloc.s 6
-		IL_041f: ldc.i4.0
-		IL_0420: ldelem.ref
-		IL_0421: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0426: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_0419: ldelem.ref
+		IL_041a: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_041f: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_0424: ldc.i4.0
+		IL_0425: conv.r8
+		IL_0426: ldstr ""
 		IL_042b: ldc.i4.0
-		IL_042c: conv.r8
-		IL_042d: ldstr ""
-		IL_0432: ldc.i4.0
-		IL_0433: ldc.i4.0
-		IL_0434: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0439: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0)
-		IL_043e: stloc.s 20
-		IL_0440: ldloc.1
-		IL_0441: ldloc.3
-		IL_0442: ldstr "pbkdf2 keylen float"
-		IL_0447: ldloc.s 20
-		IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_044e: pop
-		IL_044f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0454: stloc.3
-		IL_0455: ldc.i4.1
-		IL_0456: newarr [System.Runtime]System.Object
-		IL_045b: dup
-		IL_045c: ldc.i4.0
-		IL_045d: ldloc.0
-		IL_045e: stelem.ref
-		IL_045f: stloc.s 6
-		IL_0461: ldloc.s 6
-		IL_0463: ldc.i4.0
-		IL_0464: ldelem.ref
-		IL_0465: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_046a: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_046f: ldc.i4.0
-		IL_0470: conv.r8
-		IL_0471: ldstr ""
-		IL_0476: ldc.i4.0
-		IL_0477: ldc.i4.0
-		IL_0478: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_047d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36/FunctionObject>(!!0)
-		IL_0482: stloc.s 21
-		IL_0484: ldloc.1
-		IL_0485: ldloc.3
-		IL_0486: ldstr "pbkdf2 keylen negative"
-		IL_048b: ldloc.s 21
-		IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0492: pop
-		IL_0493: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0498: stloc.3
-		IL_0499: ldc.i4.1
-		IL_049a: newarr [System.Runtime]System.Object
-		IL_049f: dup
-		IL_04a0: ldc.i4.0
-		IL_04a1: ldloc.0
-		IL_04a2: stelem.ref
-		IL_04a3: stloc.s 6
-		IL_04a5: ldloc.s 6
-		IL_04a7: ldc.i4.0
-		IL_04a8: ldelem.ref
-		IL_04a9: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_04ae: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_04b3: ldc.i4.0
-		IL_04b4: conv.r8
-		IL_04b5: ldstr ""
-		IL_04ba: ldc.i4.0
-		IL_04bb: ldc.i4.0
-		IL_04bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30/FunctionObject>(!!0)
-		IL_04c6: stloc.s 22
-		IL_04c8: ldloc.1
-		IL_04c9: ldloc.3
-		IL_04ca: ldstr "random size type"
-		IL_04cf: ldloc.s 22
-		IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_04d6: pop
-		IL_04d7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04dc: stloc.3
-		IL_04dd: ldc.i4.1
-		IL_04de: newarr [System.Runtime]System.Object
-		IL_04e3: dup
-		IL_04e4: ldc.i4.0
-		IL_04e5: ldloc.0
-		IL_04e6: stelem.ref
-		IL_04e7: stloc.s 6
-		IL_04e9: ldloc.s 6
-		IL_04eb: ldc.i4.0
-		IL_04ec: ldelem.ref
-		IL_04ed: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_04f2: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_04f7: ldc.i4.0
-		IL_04f8: conv.r8
-		IL_04f9: ldstr ""
-		IL_04fe: ldc.i4.0
-		IL_04ff: ldc.i4.0
-		IL_0500: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0505: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34/FunctionObject>(!!0)
-		IL_050a: stloc.s 23
-		IL_050c: ldloc.1
-		IL_050d: ldloc.3
-		IL_050e: ldstr "random size negative"
-		IL_0513: ldloc.s 23
-		IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_051a: pop
-		IL_051b: ldloc.0
-		IL_051c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_0521: stloc.s 5
-		IL_0523: ldloc.s 5
-		IL_0525: ldstr "sha256"
-		IL_052a: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHash(string)
-		IL_052f: stloc.s 24
-		IL_0531: ldloc.0
+		IL_042c: ldc.i4.0
+		IL_042d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0432: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30/FunctionObject>(!!0)
+		IL_0437: stloc.s 21
+		IL_0439: ldnull
+		IL_043a: ldstr "random size type"
+		IL_043f: ldloc.s 21
+		IL_0441: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_0446: pop
+		IL_0447: ldc.i4.1
+		IL_0448: newarr [System.Runtime]System.Object
+		IL_044d: dup
+		IL_044e: ldc.i4.0
+		IL_044f: ldloc.0
+		IL_0450: stelem.ref
+		IL_0451: stloc.3
+		IL_0452: ldloc.3
+		IL_0453: ldc.i4.0
+		IL_0454: ldelem.ref
+		IL_0455: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_045a: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_045f: ldc.i4.0
+		IL_0460: conv.r8
+		IL_0461: ldstr ""
+		IL_0466: ldc.i4.0
+		IL_0467: ldc.i4.0
+		IL_0468: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_046d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34/FunctionObject>(!!0)
+		IL_0472: stloc.s 22
+		IL_0474: ldnull
+		IL_0475: ldstr "random size negative"
+		IL_047a: ldloc.s 22
+		IL_047c: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_0481: pop
+		IL_0482: ldloc.0
+		IL_0483: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+		IL_0488: stloc.s 5
+		IL_048a: ldloc.s 5
+		IL_048c: ldstr "sha256"
+		IL_0491: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHash(string)
+		IL_0496: stloc.s 23
+		IL_0498: ldloc.0
+		IL_0499: ldloc.s 23
+		IL_049b: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_04a0: ldloc.0
+		IL_04a1: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04ab: volatile.
+		IL_04ad: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_04b2: brfalse IL_04cb
+
+		IL_04b7: ldstr "update"
+		IL_04bc: ldstr "abc"
+		IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04c6: br IL_04e4
+
+		IL_04cb: ldstr "update"
+		IL_04d0: ldstr "abc"
+		IL_04d5: ldstr "Require_Crypto_ErrorPaths:Modules.Require_Crypto_ErrorPaths:__js_module_init__:129"
+		IL_04da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
+		IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_04e4: pop
+		IL_04e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04ea: stloc.s 24
+		IL_04ec: ldloc.0
+		IL_04ed: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_04f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04f7: volatile.
+		IL_04f9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_04fe: brfalse IL_0517
+
+		IL_0503: ldstr "digest"
+		IL_0508: ldstr "hex"
+		IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0512: br IL_0530
+
+		IL_0517: ldstr "digest"
+		IL_051c: ldstr "hex"
+		IL_0521: ldstr "Require_Crypto_ErrorPaths:Modules.Require_Crypto_ErrorPaths:__js_module_init__:136"
+		IL_0526: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
+		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0530: stloc.s 23
 		IL_0532: ldloc.s 24
-		IL_0534: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_0539: ldloc.0
-		IL_053a: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_053f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0544: volatile.
-		IL_0546: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_054b: brfalse IL_0564
-
-		IL_0550: ldstr "update"
-		IL_0555: ldstr "abc"
-		IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_055f: br IL_057d
-
-		IL_0564: ldstr "update"
-		IL_0569: ldstr "abc"
-		IL_056e: ldstr "Require_Crypto_ErrorPaths:Modules.Require_Crypto_ErrorPaths:__js_module_init__:129"
-		IL_0573: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_73
-		IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
-
-		IL_057d: pop
-		IL_057e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0583: stloc.s 25
-		IL_0585: ldloc.0
-		IL_0586: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0590: volatile.
-		IL_0592: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_0597: brfalse IL_05b0
-
-		IL_059c: ldstr "digest"
-		IL_05a1: ldstr "hex"
-		IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05ab: br IL_05c9
-
-		IL_05b0: ldstr "digest"
-		IL_05b5: ldstr "hex"
-		IL_05ba: ldstr "Require_Crypto_ErrorPaths:Modules.Require_Crypto_ErrorPaths:__js_module_init__:136"
-		IL_05bf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_74
-		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
-
-		IL_05c9: stloc.s 24
-		IL_05cb: ldloc.s 25
-		IL_05cd: ldstr "digest first:"
-		IL_05d2: ldloc.s 24
-		IL_05d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0534: ldstr "digest first:"
+		IL_0539: ldloc.s 23
+		IL_053b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0540: pop
+		IL_0541: ldc.i4.1
+		IL_0542: newarr [System.Runtime]System.Object
+		IL_0547: dup
+		IL_0548: ldc.i4.0
+		IL_0549: ldloc.0
+		IL_054a: stelem.ref
+		IL_054b: stloc.3
+		IL_054c: ldloc.3
+		IL_054d: ldc.i4.0
+		IL_054e: ldelem.ref
+		IL_054f: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0554: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_0559: ldc.i4.0
+		IL_055a: conv.r8
+		IL_055b: ldstr ""
+		IL_0560: ldc.i4.0
+		IL_0561: ldc.i4.0
+		IL_0562: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0567: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject>(!!0)
+		IL_056c: stloc.s 25
+		IL_056e: ldnull
+		IL_056f: ldstr "digest twice"
+		IL_0574: ldloc.s 25
+		IL_0576: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_057b: pop
+		IL_057c: ldloc.0
+		IL_057d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
+		IL_0582: stloc.s 5
+		IL_0584: ldloc.s 5
+		IL_0586: ldstr "sha256"
+		IL_058b: ldstr "key"
+		IL_0590: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
+		IL_0595: stloc.s 23
+		IL_0597: ldloc.0
+		IL_0598: ldloc.s 23
+		IL_059a: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
+		IL_059f: ldc.i4.1
+		IL_05a0: newarr [System.Runtime]System.Object
+		IL_05a5: dup
+		IL_05a6: ldc.i4.0
+		IL_05a7: ldloc.0
+		IL_05a8: stelem.ref
+		IL_05a9: stloc.3
+		IL_05aa: ldloc.3
+		IL_05ab: ldc.i4.0
+		IL_05ac: ldelem.ref
+		IL_05ad: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_05b2: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
+		IL_05b7: ldc.i4.0
+		IL_05b8: conv.r8
+		IL_05b9: ldstr ""
+		IL_05be: ldc.i4.0
+		IL_05bf: ldc.i4.0
+		IL_05c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject>(!!0)
+		IL_05ca: stloc.s 26
+		IL_05cc: ldnull
+		IL_05cd: ldstr "hmac update type"
+		IL_05d2: ldloc.s 26
+		IL_05d4: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
 		IL_05d9: pop
-		IL_05da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05df: stloc.3
-		IL_05e0: ldc.i4.1
-		IL_05e1: newarr [System.Runtime]System.Object
-		IL_05e6: dup
-		IL_05e7: ldc.i4.0
-		IL_05e8: ldloc.0
-		IL_05e9: stelem.ref
-		IL_05ea: stloc.s 6
-		IL_05ec: ldloc.s 6
-		IL_05ee: ldc.i4.0
-		IL_05ef: ldelem.ref
-		IL_05f0: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_05f5: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_05fa: ldc.i4.0
-		IL_05fb: conv.r8
-		IL_05fc: ldstr ""
-		IL_0601: ldc.i4.0
+		IL_05da: nop
+		IL_05db: nop
+		IL_05dc: ldloc.2
+		IL_05dd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_05e7: stloc.s 23
+		IL_05e9: ldloc.s 23
+		IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05f0: stloc.s 23
+		IL_05f2: ldc.i4.1
+		IL_05f3: newarr [System.Runtime]System.Object
+		IL_05f8: dup
+		IL_05f9: ldc.i4.0
+		IL_05fa: ldloc.0
+		IL_05fb: stelem.ref
+		IL_05fc: stloc.3
+		IL_05fd: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject::.ctor()
 		IL_0602: ldc.i4.0
-		IL_0603: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0608: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26/FunctionObject>(!!0)
-		IL_060d: stloc.s 26
-		IL_060f: ldloc.1
-		IL_0610: ldloc.3
-		IL_0611: ldstr "digest twice"
-		IL_0616: ldloc.s 26
-		IL_0618: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_061d: pop
-		IL_061e: ldloc.0
-		IL_061f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_0624: stloc.s 5
-		IL_0626: ldloc.s 5
-		IL_0628: ldstr "sha256"
-		IL_062d: ldstr "key"
-		IL_0632: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule::createHmac(string, object)
-		IL_0637: stloc.s 24
-		IL_0639: ldloc.0
-		IL_063a: ldloc.s 24
-		IL_063c: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
-		IL_0641: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0646: stloc.3
-		IL_0647: ldc.i4.1
-		IL_0648: newarr [System.Runtime]System.Object
-		IL_064d: dup
-		IL_064e: ldc.i4.0
-		IL_064f: ldloc.0
-		IL_0650: stelem.ref
-		IL_0651: stloc.s 6
-		IL_0653: ldloc.s 6
-		IL_0655: ldc.i4.0
-		IL_0656: ldelem.ref
-		IL_0657: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_065c: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope)
-		IL_0661: ldc.i4.0
-		IL_0662: conv.r8
-		IL_0663: ldstr ""
-		IL_0668: ldc.i4.0
-		IL_0669: ldc.i4.0
-		IL_066a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_066f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30/FunctionObject>(!!0)
-		IL_0674: stloc.s 27
-		IL_0676: ldloc.1
-		IL_0677: ldloc.3
-		IL_0678: ldstr "hmac update type"
-		IL_067d: ldloc.s 27
-		IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0684: pop
-		IL_0685: nop
-		IL_0686: nop
-		IL_0687: ldloc.2
-		IL_0688: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_068d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0692: stloc.s 24
-		IL_0694: ldloc.s 24
-		IL_0696: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_069b: stloc.s 24
-		IL_069d: ldc.i4.1
-		IL_069e: newarr [System.Runtime]System.Object
-		IL_06a3: dup
-		IL_06a4: ldc.i4.0
-		IL_06a5: ldloc.0
-		IL_06a6: stelem.ref
-		IL_06a7: stloc.3
-		IL_06a8: newobj instance void Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject::.ctor()
-		IL_06ad: ldc.i4.0
-		IL_06ae: conv.r8
-		IL_06af: ldstr ""
-		IL_06b4: ldc.i4.0
-		IL_06b5: ldc.i4.0
-		IL_06b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject>(!!0)
-		IL_06c0: stloc.s 28
-		IL_06c2: volatile.
-		IL_06c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-		IL_06c9: brfalse IL_06e1
+		IL_0603: conv.r8
+		IL_0604: ldstr ""
+		IL_0609: ldc.i4.0
+		IL_060a: ldc.i4.0
+		IL_060b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0610: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27/FunctionObject>(!!0)
+		IL_0615: stloc.s 27
+		IL_0617: volatile.
+		IL_0619: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_061e: brfalse IL_0636
 
-		IL_06ce: ldloc.s 24
-		IL_06d0: ldstr "then"
-		IL_06d5: ldloc.s 28
-		IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06dc: br IL_06f9
+		IL_0623: ldloc.s 23
+		IL_0625: ldstr "then"
+		IL_062a: ldloc.s 27
+		IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0631: br IL_064e
 
-		IL_06e1: ldloc.s 24
-		IL_06e3: ldstr "then"
-		IL_06e8: ldloc.s 28
-		IL_06ea: ldstr "Require_Crypto_ErrorPaths:Modules.Require_Crypto_ErrorPaths:__js_module_init__:164"
-		IL_06ef: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
-		IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0636: ldloc.s 23
+		IL_0638: ldstr "then"
+		IL_063d: ldloc.s 27
+		IL_063f: ldstr "Require_Crypto_ErrorPaths:Modules.Require_Crypto_ErrorPaths:__js_module_init__:164"
+		IL_0644: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_75
+		IL_0649: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_06f9: pop
-		IL_06fa: ret
+		IL_064e: pop
+		IL_064f: ret
 	} // end of method Require_Crypto_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Crypto_ErrorPaths

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
@@ -481,7 +481,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 189 (0xbd)
+		// Code size: 191 (0xbf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_DefaultParameterOverride/Scope,
@@ -522,55 +522,57 @@
 		IL_003b: ldloc.3
 		IL_003c: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_DefaultParameterOverride/Scope::path
 		IL_0041: nop
-		IL_0042: ldloc.1
-		IL_0043: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_004d: pop
-		IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0053: stloc.s 4
-		IL_0055: ldloc.0
-		IL_0056: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_DefaultParameterOverride/Scope::path
-		IL_005b: stloc.3
-		IL_005c: ldloc.3
-		IL_005d: ldstr "join"
-		IL_0062: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_0067: brtrue IL_008f
+		IL_0042: ldloc.0
+		IL_0043: castclass Modules.Require_Path_DefaultParameterOverride/Scope
+		IL_0048: ldnull
+		IL_0049: ldnull
+		IL_004a: call object Modules.Require_Path_DefaultParameterOverride/patchPath::__js_call__(class Modules.Require_Path_DefaultParameterOverride/Scope, object, object)
+		IL_004f: pop
+		IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0055: stloc.s 4
+		IL_0057: ldloc.0
+		IL_0058: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_DefaultParameterOverride/Scope::path
+		IL_005d: stloc.3
+		IL_005e: ldloc.3
+		IL_005f: ldstr "join"
+		IL_0064: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_0069: brtrue IL_0091
 
-		IL_006c: ldloc.3
-		IL_006d: ldc.i4.2
-		IL_006e: newarr [System.Runtime]System.Object
-		IL_0073: dup
-		IL_0074: ldc.i4.0
-		IL_0075: ldstr "a"
-		IL_007a: stelem.ref
-		IL_007b: dup
-		IL_007c: ldc.i4.1
-		IL_007d: ldstr "b"
-		IL_0082: stelem.ref
-		IL_0083: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_0088: stloc.s 5
-		IL_008a: br IL_00b2
+		IL_006e: ldloc.3
+		IL_006f: ldc.i4.2
+		IL_0070: newarr [System.Runtime]System.Object
+		IL_0075: dup
+		IL_0076: ldc.i4.0
+		IL_0077: ldstr "a"
+		IL_007c: stelem.ref
+		IL_007d: dup
+		IL_007e: ldc.i4.1
+		IL_007f: ldstr "b"
+		IL_0084: stelem.ref
+		IL_0085: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_008a: stloc.s 5
+		IL_008c: br IL_00b4
 
-		IL_008f: ldloc.3
-		IL_0090: ldstr "join"
-		IL_0095: ldc.i4.2
-		IL_0096: newarr [System.Runtime]System.Object
-		IL_009b: dup
-		IL_009c: ldc.i4.0
-		IL_009d: ldstr "a"
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.1
-		IL_00a5: ldstr "b"
-		IL_00aa: stelem.ref
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-		IL_00b0: stloc.s 5
+		IL_0091: ldloc.3
+		IL_0092: ldstr "join"
+		IL_0097: ldc.i4.2
+		IL_0098: newarr [System.Runtime]System.Object
+		IL_009d: dup
+		IL_009e: ldc.i4.0
+		IL_009f: ldstr "a"
+		IL_00a4: stelem.ref
+		IL_00a5: dup
+		IL_00a6: ldc.i4.1
+		IL_00a7: ldstr "b"
+		IL_00ac: stelem.ref
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_00b2: stloc.s 5
 
-		IL_00b2: ldloc.s 4
-		IL_00b4: ldloc.s 5
-		IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bb: pop
-		IL_00bc: ret
+		IL_00b4: ldloc.s 4
+		IL_00b6: ldloc.s 5
+		IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00bd: pop
+		IL_00be: ret
 	} // end of method Require_Path_DefaultParameterOverride::__js_module_init__
 
 } // end of class Modules.Require_Path_DefaultParameterOverride

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -297,7 +297,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 138 (0x8a)
+		// Code size: 137 (0x89)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Join_NestedFunction/Scope,
@@ -339,28 +339,27 @@
 		IL_003c: ldloc.s 4
 		IL_003e: stfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_Join_NestedFunction/Scope::path
 		IL_0043: nop
-		IL_0044: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0049: stloc.3
-		IL_004a: ldloc.1
-		IL_004b: ldloc.3
-		IL_004c: ldstr "a"
-		IL_0051: ldstr "b"
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_005b: stloc.s 5
-		IL_005d: ldloc.s 5
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0064: ldstr "replace"
-		IL_0069: ldstr "\\"
-		IL_006e: ldstr "/"
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0078: stloc.2
-		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007e: stloc.s 6
-		IL_0080: ldloc.s 6
-		IL_0082: ldloc.2
-		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0088: pop
-		IL_0089: ret
+		IL_0044: ldloc.0
+		IL_0045: castclass Modules.Require_Path_Join_NestedFunction/Scope
+		IL_004a: ldnull
+		IL_004b: ldstr "a"
+		IL_0050: ldstr "b"
+		IL_0055: call object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, string, string)
+		IL_005a: stloc.s 5
+		IL_005c: ldloc.s 5
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0063: ldstr "replace"
+		IL_0068: ldstr "\\"
+		IL_006d: ldstr "/"
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0077: stloc.2
+		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007d: stloc.s 6
+		IL_007f: ldloc.s 6
+		IL_0081: ldloc.2
+		IL_0082: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0087: pop
+		IL_0088: ret
 	} // end of method Require_Path_Join_NestedFunction::__js_module_init__
 
 } // end of class Modules.Require_Path_Join_NestedFunction

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
@@ -526,7 +526,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1130 (0x46a)
+		// Code size: 1122 (0x462)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_MemberOverrides/Scope,
@@ -615,365 +615,363 @@
 		IL_00ae: nop
 		IL_00af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_00b4: stloc.s 13
-		IL_00b6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00bb: stloc.s 11
-		IL_00bd: ldloc.1
-		IL_00be: ldloc.s 11
-		IL_00c0: ldc.r8 123
-		IL_00c9: box [System.Runtime]System.Double
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00d3: stloc.s 14
-		IL_00d5: ldloc.s 13
-		IL_00d7: ldloc.s 14
-		IL_00d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00de: pop
-		IL_00df: ldloc.0
-		IL_00e0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_00e5: stloc.s 12
-		IL_00e7: ldc.i4.1
-		IL_00e8: newarr [System.Runtime]System.Object
-		IL_00ed: dup
-		IL_00ee: ldc.i4.0
-		IL_00ef: ldloc.0
-		IL_00f0: stelem.ref
-		IL_00f1: stloc.s 11
-		IL_00f3: newobj instance void Modules.Require_Path_MemberOverrides/ArrowFunction_L13C13/FunctionObject::.ctor()
+		IL_00b6: ldloc.0
+		IL_00b7: castclass Modules.Require_Path_MemberOverrides/Scope
+		IL_00bc: ldnull
+		IL_00bd: ldc.r8 123
+		IL_00c6: call object Modules.Require_Path_MemberOverrides/normalize::__js_call__(class Modules.Require_Path_MemberOverrides/Scope, object, float64)
+		IL_00cb: stloc.s 14
+		IL_00cd: ldloc.s 13
+		IL_00cf: ldloc.s 14
+		IL_00d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d6: pop
+		IL_00d7: ldloc.0
+		IL_00d8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_00dd: stloc.s 12
+		IL_00df: ldc.i4.1
+		IL_00e0: newarr [System.Runtime]System.Object
+		IL_00e5: dup
+		IL_00e6: ldc.i4.0
+		IL_00e7: ldloc.0
+		IL_00e8: stelem.ref
+		IL_00e9: stloc.s 11
+		IL_00eb: newobj instance void Modules.Require_Path_MemberOverrides/ArrowFunction_L13C13/FunctionObject::.ctor()
+		IL_00f0: ldc.i4.0
+		IL_00f1: conv.r8
+		IL_00f2: ldstr ""
+		IL_00f7: ldc.i4.0
 		IL_00f8: ldc.i4.0
-		IL_00f9: conv.r8
-		IL_00fa: ldstr ""
-		IL_00ff: ldc.i4.0
-		IL_0100: ldc.i4.0
-		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_MemberOverrides/ArrowFunction_L13C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Path_MemberOverrides/ArrowFunction_L13C13/FunctionObject>(!!0)
-		IL_010b: stloc.s 15
-		IL_010d: ldloc.s 12
-		IL_010f: ldstr "join"
-		IL_0114: ldloc.s 15
-		IL_0116: ldc.i4.1
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_011c: pop
-		IL_011d: ldloc.0
-		IL_011e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_0123: stloc.s 12
-		IL_0125: ldloc.s 12
-		IL_0127: ldstr "sep"
-		IL_012c: ldstr "!"
-		IL_0131: ldc.i4.1
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0137: pop
-		IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013d: stloc.s 13
-		IL_013f: ldloc.0
-		IL_0140: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_0145: stloc.s 12
-		IL_0147: ldloc.s 12
-		IL_0149: ldstr "join"
-		IL_014e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_0153: brtrue IL_017c
+		IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_MemberOverrides/ArrowFunction_L13C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Path_MemberOverrides/ArrowFunction_L13C13/FunctionObject>(!!0)
+		IL_0103: stloc.s 15
+		IL_0105: ldloc.s 12
+		IL_0107: ldstr "join"
+		IL_010c: ldloc.s 15
+		IL_010e: ldc.i4.1
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0114: pop
+		IL_0115: ldloc.0
+		IL_0116: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_011b: stloc.s 12
+		IL_011d: ldloc.s 12
+		IL_011f: ldstr "sep"
+		IL_0124: ldstr "!"
+		IL_0129: ldc.i4.1
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_012f: pop
+		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0135: stloc.s 13
+		IL_0137: ldloc.0
+		IL_0138: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_013d: stloc.s 12
+		IL_013f: ldloc.s 12
+		IL_0141: ldstr "join"
+		IL_0146: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_014b: brtrue IL_0174
 
-		IL_0158: ldloc.s 12
-		IL_015a: ldc.i4.2
-		IL_015b: newarr [System.Runtime]System.Object
+		IL_0150: ldloc.s 12
+		IL_0152: ldc.i4.2
+		IL_0153: newarr [System.Runtime]System.Object
+		IL_0158: dup
+		IL_0159: ldc.i4.0
+		IL_015a: ldstr "a"
+		IL_015f: stelem.ref
 		IL_0160: dup
-		IL_0161: ldc.i4.0
-		IL_0162: ldstr "a"
+		IL_0161: ldc.i4.1
+		IL_0162: ldstr "b"
 		IL_0167: stelem.ref
-		IL_0168: dup
-		IL_0169: ldc.i4.1
-		IL_016a: ldstr "b"
-		IL_016f: stelem.ref
-		IL_0170: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-		IL_0175: stloc.s 14
-		IL_0177: br IL_01a0
+		IL_0168: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+		IL_016d: stloc.s 14
+		IL_016f: br IL_0198
 
-		IL_017c: ldloc.s 12
-		IL_017e: ldstr "join"
-		IL_0183: ldc.i4.2
-		IL_0184: newarr [System.Runtime]System.Object
+		IL_0174: ldloc.s 12
+		IL_0176: ldstr "join"
+		IL_017b: ldc.i4.2
+		IL_017c: newarr [System.Runtime]System.Object
+		IL_0181: dup
+		IL_0182: ldc.i4.0
+		IL_0183: ldstr "a"
+		IL_0188: stelem.ref
 		IL_0189: dup
-		IL_018a: ldc.i4.0
-		IL_018b: ldstr "a"
+		IL_018a: ldc.i4.1
+		IL_018b: ldstr "b"
 		IL_0190: stelem.ref
-		IL_0191: dup
-		IL_0192: ldc.i4.1
-		IL_0193: ldstr "b"
-		IL_0198: stelem.ref
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-		IL_019e: stloc.s 14
+		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+		IL_0196: stloc.s 14
 
-		IL_01a0: ldloc.s 13
-		IL_01a2: ldloc.s 14
-		IL_01a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a9: pop
-		IL_01aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01af: stloc.s 13
-		IL_01b1: ldloc.0
-		IL_01b2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_01b7: stloc.s 12
-		IL_01b9: ldloc.s 12
-		IL_01bb: ldstr "sep"
-		IL_01c0: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_01c5: brtrue IL_01d8
+		IL_0198: ldloc.s 13
+		IL_019a: ldloc.s 14
+		IL_019c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a1: pop
+		IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a7: stloc.s 13
+		IL_01a9: ldloc.0
+		IL_01aa: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_01af: stloc.s 12
+		IL_01b1: ldloc.s 12
+		IL_01b3: ldstr "sep"
+		IL_01b8: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_01bd: brtrue IL_01d0
 
-		IL_01ca: ldloc.s 12
-		IL_01cc: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
-		IL_01d1: stloc.s 14
-		IL_01d3: br IL_01e6
+		IL_01c2: ldloc.s 12
+		IL_01c4: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
+		IL_01c9: stloc.s 14
+		IL_01cb: br IL_01de
 
-		IL_01d8: ldloc.s 12
-		IL_01da: ldstr "sep"
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_01e4: stloc.s 14
+		IL_01d0: ldloc.s 12
+		IL_01d2: ldstr "sep"
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_01dc: stloc.s 14
 
-		IL_01e6: ldloc.s 13
-		IL_01e8: ldloc.s 14
-		IL_01ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ef: pop
-		IL_01f0: ldloc.0
-		IL_01f1: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_01f6: stloc.s 12
-		IL_01f8: ldloc.s 12
-		IL_01fa: ldstr "join"
-		IL_01ff: ldc.r8 0.0
-		IL_0208: ldc.i4.1
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_020e: pop
+		IL_01de: ldloc.s 13
+		IL_01e0: ldloc.s 14
+		IL_01e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01e7: pop
+		IL_01e8: ldloc.0
+		IL_01e9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_01ee: stloc.s 12
+		IL_01f0: ldloc.s 12
+		IL_01f2: ldstr "join"
+		IL_01f7: ldc.r8 0.0
+		IL_0200: ldc.i4.1
+		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0206: pop
 		.try
 		{
-			IL_020f: nop
-			IL_0210: ldloc.0
-			IL_0211: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-			IL_0216: stloc.s 12
-			IL_0218: ldloc.s 12
-			IL_021a: ldstr "join"
-			IL_021f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0224: brtrue IL_0244
+			IL_0207: nop
+			IL_0208: ldloc.0
+			IL_0209: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+			IL_020e: stloc.s 12
+			IL_0210: ldloc.s 12
+			IL_0212: ldstr "join"
+			IL_0217: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_021c: brtrue IL_023c
 
-			IL_0229: ldloc.s 12
-			IL_022b: ldc.i4.1
-			IL_022c: newarr [System.Runtime]System.Object
-			IL_0231: dup
-			IL_0232: ldc.i4.0
-			IL_0233: ldstr "a"
-			IL_0238: stelem.ref
-			IL_0239: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_023e: pop
-			IL_023f: br IL_025f
+			IL_0221: ldloc.s 12
+			IL_0223: ldc.i4.1
+			IL_0224: newarr [System.Runtime]System.Object
+			IL_0229: dup
+			IL_022a: ldc.i4.0
+			IL_022b: ldstr "a"
+			IL_0230: stelem.ref
+			IL_0231: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0236: pop
+			IL_0237: br IL_0257
 
-			IL_0244: ldloc.s 12
-			IL_0246: ldstr "join"
-			IL_024b: ldc.i4.1
-			IL_024c: newarr [System.Runtime]System.Object
-			IL_0251: dup
-			IL_0252: ldc.i4.0
-			IL_0253: ldstr "a"
-			IL_0258: stelem.ref
-			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_025e: pop
+			IL_023c: ldloc.s 12
+			IL_023e: ldstr "join"
+			IL_0243: ldc.i4.1
+			IL_0244: newarr [System.Runtime]System.Object
+			IL_0249: dup
+			IL_024a: ldc.i4.0
+			IL_024b: ldstr "a"
+			IL_0250: stelem.ref
+			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0256: pop
 
-			IL_025f: leave IL_02e1
+			IL_0257: leave IL_02d9
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0264: stloc.s 4
-			IL_0266: ldloc.s 4
-			IL_0268: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_026d: dup
-			IL_026e: brtrue IL_0284
+			IL_025c: stloc.s 4
+			IL_025e: ldloc.s 4
+			IL_0260: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0265: dup
+			IL_0266: brtrue IL_027c
 
-			IL_0273: pop
-			IL_0274: ldloc.s 4
-			IL_0276: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_027b: dup
-			IL_027c: brtrue IL_0290
+			IL_026b: pop
+			IL_026c: ldloc.s 4
+			IL_026e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0273: dup
+			IL_0274: brtrue IL_0288
 
-			IL_0281: pop
-			IL_0282: rethrow
+			IL_0279: pop
+			IL_027a: rethrow
 
-			IL_0284: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0289: stloc.s 5
-			IL_028b: br IL_0292
+			IL_027c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0281: stloc.s 5
+			IL_0283: br IL_028a
 
-			IL_0290: stloc.s 5
+			IL_0288: stloc.s 5
 
-			IL_0292: ldloc.s 5
-			IL_0294: stloc.s 6
-			IL_0296: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_029b: stloc.s 13
-			IL_029d: volatile.
-			IL_029f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-			IL_02a4: brfalse IL_02ba
+			IL_028a: ldloc.s 5
+			IL_028c: stloc.s 6
+			IL_028e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0293: stloc.s 13
+			IL_0295: volatile.
+			IL_0297: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_029c: brfalse IL_02b2
 
-			IL_02a9: ldloc.s 6
-			IL_02ab: ldstr "name"
-			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b5: br IL_02d0
+			IL_02a1: ldloc.s 6
+			IL_02a3: ldstr "name"
+			IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ad: br IL_02c8
 
-			IL_02ba: ldloc.s 6
-			IL_02bc: ldstr "name"
-			IL_02c1: ldstr "Require_Path_MemberOverrides:Modules.Require_Path_MemberOverrides:__js_module_init__:73"
-			IL_02c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_02b2: ldloc.s 6
+			IL_02b4: ldstr "name"
+			IL_02b9: ldstr "Require_Path_MemberOverrides:Modules.Require_Path_MemberOverrides:__js_module_init__:73"
+			IL_02be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+			IL_02c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_02d0: stloc.s 14
-			IL_02d2: ldloc.s 13
-			IL_02d4: ldloc.s 14
-			IL_02d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02db: pop
-			IL_02dc: leave IL_02e1
+			IL_02c8: stloc.s 14
+			IL_02ca: ldloc.s 13
+			IL_02cc: ldloc.s 14
+			IL_02ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02d3: pop
+			IL_02d4: leave IL_02d9
 		} // end handler
 
-		IL_02e1: ldloc.0
-		IL_02e2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_02e7: stloc.s 12
-		IL_02e9: ldloc.s 12
-		IL_02eb: ldstr "join"
-		IL_02f0: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_02f5: stloc.s 16
-		IL_02f7: ldloc.0
-		IL_02f8: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_02fd: stloc.s 12
-		IL_02ff: ldloc.s 12
-		IL_0301: ldstr "sep"
-		IL_0306: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_030b: stloc.s 16
+		IL_02d9: ldloc.0
+		IL_02da: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_02df: stloc.s 12
+		IL_02e1: ldloc.s 12
+		IL_02e3: ldstr "join"
+		IL_02e8: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_02ed: stloc.s 16
+		IL_02ef: ldloc.0
+		IL_02f0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_02f5: stloc.s 12
+		IL_02f7: ldloc.s 12
+		IL_02f9: ldstr "sep"
+		IL_02fe: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_0303: stloc.s 16
 		.try
 		{
-			IL_030d: nop
-			IL_030e: ldloc.0
-			IL_030f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-			IL_0314: stloc.s 12
-			IL_0316: ldloc.s 12
-			IL_0318: ldstr "join"
-			IL_031d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_0322: brtrue IL_0342
+			IL_0305: nop
+			IL_0306: ldloc.0
+			IL_0307: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+			IL_030c: stloc.s 12
+			IL_030e: ldloc.s 12
+			IL_0310: ldstr "join"
+			IL_0315: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_031a: brtrue IL_033a
 
-			IL_0327: ldloc.s 12
-			IL_0329: ldc.i4.1
-			IL_032a: newarr [System.Runtime]System.Object
-			IL_032f: dup
-			IL_0330: ldc.i4.0
-			IL_0331: ldstr "a"
-			IL_0336: stelem.ref
-			IL_0337: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_033c: pop
-			IL_033d: br IL_035d
+			IL_031f: ldloc.s 12
+			IL_0321: ldc.i4.1
+			IL_0322: newarr [System.Runtime]System.Object
+			IL_0327: dup
+			IL_0328: ldc.i4.0
+			IL_0329: ldstr "a"
+			IL_032e: stelem.ref
+			IL_032f: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0334: pop
+			IL_0335: br IL_0355
 
-			IL_0342: ldloc.s 12
-			IL_0344: ldstr "join"
-			IL_0349: ldc.i4.1
-			IL_034a: newarr [System.Runtime]System.Object
-			IL_034f: dup
-			IL_0350: ldc.i4.0
-			IL_0351: ldstr "a"
-			IL_0356: stelem.ref
-			IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_035c: pop
+			IL_033a: ldloc.s 12
+			IL_033c: ldstr "join"
+			IL_0341: ldc.i4.1
+			IL_0342: newarr [System.Runtime]System.Object
+			IL_0347: dup
+			IL_0348: ldc.i4.0
+			IL_0349: ldstr "a"
+			IL_034e: stelem.ref
+			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_0354: pop
 
-			IL_035d: leave IL_03df
+			IL_0355: leave IL_03d7
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0362: stloc.s 7
-			IL_0364: ldloc.s 7
-			IL_0366: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_036b: dup
-			IL_036c: brtrue IL_0382
+			IL_035a: stloc.s 7
+			IL_035c: ldloc.s 7
+			IL_035e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0363: dup
+			IL_0364: brtrue IL_037a
 
-			IL_0371: pop
-			IL_0372: ldloc.s 7
-			IL_0374: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0379: dup
-			IL_037a: brtrue IL_038e
+			IL_0369: pop
+			IL_036a: ldloc.s 7
+			IL_036c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0371: dup
+			IL_0372: brtrue IL_0386
 
-			IL_037f: pop
-			IL_0380: rethrow
+			IL_0377: pop
+			IL_0378: rethrow
 
-			IL_0382: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0387: stloc.s 8
-			IL_0389: br IL_0390
+			IL_037a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_037f: stloc.s 8
+			IL_0381: br IL_0388
 
-			IL_038e: stloc.s 8
+			IL_0386: stloc.s 8
 
-			IL_0390: ldloc.s 8
-			IL_0392: stloc.s 9
-			IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0399: stloc.s 13
-			IL_039b: volatile.
-			IL_039d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-			IL_03a2: brfalse IL_03b8
+			IL_0388: ldloc.s 8
+			IL_038a: stloc.s 9
+			IL_038c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0391: stloc.s 13
+			IL_0393: volatile.
+			IL_0395: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_039a: brfalse IL_03b0
 
-			IL_03a7: ldloc.s 9
-			IL_03a9: ldstr "name"
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b3: br IL_03ce
+			IL_039f: ldloc.s 9
+			IL_03a1: ldstr "name"
+			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ab: br IL_03c6
 
-			IL_03b8: ldloc.s 9
-			IL_03ba: ldstr "name"
-			IL_03bf: ldstr "Require_Path_MemberOverrides:Modules.Require_Path_MemberOverrides:__js_module_init__:106"
-			IL_03c4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_03b0: ldloc.s 9
+			IL_03b2: ldstr "name"
+			IL_03b7: ldstr "Require_Path_MemberOverrides:Modules.Require_Path_MemberOverrides:__js_module_init__:106"
+			IL_03bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03ce: stloc.s 14
-			IL_03d0: ldloc.s 13
-			IL_03d2: ldloc.s 14
-			IL_03d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03d9: pop
-			IL_03da: leave IL_03df
+			IL_03c6: stloc.s 14
+			IL_03c8: ldloc.s 13
+			IL_03ca: ldloc.s 14
+			IL_03cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03d1: pop
+			IL_03d2: leave IL_03d7
 		} // end handler
 
-		IL_03df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03e4: stloc.s 13
-		IL_03e6: ldloc.0
-		IL_03e7: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_03ec: stloc.s 12
-		IL_03ee: ldloc.s 12
-		IL_03f0: ldstr "sep"
-		IL_03f5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-		IL_03fa: brtrue IL_040d
+		IL_03d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03dc: stloc.s 13
+		IL_03de: ldloc.0
+		IL_03df: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_03e4: stloc.s 12
+		IL_03e6: ldloc.s 12
+		IL_03e8: ldstr "sep"
+		IL_03ed: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+		IL_03f2: brtrue IL_0405
 
-		IL_03ff: ldloc.s 12
-		IL_0401: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
-		IL_0406: stloc.s 14
-		IL_0408: br IL_041b
+		IL_03f7: ldloc.s 12
+		IL_03f9: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::get_sep()
+		IL_03fe: stloc.s 14
+		IL_0400: br IL_0413
 
-		IL_040d: ldloc.s 12
-		IL_040f: ldstr "sep"
-		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_0419: stloc.s 14
+		IL_0405: ldloc.s 12
+		IL_0407: ldstr "sep"
+		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0411: stloc.s 14
 
-		IL_041b: ldloc.s 14
-		IL_041d: ldnull
-		IL_041e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0423: stloc.s 16
-		IL_0425: ldloc.s 16
-		IL_0427: box [System.Runtime]System.Boolean
-		IL_042c: stloc.s 17
-		IL_042e: ldloc.s 13
-		IL_0430: ldloc.s 17
-		IL_0432: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0437: pop
-		IL_0438: ldloc.0
-		IL_0439: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_043e: stloc.s 12
-		IL_0440: ldloc.s 12
-		IL_0442: ldstr "join"
-		IL_0447: ldloc.2
-		IL_0448: ldc.i4.1
-		IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_044e: pop
-		IL_044f: ldloc.0
-		IL_0450: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
-		IL_0455: stloc.s 12
-		IL_0457: ldloc.s 12
-		IL_0459: ldstr "sep"
-		IL_045e: ldloc.3
-		IL_045f: ldc.i4.1
-		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0465: pop
-		IL_0466: ldnull
-		IL_0467: stloc.s 10
-		IL_0469: ret
+		IL_0413: ldloc.s 14
+		IL_0415: ldnull
+		IL_0416: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_041b: stloc.s 16
+		IL_041d: ldloc.s 16
+		IL_041f: box [System.Runtime]System.Boolean
+		IL_0424: stloc.s 17
+		IL_0426: ldloc.s 13
+		IL_0428: ldloc.s 17
+		IL_042a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_042f: pop
+		IL_0430: ldloc.0
+		IL_0431: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_0436: stloc.s 12
+		IL_0438: ldloc.s 12
+		IL_043a: ldstr "join"
+		IL_043f: ldloc.2
+		IL_0440: ldc.i4.1
+		IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0446: pop
+		IL_0447: ldloc.0
+		IL_0448: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Require_Path_MemberOverrides/Scope::path
+		IL_044d: stloc.s 12
+		IL_044f: ldloc.s 12
+		IL_0451: ldstr "sep"
+		IL_0456: ldloc.3
+		IL_0457: ldc.i4.1
+		IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_045d: pop
+		IL_045e: ldnull
+		IL_045f: stloc.s 10
+		IL_0461: ret
 	} // end of method Require_Path_MemberOverrides::__js_module_init__
 
 } // end of class Modules.Require_Path_MemberOverrides

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -1110,7 +1110,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 2529 (0x9e1)
+			// Code size: 2499 (0x9c3)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope,
@@ -1280,7 +1280,7 @@
 
 			IL_011b: ldloc.0
 			IL_011c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0121: switch (IL_013a, IL_05fd, IL_05dd, IL_08a9, IL_0889)
+			IL_0121: switch (IL_013a, IL_05e9, IL_05c9, IL_088b, IL_086b)
 			.try
 			{
 				IL_013a: nop
@@ -1290,906 +1290,900 @@
 				IL_013e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
 				IL_0143: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
 				IL_0148: stloc.s 12
-				IL_014a: ldarg.0
-				IL_014b: ldc.i4.1
-				IL_014c: ldelem.ref
-				IL_014d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0152: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-				IL_0157: ldc.i4.1
-				IL_0158: newarr [System.Runtime]System.Object
-				IL_015d: dup
-				IL_015e: ldc.i4.0
-				IL_015f: ldarg.0
-				IL_0160: ldc.i4.1
-				IL_0161: ldelem.ref
-				IL_0162: stelem.ref
-				IL_0163: stloc.s 13
-				IL_0165: ldloc.s 13
-				IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_016c: stloc.s 14
-				IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0173: dup
-				IL_0174: ldstr "signal"
-				IL_0179: ldc.i4.0
-				IL_017a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_017f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0184: stloc.s 15
-				IL_0186: ldc.i4.1
-				IL_0187: newarr [System.Runtime]System.Object
-				IL_018c: dup
-				IL_018d: ldc.i4.0
-				IL_018e: ldarg.0
-				IL_018f: ldc.i4.1
-				IL_0190: ldelem.ref
-				IL_0191: stelem.ref
-				IL_0192: stloc.s 13
-				IL_0194: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject::.ctor()
-				IL_0199: ldc.i4.0
-				IL_019a: conv.r8
-				IL_019b: ldstr ""
-				IL_01a0: ldc.i4.0
-				IL_01a1: ldc.i4.0
-				IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_01a7: stloc.s 16
-				IL_01a9: ldloc.s 12
-				IL_01ab: ldstr "finished"
-				IL_01b0: ldloc.s 14
-				IL_01b2: ldloc.s 15
-				IL_01b4: ldloc.s 16
-				IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-				IL_01bb: pop
-				IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_01c1: stloc.s 17
-				IL_01c3: ldloc.s 17
-				IL_01c5: ldstr "callback-finished:ok"
-				IL_01ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_01cf: pop
-				IL_01d0: leave IL_02e7
+				IL_014a: ldc.i4.1
+				IL_014b: newarr [System.Runtime]System.Object
+				IL_0150: dup
+				IL_0151: ldc.i4.0
+				IL_0152: ldarg.0
+				IL_0153: ldc.i4.1
+				IL_0154: ldelem.ref
+				IL_0155: stelem.ref
+				IL_0156: stloc.s 13
+				IL_0158: ldloc.s 13
+				IL_015a: ldc.i4.0
+				IL_015b: ldelem.ref
+				IL_015c: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0161: ldnull
+				IL_0162: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_0167: stloc.s 14
+				IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_016e: dup
+				IL_016f: ldstr "signal"
+				IL_0174: ldc.i4.0
+				IL_0175: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_017a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_017f: stloc.s 15
+				IL_0181: ldc.i4.1
+				IL_0182: newarr [System.Runtime]System.Object
+				IL_0187: dup
+				IL_0188: ldc.i4.0
+				IL_0189: ldarg.0
+				IL_018a: ldc.i4.1
+				IL_018b: ldelem.ref
+				IL_018c: stelem.ref
+				IL_018d: stloc.s 13
+				IL_018f: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject::.ctor()
+				IL_0194: ldc.i4.0
+				IL_0195: conv.r8
+				IL_0196: ldstr ""
+				IL_019b: ldc.i4.0
+				IL_019c: ldc.i4.0
+				IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_01a2: stloc.s 16
+				IL_01a4: ldloc.s 12
+				IL_01a6: ldstr "finished"
+				IL_01ab: ldloc.s 14
+				IL_01ad: ldloc.s 15
+				IL_01af: ldloc.s 16
+				IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+				IL_01b6: pop
+				IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_01bc: stloc.s 17
+				IL_01be: ldloc.s 17
+				IL_01c0: ldstr "callback-finished:ok"
+				IL_01c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_01ca: pop
+				IL_01cb: leave IL_02e2
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_01d5: stloc.1
-				IL_01d6: ldloc.1
-				IL_01d7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_01dc: dup
-				IL_01dd: brtrue IL_01f2
+				IL_01d0: stloc.1
+				IL_01d1: ldloc.1
+				IL_01d2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_01d7: dup
+				IL_01d8: brtrue IL_01ed
 
-				IL_01e2: pop
-				IL_01e3: ldloc.1
-				IL_01e4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_01e9: dup
-				IL_01ea: brtrue IL_01fd
+				IL_01dd: pop
+				IL_01de: ldloc.1
+				IL_01df: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_01e4: dup
+				IL_01e5: brtrue IL_01f8
 
-				IL_01ef: pop
-				IL_01f0: rethrow
+				IL_01ea: pop
+				IL_01eb: rethrow
 
-				IL_01f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_01f7: stloc.2
-				IL_01f8: br IL_01fe
+				IL_01ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_01f2: stloc.2
+				IL_01f3: br IL_01f9
 
-				IL_01fd: stloc.2
+				IL_01f8: stloc.2
 
-				IL_01fe: ldloc.2
-				IL_01ff: stloc.3
-				IL_0200: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0205: stloc.s 17
-				IL_0207: volatile.
-				IL_0209: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-				IL_020e: brfalse IL_0223
+				IL_01f9: ldloc.2
+				IL_01fa: stloc.3
+				IL_01fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0200: stloc.s 17
+				IL_0202: volatile.
+				IL_0204: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+				IL_0209: brfalse IL_021e
 
-				IL_0213: ldloc.3
-				IL_0214: ldstr "name"
-				IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_021e: br IL_0238
+				IL_020e: ldloc.3
+				IL_020f: ldstr "name"
+				IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0219: br IL_0233
 
-				IL_0223: ldloc.3
-				IL_0224: ldstr "name"
-				IL_0229: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:29"
-				IL_022e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-				IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_021e: ldloc.3
+				IL_021f: ldstr "name"
+				IL_0224: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:28"
+				IL_0229: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+				IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0238: stloc.s 14
-				IL_023a: ldstr "callback-finished:"
-				IL_023f: ldloc.s 14
-				IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0246: stloc.s 18
-				IL_0248: ldloc.s 18
-				IL_024a: ldstr ":"
-				IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0254: stloc.s 18
-				IL_0256: volatile.
-				IL_0258: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-				IL_025d: brfalse IL_0272
+				IL_0233: stloc.s 14
+				IL_0235: ldstr "callback-finished:"
+				IL_023a: ldloc.s 14
+				IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0241: stloc.s 18
+				IL_0243: ldloc.s 18
+				IL_0245: ldstr ":"
+				IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_024f: stloc.s 18
+				IL_0251: volatile.
+				IL_0253: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+				IL_0258: brfalse IL_026d
 
-				IL_0262: ldloc.3
-				IL_0263: ldstr "code"
-				IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_026d: br IL_0287
+				IL_025d: ldloc.3
+				IL_025e: ldstr "code"
+				IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0268: br IL_0282
 
-				IL_0272: ldloc.3
-				IL_0273: ldstr "code"
-				IL_0278: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:34"
-				IL_027d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-				IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_026d: ldloc.3
+				IL_026e: ldstr "code"
+				IL_0273: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:33"
+				IL_0278: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+				IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0287: stloc.s 14
-				IL_0289: ldloc.s 18
-				IL_028b: ldloc.s 14
-				IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0292: stloc.s 18
-				IL_0294: ldloc.s 17
-				IL_0296: ldloc.s 18
-				IL_0298: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_029d: pop
-				IL_029e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_02a3: stloc.s 17
-				IL_02a5: volatile.
-				IL_02a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-				IL_02ac: brfalse IL_02c1
+				IL_0282: stloc.s 14
+				IL_0284: ldloc.s 18
+				IL_0286: ldloc.s 14
+				IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_028d: stloc.s 18
+				IL_028f: ldloc.s 17
+				IL_0291: ldloc.s 18
+				IL_0293: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0298: pop
+				IL_0299: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_029e: stloc.s 17
+				IL_02a0: volatile.
+				IL_02a2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+				IL_02a7: brfalse IL_02bc
 
-				IL_02b1: ldloc.3
-				IL_02b2: ldstr "message"
-				IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02bc: br IL_02d6
+				IL_02ac: ldloc.3
+				IL_02ad: ldstr "message"
+				IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_02b7: br IL_02d1
 
-				IL_02c1: ldloc.3
-				IL_02c2: ldstr "message"
-				IL_02c7: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:40"
-				IL_02cc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-				IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_02bc: ldloc.3
+				IL_02bd: ldstr "message"
+				IL_02c2: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:39"
+				IL_02c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+				IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_02d6: stloc.s 14
-				IL_02d8: ldloc.s 17
-				IL_02da: ldloc.s 14
-				IL_02dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_02e1: pop
-				IL_02e2: leave IL_02e7
+				IL_02d1: stloc.s 14
+				IL_02d3: ldloc.s 17
+				IL_02d5: ldloc.s 14
+				IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_02dc: pop
+				IL_02dd: leave IL_02e2
 			} // end handler
 			.try
 			{
-				IL_02e7: nop
-				IL_02e8: ldarg.0
-				IL_02e9: ldc.i4.1
-				IL_02ea: ldelem.ref
-				IL_02eb: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_02f0: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_02f5: stloc.s 12
-				IL_02f7: ldarg.0
-				IL_02f8: ldc.i4.1
-				IL_02f9: ldelem.ref
-				IL_02fa: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_02ff: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
-				IL_0304: ldc.i4.1
-				IL_0305: newarr [System.Runtime]System.Object
-				IL_030a: dup
-				IL_030b: ldc.i4.0
-				IL_030c: ldarg.0
-				IL_030d: ldc.i4.1
-				IL_030e: ldelem.ref
-				IL_030f: stelem.ref
-				IL_0310: stloc.s 13
-				IL_0312: ldloc.s 13
-				IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0319: stloc.s 14
-				IL_031b: ldarg.0
-				IL_031c: ldc.i4.1
-				IL_031d: ldelem.ref
-				IL_031e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0323: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-				IL_0328: ldc.i4.1
-				IL_0329: newarr [System.Runtime]System.Object
-				IL_032e: dup
-				IL_032f: ldc.i4.0
-				IL_0330: ldarg.0
-				IL_0331: ldc.i4.1
-				IL_0332: ldelem.ref
-				IL_0333: stelem.ref
-				IL_0334: stloc.s 13
-				IL_0336: ldloc.s 13
-				IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_033d: stloc.s 19
-				IL_033f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0344: stloc.s 15
-				IL_0346: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_034b: dup
-				IL_034c: ldstr "signal"
-				IL_0351: ldloc.s 15
-				IL_0353: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0358: stloc.s 15
-				IL_035a: ldc.i4.1
-				IL_035b: newarr [System.Runtime]System.Object
-				IL_0360: dup
-				IL_0361: ldc.i4.0
-				IL_0362: ldarg.0
-				IL_0363: ldc.i4.1
-				IL_0364: ldelem.ref
-				IL_0365: stelem.ref
-				IL_0366: stloc.s 13
-				IL_0368: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject::.ctor()
-				IL_036d: ldc.i4.0
-				IL_036e: conv.r8
-				IL_036f: ldstr ""
-				IL_0374: ldc.i4.0
-				IL_0375: ldc.i4.0
-				IL_0376: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject>(!!0, float64, string, bool, bool)
-				IL_037b: stloc.s 20
-				IL_037d: ldloc.s 12
-				IL_037f: ldc.i4.4
-				IL_0380: newarr [System.Runtime]System.Object
+				IL_02e2: nop
+				IL_02e3: ldarg.0
+				IL_02e4: ldc.i4.1
+				IL_02e5: ldelem.ref
+				IL_02e6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_02eb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+				IL_02f0: stloc.s 12
+				IL_02f2: ldc.i4.1
+				IL_02f3: newarr [System.Runtime]System.Object
+				IL_02f8: dup
+				IL_02f9: ldc.i4.0
+				IL_02fa: ldarg.0
+				IL_02fb: ldc.i4.1
+				IL_02fc: ldelem.ref
+				IL_02fd: stelem.ref
+				IL_02fe: stloc.s 13
+				IL_0300: ldloc.s 13
+				IL_0302: ldc.i4.0
+				IL_0303: ldelem.ref
+				IL_0304: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0309: ldnull
+				IL_030a: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_030f: stloc.s 14
+				IL_0311: ldc.i4.1
+				IL_0312: newarr [System.Runtime]System.Object
+				IL_0317: dup
+				IL_0318: ldc.i4.0
+				IL_0319: ldarg.0
+				IL_031a: ldc.i4.1
+				IL_031b: ldelem.ref
+				IL_031c: stelem.ref
+				IL_031d: stloc.s 13
+				IL_031f: ldloc.s 13
+				IL_0321: ldc.i4.0
+				IL_0322: ldelem.ref
+				IL_0323: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0328: ldnull
+				IL_0329: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_032e: stloc.s 19
+				IL_0330: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0335: stloc.s 15
+				IL_0337: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_033c: dup
+				IL_033d: ldstr "signal"
+				IL_0342: ldloc.s 15
+				IL_0344: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_0349: stloc.s 15
+				IL_034b: ldc.i4.1
+				IL_034c: newarr [System.Runtime]System.Object
+				IL_0351: dup
+				IL_0352: ldc.i4.0
+				IL_0353: ldarg.0
+				IL_0354: ldc.i4.1
+				IL_0355: ldelem.ref
+				IL_0356: stelem.ref
+				IL_0357: stloc.s 13
+				IL_0359: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject::.ctor()
+				IL_035e: ldc.i4.0
+				IL_035f: conv.r8
+				IL_0360: ldstr ""
+				IL_0365: ldc.i4.0
+				IL_0366: ldc.i4.0
+				IL_0367: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_036c: stloc.s 20
+				IL_036e: ldloc.s 12
+				IL_0370: ldc.i4.4
+				IL_0371: newarr [System.Runtime]System.Object
+				IL_0376: dup
+				IL_0377: ldc.i4.0
+				IL_0378: ldloc.s 14
+				IL_037a: stelem.ref
+				IL_037b: dup
+				IL_037c: ldc.i4.1
+				IL_037d: ldloc.s 19
+				IL_037f: stelem.ref
+				IL_0380: dup
+				IL_0381: ldc.i4.2
+				IL_0382: ldloc.s 15
+				IL_0384: stelem.ref
 				IL_0385: dup
-				IL_0386: ldc.i4.0
-				IL_0387: ldloc.s 14
+				IL_0386: ldc.i4.3
+				IL_0387: ldloc.s 20
 				IL_0389: stelem.ref
-				IL_038a: dup
-				IL_038b: ldc.i4.1
-				IL_038c: ldloc.s 19
-				IL_038e: stelem.ref
-				IL_038f: dup
-				IL_0390: ldc.i4.2
-				IL_0391: ldloc.s 15
-				IL_0393: stelem.ref
-				IL_0394: dup
-				IL_0395: ldc.i4.3
-				IL_0396: ldloc.s 20
-				IL_0398: stelem.ref
-				IL_0399: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::pipeline(object[])
-				IL_039e: pop
-				IL_039f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_03a4: stloc.s 17
-				IL_03a6: ldloc.s 17
-				IL_03a8: ldstr "callback-pipeline:ok"
-				IL_03ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_03b2: pop
-				IL_03b3: leave IL_04d7
+				IL_038a: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule::pipeline(object[])
+				IL_038f: pop
+				IL_0390: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0395: stloc.s 17
+				IL_0397: ldloc.s 17
+				IL_0399: ldstr "callback-pipeline:ok"
+				IL_039e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_03a3: pop
+				IL_03a4: leave IL_04c8
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_03b8: stloc.s 4
-				IL_03ba: ldloc.s 4
-				IL_03bc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_03c1: dup
-				IL_03c2: brtrue IL_03d8
+				IL_03a9: stloc.s 4
+				IL_03ab: ldloc.s 4
+				IL_03ad: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_03b2: dup
+				IL_03b3: brtrue IL_03c9
 
-				IL_03c7: pop
-				IL_03c8: ldloc.s 4
-				IL_03ca: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_03cf: dup
-				IL_03d0: brtrue IL_03e4
+				IL_03b8: pop
+				IL_03b9: ldloc.s 4
+				IL_03bb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_03c0: dup
+				IL_03c1: brtrue IL_03d5
 
-				IL_03d5: pop
-				IL_03d6: rethrow
+				IL_03c6: pop
+				IL_03c7: rethrow
 
-				IL_03d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_03dd: stloc.s 5
-				IL_03df: br IL_03e6
+				IL_03c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_03ce: stloc.s 5
+				IL_03d0: br IL_03d7
 
-				IL_03e4: stloc.s 5
+				IL_03d5: stloc.s 5
 
-				IL_03e6: ldloc.s 5
-				IL_03e8: stloc.s 6
-				IL_03ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_03ef: stloc.s 17
-				IL_03f1: volatile.
-				IL_03f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-				IL_03f8: brfalse IL_040e
+				IL_03d7: ldloc.s 5
+				IL_03d9: stloc.s 6
+				IL_03db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_03e0: stloc.s 17
+				IL_03e2: volatile.
+				IL_03e4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+				IL_03e9: brfalse IL_03ff
 
-				IL_03fd: ldloc.s 6
-				IL_03ff: ldstr "name"
-				IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0409: br IL_0424
+				IL_03ee: ldloc.s 6
+				IL_03f0: ldstr "name"
+				IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03fa: br IL_0415
 
-				IL_040e: ldloc.s 6
-				IL_0410: ldstr "name"
-				IL_0415: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:77"
-				IL_041a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-				IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_03ff: ldloc.s 6
+				IL_0401: ldstr "name"
+				IL_0406: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:74"
+				IL_040b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+				IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0424: stloc.s 19
-				IL_0426: ldstr "callback-pipeline:"
-				IL_042b: ldloc.s 19
-				IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0432: stloc.s 18
-				IL_0434: ldloc.s 18
-				IL_0436: ldstr ":"
-				IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0440: stloc.s 18
-				IL_0442: volatile.
-				IL_0444: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-				IL_0449: brfalse IL_045f
+				IL_0415: stloc.s 19
+				IL_0417: ldstr "callback-pipeline:"
+				IL_041c: ldloc.s 19
+				IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0423: stloc.s 18
+				IL_0425: ldloc.s 18
+				IL_0427: ldstr ":"
+				IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0431: stloc.s 18
+				IL_0433: volatile.
+				IL_0435: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+				IL_043a: brfalse IL_0450
 
-				IL_044e: ldloc.s 6
-				IL_0450: ldstr "code"
-				IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_045a: br IL_0475
+				IL_043f: ldloc.s 6
+				IL_0441: ldstr "code"
+				IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_044b: br IL_0466
 
-				IL_045f: ldloc.s 6
-				IL_0461: ldstr "code"
-				IL_0466: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:82"
-				IL_046b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-				IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_0450: ldloc.s 6
+				IL_0452: ldstr "code"
+				IL_0457: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:79"
+				IL_045c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+				IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_0475: stloc.s 19
-				IL_0477: ldloc.s 18
-				IL_0479: ldloc.s 19
-				IL_047b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0480: stloc.s 18
-				IL_0482: ldloc.s 17
-				IL_0484: ldloc.s 18
-				IL_0486: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_048b: pop
-				IL_048c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0491: stloc.s 17
-				IL_0493: volatile.
-				IL_0495: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-				IL_049a: brfalse IL_04b0
+				IL_0466: stloc.s 19
+				IL_0468: ldloc.s 18
+				IL_046a: ldloc.s 19
+				IL_046c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0471: stloc.s 18
+				IL_0473: ldloc.s 17
+				IL_0475: ldloc.s 18
+				IL_0477: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_047c: pop
+				IL_047d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0482: stloc.s 17
+				IL_0484: volatile.
+				IL_0486: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+				IL_048b: brfalse IL_04a1
 
-				IL_049f: ldloc.s 6
-				IL_04a1: ldstr "message"
-				IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_04ab: br IL_04c6
+				IL_0490: ldloc.s 6
+				IL_0492: ldstr "message"
+				IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_049c: br IL_04b7
 
-				IL_04b0: ldloc.s 6
-				IL_04b2: ldstr "message"
-				IL_04b7: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:88"
-				IL_04bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-				IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+				IL_04a1: ldloc.s 6
+				IL_04a3: ldstr "message"
+				IL_04a8: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:85"
+				IL_04ad: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+				IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-				IL_04c6: stloc.s 19
-				IL_04c8: ldloc.s 17
-				IL_04ca: ldloc.s 19
-				IL_04cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_04d1: pop
-				IL_04d2: leave IL_04d7
+				IL_04b7: stloc.s 19
+				IL_04b9: ldloc.s 17
+				IL_04bb: ldloc.s 19
+				IL_04bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_04c2: pop
+				IL_04c3: leave IL_04c8
 			} // end handler
 
-			IL_04d7: ldloc.0
-			IL_04d8: ldc.i4.0
-			IL_04d9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04de: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_04e3: ldarg.0
-			IL_04e4: ldc.i4.1
-			IL_04e5: ldelem.ref
-			IL_04e6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_04eb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_04f0: stloc.s 21
-			IL_04f2: ldarg.0
-			IL_04f3: ldc.i4.1
+			IL_04c8: ldloc.0
+			IL_04c9: ldc.i4.0
+			IL_04ca: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04cf: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_04d4: ldarg.0
+			IL_04d5: ldc.i4.1
+			IL_04d6: ldelem.ref
+			IL_04d7: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_04dc: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_04e1: stloc.s 21
+			IL_04e3: ldc.i4.1
+			IL_04e4: newarr [System.Runtime]System.Object
+			IL_04e9: dup
+			IL_04ea: ldc.i4.0
+			IL_04eb: ldarg.0
+			IL_04ec: ldc.i4.1
+			IL_04ed: ldelem.ref
+			IL_04ee: stelem.ref
+			IL_04ef: stloc.s 13
+			IL_04f1: ldloc.s 13
+			IL_04f3: ldc.i4.0
 			IL_04f4: ldelem.ref
 			IL_04f5: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_04fa: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-			IL_04ff: ldc.i4.1
-			IL_0500: newarr [System.Runtime]System.Object
-			IL_0505: dup
-			IL_0506: ldc.i4.0
-			IL_0507: ldarg.0
-			IL_0508: ldc.i4.1
-			IL_0509: ldelem.ref
-			IL_050a: stelem.ref
-			IL_050b: stloc.s 13
-			IL_050d: ldloc.s 13
-			IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0514: stloc.s 19
-			IL_0516: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_051b: dup
-			IL_051c: ldstr "signal"
-			IL_0521: ldc.i4.0
-			IL_0522: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0527: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_052c: stloc.s 15
-			IL_052e: ldloc.s 21
-			IL_0530: ldloc.s 19
-			IL_0532: ldloc.s 15
-			IL_0534: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::finished(object, object)
-			IL_0539: stloc.s 19
-			IL_053b: ldloc.0
-			IL_053c: ldc.i4.2
-			IL_053d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0542: ldloc.0
-			IL_0543: ldloc.s 19
-			IL_0545: ldarg.0
-			IL_0546: ldc.i4.1
-			IL_0547: ldloc.0
-			IL_0548: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_054d: ldc.i4.1
-			IL_054e: ldstr "_pendingException"
-			IL_0553: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
-			IL_0558: ldloc.0
-			IL_0559: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_055e: dup
-			IL_055f: ldc.i4.0
-			IL_0560: ldloc.1
-			IL_0561: stelem.ref
-			IL_0562: dup
-			IL_0563: ldc.i4.1
-			IL_0564: ldloc.2
-			IL_0565: stelem.ref
-			IL_0566: dup
-			IL_0567: ldc.i4.2
-			IL_0568: ldloc.3
+			IL_04fa: ldnull
+			IL_04fb: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+			IL_0500: stloc.s 19
+			IL_0502: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0507: dup
+			IL_0508: ldstr "signal"
+			IL_050d: ldc.i4.0
+			IL_050e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0513: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0518: stloc.s 15
+			IL_051a: ldloc.s 21
+			IL_051c: ldloc.s 19
+			IL_051e: ldloc.s 15
+			IL_0520: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::finished(object, object)
+			IL_0525: stloc.s 19
+			IL_0527: ldloc.0
+			IL_0528: ldc.i4.2
+			IL_0529: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_052e: ldloc.0
+			IL_052f: ldloc.s 19
+			IL_0531: ldarg.0
+			IL_0532: ldc.i4.1
+			IL_0533: ldloc.0
+			IL_0534: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0539: ldc.i4.1
+			IL_053a: ldstr "_pendingException"
+			IL_053f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
+			IL_0544: ldloc.0
+			IL_0545: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_054a: dup
+			IL_054b: ldc.i4.0
+			IL_054c: ldloc.1
+			IL_054d: stelem.ref
+			IL_054e: dup
+			IL_054f: ldc.i4.1
+			IL_0550: ldloc.2
+			IL_0551: stelem.ref
+			IL_0552: dup
+			IL_0553: ldc.i4.2
+			IL_0554: ldloc.3
+			IL_0555: stelem.ref
+			IL_0556: dup
+			IL_0557: ldc.i4.3
+			IL_0558: ldloc.s 4
+			IL_055a: stelem.ref
+			IL_055b: dup
+			IL_055c: ldc.i4.4
+			IL_055d: ldloc.s 5
+			IL_055f: stelem.ref
+			IL_0560: dup
+			IL_0561: ldc.i4.5
+			IL_0562: ldloc.s 6
+			IL_0564: stelem.ref
+			IL_0565: dup
+			IL_0566: ldc.i4.6
+			IL_0567: ldloc.s 7
 			IL_0569: stelem.ref
 			IL_056a: dup
-			IL_056b: ldc.i4.3
-			IL_056c: ldloc.s 4
+			IL_056b: ldc.i4.7
+			IL_056c: ldloc.s 8
 			IL_056e: stelem.ref
 			IL_056f: dup
-			IL_0570: ldc.i4.4
-			IL_0571: ldloc.s 5
+			IL_0570: ldc.i4.8
+			IL_0571: ldloc.s 9
 			IL_0573: stelem.ref
 			IL_0574: dup
-			IL_0575: ldc.i4.5
-			IL_0576: ldloc.s 6
-			IL_0578: stelem.ref
-			IL_0579: dup
-			IL_057a: ldc.i4.6
-			IL_057b: ldloc.s 7
-			IL_057d: stelem.ref
-			IL_057e: dup
-			IL_057f: ldc.i4.7
-			IL_0580: ldloc.s 8
-			IL_0582: stelem.ref
-			IL_0583: dup
-			IL_0584: ldc.i4.8
-			IL_0585: ldloc.s 9
-			IL_0587: stelem.ref
-			IL_0588: dup
-			IL_0589: ldc.i4.s 9
-			IL_058b: ldloc.s 10
-			IL_058d: stelem.ref
-			IL_058e: dup
-			IL_058f: ldc.i4.s 10
-			IL_0591: ldloc.s 11
-			IL_0593: stelem.ref
-			IL_0594: dup
-			IL_0595: ldc.i4.s 11
-			IL_0597: ldloc.s 12
-			IL_0599: stelem.ref
-			IL_059a: dup
-			IL_059b: ldc.i4.s 12
-			IL_059d: ldloc.s 13
-			IL_059f: stelem.ref
-			IL_05a0: dup
-			IL_05a1: ldc.i4.s 13
-			IL_05a3: ldloc.s 14
-			IL_05a5: stelem.ref
-			IL_05a6: dup
-			IL_05a7: ldc.i4.s 14
-			IL_05a9: ldloc.s 15
-			IL_05ab: stelem.ref
-			IL_05ac: dup
-			IL_05ad: ldc.i4.s 15
-			IL_05af: ldloc.s 16
-			IL_05b1: stelem.ref
-			IL_05b2: dup
-			IL_05b3: ldc.i4.s 16
-			IL_05b5: ldloc.s 17
-			IL_05b7: stelem.ref
-			IL_05b8: dup
-			IL_05b9: ldc.i4.s 17
-			IL_05bb: ldloc.s 18
-			IL_05bd: stelem.ref
-			IL_05be: dup
-			IL_05bf: ldc.i4.s 18
-			IL_05c1: ldloc.s 19
-			IL_05c3: stelem.ref
-			IL_05c4: dup
-			IL_05c5: ldc.i4.s 19
-			IL_05c7: ldloc.s 20
-			IL_05c9: stelem.ref
-			IL_05ca: dup
-			IL_05cb: ldc.i4.s 20
-			IL_05cd: ldloc.s 21
-			IL_05cf: stelem.ref
-			IL_05d0: pop
-			IL_05d1: ldloc.0
-			IL_05d2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05d7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05dc: ret
+			IL_0575: ldc.i4.s 9
+			IL_0577: ldloc.s 10
+			IL_0579: stelem.ref
+			IL_057a: dup
+			IL_057b: ldc.i4.s 10
+			IL_057d: ldloc.s 11
+			IL_057f: stelem.ref
+			IL_0580: dup
+			IL_0581: ldc.i4.s 11
+			IL_0583: ldloc.s 12
+			IL_0585: stelem.ref
+			IL_0586: dup
+			IL_0587: ldc.i4.s 12
+			IL_0589: ldloc.s 13
+			IL_058b: stelem.ref
+			IL_058c: dup
+			IL_058d: ldc.i4.s 13
+			IL_058f: ldloc.s 14
+			IL_0591: stelem.ref
+			IL_0592: dup
+			IL_0593: ldc.i4.s 14
+			IL_0595: ldloc.s 15
+			IL_0597: stelem.ref
+			IL_0598: dup
+			IL_0599: ldc.i4.s 15
+			IL_059b: ldloc.s 16
+			IL_059d: stelem.ref
+			IL_059e: dup
+			IL_059f: ldc.i4.s 16
+			IL_05a1: ldloc.s 17
+			IL_05a3: stelem.ref
+			IL_05a4: dup
+			IL_05a5: ldc.i4.s 17
+			IL_05a7: ldloc.s 18
+			IL_05a9: stelem.ref
+			IL_05aa: dup
+			IL_05ab: ldc.i4.s 18
+			IL_05ad: ldloc.s 19
+			IL_05af: stelem.ref
+			IL_05b0: dup
+			IL_05b1: ldc.i4.s 19
+			IL_05b3: ldloc.s 20
+			IL_05b5: stelem.ref
+			IL_05b6: dup
+			IL_05b7: ldc.i4.s 20
+			IL_05b9: ldloc.s 21
+			IL_05bb: stelem.ref
+			IL_05bc: pop
+			IL_05bd: ldloc.0
+			IL_05be: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05c3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05c8: ret
 
-			IL_05dd: ldloc.0
-			IL_05de: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
+			IL_05c9: ldloc.0
+			IL_05ca: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
+			IL_05cf: pop
+			IL_05d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05d5: stloc.s 17
+			IL_05d7: ldloc.s 17
+			IL_05d9: ldstr "promise-finished:ok"
+			IL_05de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_05e3: pop
-			IL_05e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05e9: stloc.s 17
-			IL_05eb: ldloc.s 17
-			IL_05ed: ldstr "promise-finished:ok"
-			IL_05f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05f7: pop
-			IL_05f8: br IL_0702
+			IL_05e4: br IL_06ee
 
-			IL_05fd: ldloc.0
-			IL_05fe: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0603: stloc.s 19
-			IL_0605: ldloc.0
-			IL_0606: ldc.i4.0
-			IL_0607: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_060c: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0611: ldloc.s 19
-			IL_0613: stloc.s 7
-			IL_0615: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_061a: stloc.s 17
-			IL_061c: volatile.
-			IL_061e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0623: brfalse IL_0639
+			IL_05e9: ldloc.0
+			IL_05ea: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_05ef: stloc.s 19
+			IL_05f1: ldloc.0
+			IL_05f2: ldc.i4.0
+			IL_05f3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_05f8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_05fd: ldloc.s 19
+			IL_05ff: stloc.s 7
+			IL_0601: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0606: stloc.s 17
+			IL_0608: volatile.
+			IL_060a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_060f: brfalse IL_0625
 
-			IL_0628: ldloc.s 7
-			IL_062a: ldstr "name"
-			IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0634: br IL_064f
+			IL_0614: ldloc.s 7
+			IL_0616: ldstr "name"
+			IL_061b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0620: br IL_063b
 
-			IL_0639: ldloc.s 7
-			IL_063b: ldstr "name"
-			IL_0640: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:121"
-			IL_0645: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0625: ldloc.s 7
+			IL_0627: ldstr "name"
+			IL_062c: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:117"
+			IL_0631: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_064f: stloc.s 19
-			IL_0651: ldstr "promise-finished:"
-			IL_0656: ldloc.s 19
-			IL_0658: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_065d: stloc.s 18
-			IL_065f: ldloc.s 18
-			IL_0661: ldstr ":"
-			IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_066b: stloc.s 18
-			IL_066d: volatile.
-			IL_066f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_0674: brfalse IL_068a
+			IL_063b: stloc.s 19
+			IL_063d: ldstr "promise-finished:"
+			IL_0642: ldloc.s 19
+			IL_0644: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0649: stloc.s 18
+			IL_064b: ldloc.s 18
+			IL_064d: ldstr ":"
+			IL_0652: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0657: stloc.s 18
+			IL_0659: volatile.
+			IL_065b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0660: brfalse IL_0676
 
-			IL_0679: ldloc.s 7
-			IL_067b: ldstr "code"
-			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0685: br IL_06a0
+			IL_0665: ldloc.s 7
+			IL_0667: ldstr "code"
+			IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0671: br IL_068c
 
-			IL_068a: ldloc.s 7
-			IL_068c: ldstr "code"
-			IL_0691: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:126"
-			IL_0696: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_069b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0676: ldloc.s 7
+			IL_0678: ldstr "code"
+			IL_067d: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:122"
+			IL_0682: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06a0: stloc.s 19
-			IL_06a2: ldloc.s 18
-			IL_06a4: ldloc.s 19
-			IL_06a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06ab: stloc.s 18
-			IL_06ad: ldloc.s 17
-			IL_06af: ldloc.s 18
-			IL_06b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06b6: pop
-			IL_06b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06bc: stloc.s 17
-			IL_06be: volatile.
-			IL_06c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_06c5: brfalse IL_06db
+			IL_068c: stloc.s 19
+			IL_068e: ldloc.s 18
+			IL_0690: ldloc.s 19
+			IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0697: stloc.s 18
+			IL_0699: ldloc.s 17
+			IL_069b: ldloc.s 18
+			IL_069d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06a2: pop
+			IL_06a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06a8: stloc.s 17
+			IL_06aa: volatile.
+			IL_06ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_06b1: brfalse IL_06c7
 
-			IL_06ca: ldloc.s 7
-			IL_06cc: ldstr "message"
-			IL_06d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06d6: br IL_06f1
+			IL_06b6: ldloc.s 7
+			IL_06b8: ldstr "message"
+			IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06c2: br IL_06dd
 
-			IL_06db: ldloc.s 7
-			IL_06dd: ldstr "message"
-			IL_06e2: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:132"
-			IL_06e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_06c7: ldloc.s 7
+			IL_06c9: ldstr "message"
+			IL_06ce: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:128"
+			IL_06d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_06d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_06f1: stloc.s 19
-			IL_06f3: ldloc.s 17
-			IL_06f5: ldloc.s 19
-			IL_06f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06fc: pop
-			IL_06fd: br IL_0702
+			IL_06dd: stloc.s 19
+			IL_06df: ldloc.s 17
+			IL_06e1: ldloc.s 19
+			IL_06e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06e8: pop
+			IL_06e9: br IL_06ee
 
-			IL_0702: ldloc.0
-			IL_0703: ldc.i4.0
-			IL_0704: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0709: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_070e: ldarg.0
-			IL_070f: ldc.i4.1
-			IL_0710: ldelem.ref
-			IL_0711: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0716: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
-			IL_071b: ldc.i4.1
-			IL_071c: newarr [System.Runtime]System.Object
-			IL_0721: dup
-			IL_0722: ldc.i4.0
-			IL_0723: ldarg.0
-			IL_0724: ldc.i4.1
-			IL_0725: ldelem.ref
-			IL_0726: stelem.ref
-			IL_0727: stloc.s 13
-			IL_0729: ldloc.s 13
-			IL_072b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0730: stloc.s 8
-			IL_0732: ldarg.0
-			IL_0733: ldc.i4.1
-			IL_0734: ldelem.ref
-			IL_0735: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_073a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_073f: stloc.s 21
-			IL_0741: ldarg.0
-			IL_0742: ldc.i4.1
-			IL_0743: ldelem.ref
-			IL_0744: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0749: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
-			IL_074e: ldc.i4.1
-			IL_074f: newarr [System.Runtime]System.Object
-			IL_0754: dup
-			IL_0755: ldc.i4.0
-			IL_0756: ldarg.0
-			IL_0757: ldc.i4.1
-			IL_0758: ldelem.ref
-			IL_0759: stelem.ref
-			IL_075a: stloc.s 13
-			IL_075c: ldloc.s 13
-			IL_075e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0763: stloc.s 19
-			IL_0765: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_076a: stloc.s 15
-			IL_076c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0771: dup
-			IL_0772: ldstr "signal"
-			IL_0777: ldloc.s 15
-			IL_0779: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_077e: stloc.s 15
-			IL_0780: ldloc.s 21
-			IL_0782: ldc.i4.3
-			IL_0783: newarr [System.Runtime]System.Object
-			IL_0788: dup
-			IL_0789: ldc.i4.0
-			IL_078a: ldloc.s 8
-			IL_078c: stelem.ref
-			IL_078d: dup
-			IL_078e: ldc.i4.1
-			IL_078f: ldloc.s 19
-			IL_0791: stelem.ref
-			IL_0792: dup
-			IL_0793: ldc.i4.2
-			IL_0794: ldloc.s 15
-			IL_0796: stelem.ref
-			IL_0797: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::pipeline(object[])
-			IL_079c: stloc.s 9
-			IL_079e: ldloc.s 8
-			IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07a5: stloc.s 19
-			IL_07a7: volatile.
-			IL_07a9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_07ae: brfalse IL_07ca
+			IL_06ee: ldloc.0
+			IL_06ef: ldc.i4.0
+			IL_06f0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_06f5: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_06fa: ldc.i4.1
+			IL_06fb: newarr [System.Runtime]System.Object
+			IL_0700: dup
+			IL_0701: ldc.i4.0
+			IL_0702: ldarg.0
+			IL_0703: ldc.i4.1
+			IL_0704: ldelem.ref
+			IL_0705: stelem.ref
+			IL_0706: stloc.s 13
+			IL_0708: ldloc.s 13
+			IL_070a: ldc.i4.0
+			IL_070b: ldelem.ref
+			IL_070c: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0711: ldnull
+			IL_0712: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+			IL_0717: stloc.s 8
+			IL_0719: ldarg.0
+			IL_071a: ldc.i4.1
+			IL_071b: ldelem.ref
+			IL_071c: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0721: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_0726: stloc.s 21
+			IL_0728: ldc.i4.1
+			IL_0729: newarr [System.Runtime]System.Object
+			IL_072e: dup
+			IL_072f: ldc.i4.0
+			IL_0730: ldarg.0
+			IL_0731: ldc.i4.1
+			IL_0732: ldelem.ref
+			IL_0733: stelem.ref
+			IL_0734: stloc.s 13
+			IL_0736: ldloc.s 13
+			IL_0738: ldc.i4.0
+			IL_0739: ldelem.ref
+			IL_073a: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_073f: ldnull
+			IL_0740: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+			IL_0745: stloc.s 19
+			IL_0747: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_074c: stloc.s 15
+			IL_074e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0753: dup
+			IL_0754: ldstr "signal"
+			IL_0759: ldloc.s 15
+			IL_075b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0760: stloc.s 15
+			IL_0762: ldloc.s 21
+			IL_0764: ldc.i4.3
+			IL_0765: newarr [System.Runtime]System.Object
+			IL_076a: dup
+			IL_076b: ldc.i4.0
+			IL_076c: ldloc.s 8
+			IL_076e: stelem.ref
+			IL_076f: dup
+			IL_0770: ldc.i4.1
+			IL_0771: ldloc.s 19
+			IL_0773: stelem.ref
+			IL_0774: dup
+			IL_0775: ldc.i4.2
+			IL_0776: ldloc.s 15
+			IL_0778: stelem.ref
+			IL_0779: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule::pipeline(object[])
+			IL_077e: stloc.s 9
+			IL_0780: ldloc.s 8
+			IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0787: stloc.s 19
+			IL_0789: volatile.
+			IL_078b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0790: brfalse IL_07ac
 
-			IL_07b3: ldloc.s 19
-			IL_07b5: ldstr "push"
-			IL_07ba: ldc.i4.0
-			IL_07bb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_07c5: br IL_07e6
+			IL_0795: ldloc.s 19
+			IL_0797: ldstr "push"
+			IL_079c: ldc.i4.0
+			IL_079d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_07a7: br IL_07c8
 
-			IL_07ca: ldloc.s 19
-			IL_07cc: ldstr "push"
-			IL_07d1: ldc.i4.0
-			IL_07d2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_07d7: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:157"
-			IL_07dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_07e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_07ac: ldloc.s 19
+			IL_07ae: ldstr "push"
+			IL_07b3: ldc.i4.0
+			IL_07b4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_07b9: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:151"
+			IL_07be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_07c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_07e6: pop
-			IL_07e7: ldloc.0
-			IL_07e8: ldc.i4.4
-			IL_07e9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07ee: ldloc.0
-			IL_07ef: ldloc.s 9
-			IL_07f1: ldarg.0
-			IL_07f2: ldc.i4.2
-			IL_07f3: ldloc.0
-			IL_07f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07c8: pop
+			IL_07c9: ldloc.0
+			IL_07ca: ldc.i4.4
+			IL_07cb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07d0: ldloc.0
+			IL_07d1: ldloc.s 9
+			IL_07d3: ldarg.0
+			IL_07d4: ldc.i4.2
+			IL_07d5: ldloc.0
+			IL_07d6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07db: ldc.i4.3
+			IL_07dc: ldstr "_pendingException"
+			IL_07e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
+			IL_07e6: ldloc.0
+			IL_07e7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07ec: dup
+			IL_07ed: ldc.i4.0
+			IL_07ee: ldloc.1
+			IL_07ef: stelem.ref
+			IL_07f0: dup
+			IL_07f1: ldc.i4.1
+			IL_07f2: ldloc.2
+			IL_07f3: stelem.ref
+			IL_07f4: dup
+			IL_07f5: ldc.i4.2
+			IL_07f6: ldloc.3
+			IL_07f7: stelem.ref
+			IL_07f8: dup
 			IL_07f9: ldc.i4.3
-			IL_07fa: ldstr "_pendingException"
-			IL_07ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation, int32, string)
-			IL_0804: ldloc.0
-			IL_0805: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_080a: dup
-			IL_080b: ldc.i4.0
-			IL_080c: ldloc.1
-			IL_080d: stelem.ref
-			IL_080e: dup
-			IL_080f: ldc.i4.1
-			IL_0810: ldloc.2
-			IL_0811: stelem.ref
-			IL_0812: dup
-			IL_0813: ldc.i4.2
-			IL_0814: ldloc.3
+			IL_07fa: ldloc.s 4
+			IL_07fc: stelem.ref
+			IL_07fd: dup
+			IL_07fe: ldc.i4.4
+			IL_07ff: ldloc.s 5
+			IL_0801: stelem.ref
+			IL_0802: dup
+			IL_0803: ldc.i4.5
+			IL_0804: ldloc.s 6
+			IL_0806: stelem.ref
+			IL_0807: dup
+			IL_0808: ldc.i4.6
+			IL_0809: ldloc.s 7
+			IL_080b: stelem.ref
+			IL_080c: dup
+			IL_080d: ldc.i4.7
+			IL_080e: ldloc.s 8
+			IL_0810: stelem.ref
+			IL_0811: dup
+			IL_0812: ldc.i4.8
+			IL_0813: ldloc.s 9
 			IL_0815: stelem.ref
 			IL_0816: dup
-			IL_0817: ldc.i4.3
-			IL_0818: ldloc.s 4
-			IL_081a: stelem.ref
-			IL_081b: dup
-			IL_081c: ldc.i4.4
-			IL_081d: ldloc.s 5
-			IL_081f: stelem.ref
-			IL_0820: dup
-			IL_0821: ldc.i4.5
-			IL_0822: ldloc.s 6
-			IL_0824: stelem.ref
-			IL_0825: dup
-			IL_0826: ldc.i4.6
-			IL_0827: ldloc.s 7
-			IL_0829: stelem.ref
-			IL_082a: dup
-			IL_082b: ldc.i4.7
-			IL_082c: ldloc.s 8
-			IL_082e: stelem.ref
-			IL_082f: dup
-			IL_0830: ldc.i4.8
-			IL_0831: ldloc.s 9
+			IL_0817: ldc.i4.s 9
+			IL_0819: ldloc.s 10
+			IL_081b: stelem.ref
+			IL_081c: dup
+			IL_081d: ldc.i4.s 10
+			IL_081f: ldloc.s 11
+			IL_0821: stelem.ref
+			IL_0822: dup
+			IL_0823: ldc.i4.s 11
+			IL_0825: ldloc.s 12
+			IL_0827: stelem.ref
+			IL_0828: dup
+			IL_0829: ldc.i4.s 12
+			IL_082b: ldloc.s 13
+			IL_082d: stelem.ref
+			IL_082e: dup
+			IL_082f: ldc.i4.s 13
+			IL_0831: ldloc.s 14
 			IL_0833: stelem.ref
 			IL_0834: dup
-			IL_0835: ldc.i4.s 9
-			IL_0837: ldloc.s 10
+			IL_0835: ldc.i4.s 14
+			IL_0837: ldloc.s 15
 			IL_0839: stelem.ref
 			IL_083a: dup
-			IL_083b: ldc.i4.s 10
-			IL_083d: ldloc.s 11
+			IL_083b: ldc.i4.s 15
+			IL_083d: ldloc.s 16
 			IL_083f: stelem.ref
 			IL_0840: dup
-			IL_0841: ldc.i4.s 11
-			IL_0843: ldloc.s 12
+			IL_0841: ldc.i4.s 16
+			IL_0843: ldloc.s 17
 			IL_0845: stelem.ref
 			IL_0846: dup
-			IL_0847: ldc.i4.s 12
-			IL_0849: ldloc.s 13
+			IL_0847: ldc.i4.s 17
+			IL_0849: ldloc.s 18
 			IL_084b: stelem.ref
 			IL_084c: dup
-			IL_084d: ldc.i4.s 13
-			IL_084f: ldloc.s 14
+			IL_084d: ldc.i4.s 18
+			IL_084f: ldloc.s 19
 			IL_0851: stelem.ref
 			IL_0852: dup
-			IL_0853: ldc.i4.s 14
-			IL_0855: ldloc.s 15
+			IL_0853: ldc.i4.s 19
+			IL_0855: ldloc.s 20
 			IL_0857: stelem.ref
 			IL_0858: dup
-			IL_0859: ldc.i4.s 15
-			IL_085b: ldloc.s 16
+			IL_0859: ldc.i4.s 20
+			IL_085b: ldloc.s 21
 			IL_085d: stelem.ref
-			IL_085e: dup
-			IL_085f: ldc.i4.s 16
-			IL_0861: ldloc.s 17
-			IL_0863: stelem.ref
-			IL_0864: dup
-			IL_0865: ldc.i4.s 17
-			IL_0867: ldloc.s 18
-			IL_0869: stelem.ref
-			IL_086a: dup
-			IL_086b: ldc.i4.s 18
-			IL_086d: ldloc.s 19
-			IL_086f: stelem.ref
-			IL_0870: dup
-			IL_0871: ldc.i4.s 19
-			IL_0873: ldloc.s 20
-			IL_0875: stelem.ref
-			IL_0876: dup
-			IL_0877: ldc.i4.s 20
-			IL_0879: ldloc.s 21
-			IL_087b: stelem.ref
-			IL_087c: pop
-			IL_087d: ldloc.0
-			IL_087e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0883: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0888: ret
+			IL_085e: pop
+			IL_085f: ldloc.0
+			IL_0860: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0865: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_086a: ret
 
-			IL_0889: ldloc.0
-			IL_088a: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
-			IL_088f: pop
-			IL_0890: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0895: stloc.s 17
-			IL_0897: ldloc.s 17
-			IL_0899: ldstr "promise-pipeline:ok"
-			IL_089e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08a3: pop
-			IL_08a4: br IL_09ae
+			IL_086b: ldloc.0
+			IL_086c: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
+			IL_0871: pop
+			IL_0872: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0877: stloc.s 17
+			IL_0879: ldloc.s 17
+			IL_087b: ldstr "promise-pipeline:ok"
+			IL_0880: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0885: pop
+			IL_0886: br IL_0990
 
-			IL_08a9: ldloc.0
-			IL_08aa: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_08af: stloc.s 19
-			IL_08b1: ldloc.0
-			IL_08b2: ldc.i4.0
-			IL_08b3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_08b8: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_08bd: ldloc.s 19
-			IL_08bf: stloc.s 10
-			IL_08c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08c6: stloc.s 17
-			IL_08c8: volatile.
-			IL_08ca: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_08cf: brfalse IL_08e5
+			IL_088b: ldloc.0
+			IL_088c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0891: stloc.s 19
+			IL_0893: ldloc.0
+			IL_0894: ldc.i4.0
+			IL_0895: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_089a: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_089f: ldloc.s 19
+			IL_08a1: stloc.s 10
+			IL_08a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08a8: stloc.s 17
+			IL_08aa: volatile.
+			IL_08ac: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_08b1: brfalse IL_08c7
 
-			IL_08d4: ldloc.s 10
-			IL_08d6: ldstr "name"
-			IL_08db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08e0: br IL_08fb
+			IL_08b6: ldloc.s 10
+			IL_08b8: ldstr "name"
+			IL_08bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08c2: br IL_08dd
 
-			IL_08e5: ldloc.s 10
-			IL_08e7: ldstr "name"
-			IL_08ec: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:175"
-			IL_08f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_08f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_08c7: ldloc.s 10
+			IL_08c9: ldstr "name"
+			IL_08ce: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:169"
+			IL_08d3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_08fb: stloc.s 19
-			IL_08fd: ldstr "promise-pipeline:"
-			IL_0902: ldloc.s 19
-			IL_0904: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0909: stloc.s 18
-			IL_090b: ldloc.s 18
-			IL_090d: ldstr ":"
-			IL_0912: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0917: stloc.s 18
-			IL_0919: volatile.
-			IL_091b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_0920: brfalse IL_0936
+			IL_08dd: stloc.s 19
+			IL_08df: ldstr "promise-pipeline:"
+			IL_08e4: ldloc.s 19
+			IL_08e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_08eb: stloc.s 18
+			IL_08ed: ldloc.s 18
+			IL_08ef: ldstr ":"
+			IL_08f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_08f9: stloc.s 18
+			IL_08fb: volatile.
+			IL_08fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0902: brfalse IL_0918
 
-			IL_0925: ldloc.s 10
-			IL_0927: ldstr "code"
-			IL_092c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0931: br IL_094c
+			IL_0907: ldloc.s 10
+			IL_0909: ldstr "code"
+			IL_090e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0913: br IL_092e
 
-			IL_0936: ldloc.s 10
-			IL_0938: ldstr "code"
-			IL_093d: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:180"
-			IL_0942: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_0947: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0918: ldloc.s 10
+			IL_091a: ldstr "code"
+			IL_091f: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:174"
+			IL_0924: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_0929: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_094c: stloc.s 19
-			IL_094e: ldloc.s 18
-			IL_0950: ldloc.s 19
-			IL_0952: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0957: stloc.s 18
-			IL_0959: ldloc.s 17
-			IL_095b: ldloc.s 18
-			IL_095d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0962: pop
-			IL_0963: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0968: stloc.s 17
-			IL_096a: volatile.
-			IL_096c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0971: brfalse IL_0987
+			IL_092e: stloc.s 19
+			IL_0930: ldloc.s 18
+			IL_0932: ldloc.s 19
+			IL_0934: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0939: stloc.s 18
+			IL_093b: ldloc.s 17
+			IL_093d: ldloc.s 18
+			IL_093f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0944: pop
+			IL_0945: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_094a: stloc.s 17
+			IL_094c: volatile.
+			IL_094e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0953: brfalse IL_0969
 
-			IL_0976: ldloc.s 10
-			IL_0978: ldstr "message"
-			IL_097d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0982: br IL_099d
+			IL_0958: ldloc.s 10
+			IL_095a: ldstr "message"
+			IL_095f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0964: br IL_097f
 
-			IL_0987: ldloc.s 10
-			IL_0989: ldstr "message"
-			IL_098e: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:186"
-			IL_0993: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0969: ldloc.s 10
+			IL_096b: ldstr "message"
+			IL_0970: ldstr "Stream_Helper_Signal_Requires_AbortSignal:<TwoPhaseDummy_M6>:__js_call__:180"
+			IL_0975: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_097a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_099d: stloc.s 19
-			IL_099f: ldloc.s 17
-			IL_09a1: ldloc.s 19
-			IL_09a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_09a8: pop
-			IL_09a9: br IL_09ae
+			IL_097f: stloc.s 19
+			IL_0981: ldloc.s 17
+			IL_0983: ldloc.s 19
+			IL_0985: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_098a: pop
+			IL_098b: br IL_0990
 
-			IL_09ae: ldnull
-			IL_09af: stloc.s 11
-			IL_09b1: ldloc.0
-			IL_09b2: ldc.i4.m1
-			IL_09b3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_09b8: ldloc.0
-			IL_09b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_09c3: ldarg.0
-			IL_09c4: ldc.i4.1
-			IL_09c5: newarr [System.Runtime]System.Object
-			IL_09ca: dup
-			IL_09cb: ldc.i4.0
-			IL_09cc: ldloc.s 11
-			IL_09ce: stelem.ref
-			IL_09cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_09d4: pop
-			IL_09d5: ldloc.0
-			IL_09d6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09db: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_09e0: ret
+			IL_0990: ldnull
+			IL_0991: stloc.s 11
+			IL_0993: ldloc.0
+			IL_0994: ldc.i4.m1
+			IL_0995: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_099a: ldloc.0
+			IL_099b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_09a5: ldarg.0
+			IL_09a6: ldc.i4.1
+			IL_09a7: newarr [System.Runtime]System.Object
+			IL_09ac: dup
+			IL_09ad: ldc.i4.0
+			IL_09ae: ldloc.s 11
+			IL_09b0: stelem.ref
+			IL_09b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_09b6: pop
+			IL_09b7: ldloc.0
+			IL_09b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09bd: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09c2: ret
 		} // end of method main::__js_call__
 
 	} // end of class main

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
@@ -1520,31 +1520,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Header size: 12
-			// Code size: 29 (0x1d)
+			// Header size: 1
+			// Code size: 10 (0xa)
 			.maxstack 8
-			.locals init (
-				[0] object,
-				[1] object[]
-			)
 
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::logAbort
-			IL_0006: stloc.0
-			IL_0007: ldc.i4.1
-			IL_0008: newarr [System.Runtime]System.Object
-			IL_000d: dup
-			IL_000e: ldc.i4.0
-			IL_000f: ldarg.0
-			IL_0010: stelem.ref
-			IL_0011: stloc.1
-			IL_0012: ldloc.0
-			IL_0013: ldloc.1
-			IL_0014: ldarg.2
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_001a: pop
-			IL_001b: ldnull
-			IL_001c: ret
+			IL_0000: ldnull
+			IL_0001: ldarg.2
+			IL_0002: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
+			IL_0007: pop
+			IL_0008: ldnull
+			IL_0009: ret
 		} // end of method FunctionExpression_L45C9::__js_call__
 
 	} // end of class FunctionExpression_L45C9
@@ -1841,42 +1826,16 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Header size: 12
-				// Code size: 44 (0x2c)
+				// Header size: 1
+				// Code size: 10 (0xa)
 				.maxstack 8
-				.locals init (
-					[0] object,
-					[1] object[]
-				)
 
-				IL_0000: ldarg.0
-				IL_0001: ldc.i4.0
-				IL_0002: ldelem.ref
-				IL_0003: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-				IL_0008: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::logAbort
-				IL_000d: stloc.0
-				IL_000e: ldc.i4.2
-				IL_000f: newarr [System.Runtime]System.Object
-				IL_0014: dup
-				IL_0015: ldc.i4.0
-				IL_0016: ldarg.0
-				IL_0017: ldc.i4.0
-				IL_0018: ldelem.ref
-				IL_0019: stelem.ref
-				IL_001a: dup
-				IL_001b: ldc.i4.1
-				IL_001c: ldarg.0
-				IL_001d: ldc.i4.1
-				IL_001e: ldelem.ref
-				IL_001f: stelem.ref
-				IL_0020: stloc.1
-				IL_0021: ldloc.0
-				IL_0022: ldloc.1
-				IL_0023: ldarg.2
-				IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0029: pop
-				IL_002a: ldnull
-				IL_002b: ret
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
+				IL_0007: pop
+				IL_0008: ldnull
+				IL_0009: ret
 			} // end of method FunctionExpression_L56C13::__js_call__
 
 		} // end of class FunctionExpression_L56C13
@@ -2015,7 +1974,7 @@
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
 			// Header size: 12
-			// Code size: 377 (0x179)
+			// Code size: 368 (0x170)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope,
@@ -2031,144 +1990,139 @@
 			IL_0000: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
-			IL_0007: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::createController
-			IL_000c: ldc.i4.1
-			IL_000d: newarr [System.Runtime]System.Object
-			IL_0012: dup
-			IL_0013: ldc.i4.0
-			IL_0014: ldarg.0
-			IL_0015: stelem.ref
-			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_001b: stloc.1
-			IL_001c: ldloc.1
-			IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0022: volatile.
-			IL_0024: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_0029: brfalse IL_003d
+			IL_0007: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+			IL_000c: ldnull
+			IL_000d: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+			IL_0012: stloc.1
+			IL_0013: ldloc.1
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0019: volatile.
+			IL_001b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0020: brfalse IL_0034
 
-			IL_002e: ldstr "abort"
-			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0038: br IL_0051
+			IL_0025: ldstr "abort"
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_002f: br IL_0048
 
-			IL_003d: ldstr "abort"
-			IL_0042: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:8"
-			IL_0047: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0034: ldstr "abort"
+			IL_0039: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:7"
+			IL_003e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_0051: pop
-			IL_0052: ldarg.0
-			IL_0053: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-			IL_0058: stloc.2
-			IL_0059: volatile.
-			IL_005b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_0060: brfalse IL_0075
+			IL_0048: pop
+			IL_0049: ldarg.0
+			IL_004a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+			IL_004f: stloc.2
+			IL_0050: volatile.
+			IL_0052: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_0057: brfalse IL_006c
 
-			IL_0065: ldloc.1
-			IL_0066: ldstr "signal"
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0070: br IL_008a
+			IL_005c: ldloc.1
+			IL_005d: ldstr "signal"
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0067: br IL_0081
 
-			IL_0075: ldloc.1
-			IL_0076: ldstr "signal"
-			IL_007b: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:13"
-			IL_0080: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_006c: ldloc.1
+			IL_006d: ldstr "signal"
+			IL_0072: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:12"
+			IL_0077: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_008a: stloc.3
-			IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0090: dup
-			IL_0091: ldstr "signal"
-			IL_0096: ldloc.3
-			IL_0097: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_009c: stloc.s 4
-			IL_009e: ldloc.2
-			IL_009f: ldstr "immediate-value"
-			IL_00a4: ldloc.s 4
-			IL_00a6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setImmediate(object, object)
-			IL_00ab: stloc.3
-			IL_00ac: ldloc.3
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b2: stloc.3
-			IL_00b3: ldc.i4.1
-			IL_00b4: newarr [System.Runtime]System.Object
-			IL_00b9: dup
-			IL_00ba: ldc.i4.0
-			IL_00bb: ldarg.0
-			IL_00bc: stelem.ref
-			IL_00bd: stloc.s 5
-			IL_00bf: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject::.ctor()
-			IL_00c4: ldc.i4.0
-			IL_00c5: conv.r8
-			IL_00c6: ldstr ""
-			IL_00cb: ldc.i4.0
-			IL_00cc: ldc.i4.0
-			IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_00d2: stloc.s 6
-			IL_00d4: volatile.
-			IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_00db: brfalse IL_00f2
+			IL_0081: stloc.3
+			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0087: dup
+			IL_0088: ldstr "signal"
+			IL_008d: ldloc.3
+			IL_008e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0093: stloc.s 4
+			IL_0095: ldloc.2
+			IL_0096: ldstr "immediate-value"
+			IL_009b: ldloc.s 4
+			IL_009d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setImmediate(object, object)
+			IL_00a2: stloc.3
+			IL_00a3: ldloc.3
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a9: stloc.3
+			IL_00aa: ldc.i4.1
+			IL_00ab: newarr [System.Runtime]System.Object
+			IL_00b0: dup
+			IL_00b1: ldc.i4.0
+			IL_00b2: ldarg.0
+			IL_00b3: stelem.ref
+			IL_00b4: stloc.s 5
+			IL_00b6: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject::.ctor()
+			IL_00bb: ldc.i4.0
+			IL_00bc: conv.r8
+			IL_00bd: ldstr ""
+			IL_00c2: ldc.i4.0
+			IL_00c3: ldc.i4.0
+			IL_00c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00c9: stloc.s 6
+			IL_00cb: volatile.
+			IL_00cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_00d2: brfalse IL_00e9
 
-			IL_00e0: ldloc.3
-			IL_00e1: ldstr "then"
-			IL_00e6: ldloc.s 6
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ed: br IL_0109
+			IL_00d7: ldloc.3
+			IL_00d8: ldstr "then"
+			IL_00dd: ldloc.s 6
+			IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e4: br IL_0100
 
-			IL_00f2: ldloc.3
-			IL_00f3: ldstr "then"
-			IL_00f8: ldloc.s 6
-			IL_00fa: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:19"
-			IL_00ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_00e9: ldloc.3
+			IL_00ea: ldstr "then"
+			IL_00ef: ldloc.s 6
+			IL_00f1: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:18"
+			IL_00f6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0109: stloc.3
-			IL_010a: ldloc.3
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0110: stloc.3
-			IL_0111: ldc.i4.2
-			IL_0112: newarr [System.Runtime]System.Object
-			IL_0117: dup
-			IL_0118: ldc.i4.0
-			IL_0119: ldarg.0
-			IL_011a: stelem.ref
-			IL_011b: dup
-			IL_011c: ldc.i4.1
-			IL_011d: ldloc.0
-			IL_011e: stelem.ref
-			IL_011f: stloc.s 5
+			IL_0100: stloc.3
+			IL_0101: ldloc.3
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0107: stloc.3
+			IL_0108: ldc.i4.2
+			IL_0109: newarr [System.Runtime]System.Object
+			IL_010e: dup
+			IL_010f: ldc.i4.0
+			IL_0110: ldarg.0
+			IL_0111: stelem.ref
+			IL_0112: dup
+			IL_0113: ldc.i4.1
+			IL_0114: ldloc.0
+			IL_0115: stelem.ref
+			IL_0116: stloc.s 5
+			IL_0118: ldloc.s 5
+			IL_011a: ldc.i4.0
+			IL_011b: ldelem.ref
+			IL_011c: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
 			IL_0121: ldloc.s 5
-			IL_0123: ldc.i4.0
-			IL_0124: ldelem.ref
-			IL_0125: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-			IL_012a: ldloc.s 5
-			IL_012c: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object[])
-			IL_0131: ldc.i4.1
-			IL_0132: conv.r8
-			IL_0133: ldstr ""
-			IL_0138: ldc.i4.0
-			IL_0139: ldc.i4.0
-			IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_013f: stloc.s 7
-			IL_0141: volatile.
-			IL_0143: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0148: brfalse IL_015f
+			IL_0123: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object[])
+			IL_0128: ldc.i4.1
+			IL_0129: conv.r8
+			IL_012a: ldstr ""
+			IL_012f: ldc.i4.0
+			IL_0130: ldc.i4.0
+			IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0136: stloc.s 7
+			IL_0138: volatile.
+			IL_013a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_013f: brfalse IL_0156
 
-			IL_014d: ldloc.3
-			IL_014e: ldstr "catch"
-			IL_0153: ldloc.s 7
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_015a: br IL_0176
+			IL_0144: ldloc.3
+			IL_0145: ldstr "catch"
+			IL_014a: ldloc.s 7
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0151: br IL_016d
 
-			IL_015f: ldloc.3
-			IL_0160: ldstr "catch"
-			IL_0165: ldloc.s 7
-			IL_0167: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:23"
-			IL_016c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0156: ldloc.3
+			IL_0157: ldstr "catch"
+			IL_015c: ldloc.s 7
+			IL_015e: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:<TwoPhaseDummy_M8>:__js_call__:22"
+			IL_0163: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0176: stloc.3
-			IL_0177: ldloc.3
-			IL_0178: ret
+			IL_016d: stloc.3
+			IL_016e: ldloc.3
+			IL_016f: ret
 		} // end of method FunctionExpression_L48C8::__js_call__
 
 	} // end of class FunctionExpression_L48C8
@@ -2218,7 +2172,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 606 (0x25e)
+		// Code size: 602 (0x25a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope,
@@ -2288,175 +2242,175 @@
 		IL_0074: nop
 		IL_0075: nop
 		IL_0076: ldloc.0
-		IL_0077: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::createController
-		IL_007c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0086: stloc.1
-		IL_0087: ldloc.0
-		IL_0088: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-		IL_008d: stloc.s 6
-		IL_008f: volatile.
-		IL_0091: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0096: brfalse IL_00ab
+		IL_0077: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_007c: ldnull
+		IL_007d: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+		IL_0082: stloc.1
+		IL_0083: ldloc.0
+		IL_0084: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+		IL_0089: stloc.s 6
+		IL_008b: volatile.
+		IL_008d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0092: brfalse IL_00a7
 
-		IL_009b: ldloc.1
-		IL_009c: ldstr "signal"
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a6: br IL_00c0
+		IL_0097: ldloc.1
+		IL_0098: ldstr "signal"
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a2: br IL_00bc
 
-		IL_00ab: ldloc.1
-		IL_00ac: ldstr "signal"
-		IL_00b1: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:27"
-		IL_00b6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00a7: ldloc.1
+		IL_00a8: ldstr "signal"
+		IL_00ad: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:26"
+		IL_00b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00c0: stloc.s 7
-		IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00c7: dup
-		IL_00c8: ldstr "signal"
-		IL_00cd: ldloc.s 7
-		IL_00cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00d4: stloc.s 8
-		IL_00d6: ldloc.s 6
-		IL_00d8: ldc.r8 0.0
-		IL_00e1: box [System.Runtime]System.Double
-		IL_00e6: ldstr "timeout-value"
-		IL_00eb: ldloc.s 8
-		IL_00ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object, object)
-		IL_00f2: stloc.2
-		IL_00f3: ldloc.1
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f9: volatile.
-		IL_00fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0100: brfalse IL_0114
+		IL_00bc: stloc.s 7
+		IL_00be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00c3: dup
+		IL_00c4: ldstr "signal"
+		IL_00c9: ldloc.s 7
+		IL_00cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00d0: stloc.s 8
+		IL_00d2: ldloc.s 6
+		IL_00d4: ldc.r8 0.0
+		IL_00dd: box [System.Runtime]System.Double
+		IL_00e2: ldstr "timeout-value"
+		IL_00e7: ldloc.s 8
+		IL_00e9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptPromise [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setTimeout(object, object, object)
+		IL_00ee: stloc.2
+		IL_00ef: ldloc.1
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f5: volatile.
+		IL_00f7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_00fc: brfalse IL_0110
 
-		IL_0105: ldstr "abort"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_010f: br IL_0128
+		IL_0101: ldstr "abort"
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_010b: br IL_0124
 
-		IL_0114: ldstr "abort"
-		IL_0119: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:33"
-		IL_011e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0110: ldstr "abort"
+		IL_0115: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:32"
+		IL_011a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0128: pop
-		IL_0129: ldloc.2
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012f: stloc.s 7
-		IL_0131: ldc.i4.1
-		IL_0132: newarr [System.Runtime]System.Object
-		IL_0137: dup
-		IL_0138: ldc.i4.0
-		IL_0139: ldloc.0
-		IL_013a: stelem.ref
-		IL_013b: stloc.3
-		IL_013c: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject::.ctor()
-		IL_0141: ldc.i4.0
-		IL_0142: conv.r8
-		IL_0143: ldstr ""
-		IL_0148: ldc.i4.0
-		IL_0149: ldc.i4.0
-		IL_014a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_014f: stloc.s 9
-		IL_0151: volatile.
-		IL_0153: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0158: brfalse IL_0170
+		IL_0124: pop
+		IL_0125: ldloc.2
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012b: stloc.s 7
+		IL_012d: ldc.i4.1
+		IL_012e: newarr [System.Runtime]System.Object
+		IL_0133: dup
+		IL_0134: ldc.i4.0
+		IL_0135: ldloc.0
+		IL_0136: stelem.ref
+		IL_0137: stloc.3
+		IL_0138: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject::.ctor()
+		IL_013d: ldc.i4.0
+		IL_013e: conv.r8
+		IL_013f: ldstr ""
+		IL_0144: ldc.i4.0
+		IL_0145: ldc.i4.0
+		IL_0146: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_014b: stloc.s 9
+		IL_014d: volatile.
+		IL_014f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0154: brfalse IL_016c
 
-		IL_015d: ldloc.s 7
-		IL_015f: ldstr "then"
-		IL_0164: ldloc.s 9
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016b: br IL_0188
+		IL_0159: ldloc.s 7
+		IL_015b: ldstr "then"
+		IL_0160: ldloc.s 9
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0167: br IL_0184
 
-		IL_0170: ldloc.s 7
-		IL_0172: ldstr "then"
-		IL_0177: ldloc.s 9
-		IL_0179: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:38"
-		IL_017e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_016c: ldloc.s 7
+		IL_016e: ldstr "then"
+		IL_0173: ldloc.s 9
+		IL_0175: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:37"
+		IL_017a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0188: stloc.s 7
-		IL_018a: ldloc.s 7
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0191: stloc.s 7
-		IL_0193: ldc.i4.1
-		IL_0194: newarr [System.Runtime]System.Object
-		IL_0199: dup
-		IL_019a: ldc.i4.0
-		IL_019b: ldloc.0
-		IL_019c: stelem.ref
-		IL_019d: stloc.3
-		IL_019e: ldloc.3
-		IL_019f: ldc.i4.0
-		IL_01a0: ldelem.ref
-		IL_01a1: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_01a6: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
-		IL_01ab: ldc.i4.1
-		IL_01ac: conv.r8
-		IL_01ad: ldstr ""
-		IL_01b2: ldc.i4.0
-		IL_01b3: ldc.i4.0
-		IL_01b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01b9: stloc.s 10
-		IL_01bb: volatile.
-		IL_01bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_01c2: brfalse IL_01da
+		IL_0184: stloc.s 7
+		IL_0186: ldloc.s 7
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018d: stloc.s 7
+		IL_018f: ldc.i4.1
+		IL_0190: newarr [System.Runtime]System.Object
+		IL_0195: dup
+		IL_0196: ldc.i4.0
+		IL_0197: ldloc.0
+		IL_0198: stelem.ref
+		IL_0199: stloc.3
+		IL_019a: ldloc.3
+		IL_019b: ldc.i4.0
+		IL_019c: ldelem.ref
+		IL_019d: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_01a2: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
+		IL_01a7: ldc.i4.1
+		IL_01a8: conv.r8
+		IL_01a9: ldstr ""
+		IL_01ae: ldc.i4.0
+		IL_01af: ldc.i4.0
+		IL_01b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01b5: stloc.s 10
+		IL_01b7: volatile.
+		IL_01b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01be: brfalse IL_01d6
 
-		IL_01c7: ldloc.s 7
-		IL_01c9: ldstr "catch"
-		IL_01ce: ldloc.s 10
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d5: br IL_01f2
+		IL_01c3: ldloc.s 7
+		IL_01c5: ldstr "catch"
+		IL_01ca: ldloc.s 10
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d1: br IL_01ee
 
-		IL_01da: ldloc.s 7
-		IL_01dc: ldstr "catch"
-		IL_01e1: ldloc.s 10
-		IL_01e3: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:42"
-		IL_01e8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_01d6: ldloc.s 7
+		IL_01d8: ldstr "catch"
+		IL_01dd: ldloc.s 10
+		IL_01df: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:41"
+		IL_01e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_01f2: stloc.s 7
-		IL_01f4: ldloc.s 7
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01fb: stloc.s 7
-		IL_01fd: ldc.i4.1
-		IL_01fe: newarr [System.Runtime]System.Object
-		IL_0203: dup
-		IL_0204: ldc.i4.0
-		IL_0205: ldloc.0
-		IL_0206: stelem.ref
-		IL_0207: stloc.3
-		IL_0208: ldloc.3
-		IL_0209: ldc.i4.0
-		IL_020a: ldelem.ref
-		IL_020b: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0210: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
-		IL_0215: ldc.i4.0
-		IL_0216: conv.r8
-		IL_0217: ldstr ""
-		IL_021c: ldc.i4.0
-		IL_021d: ldc.i4.0
-		IL_021e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0223: stloc.s 11
-		IL_0225: volatile.
-		IL_0227: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_022c: brfalse IL_0244
+		IL_01ee: stloc.s 7
+		IL_01f0: ldloc.s 7
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f7: stloc.s 7
+		IL_01f9: ldc.i4.1
+		IL_01fa: newarr [System.Runtime]System.Object
+		IL_01ff: dup
+		IL_0200: ldc.i4.0
+		IL_0201: ldloc.0
+		IL_0202: stelem.ref
+		IL_0203: stloc.3
+		IL_0204: ldloc.3
+		IL_0205: ldc.i4.0
+		IL_0206: ldelem.ref
+		IL_0207: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_020c: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
+		IL_0211: ldc.i4.0
+		IL_0212: conv.r8
+		IL_0213: ldstr ""
+		IL_0218: ldc.i4.0
+		IL_0219: ldc.i4.0
+		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_021f: stloc.s 11
+		IL_0221: volatile.
+		IL_0223: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0228: brfalse IL_0240
 
-		IL_0231: ldloc.s 7
-		IL_0233: ldstr "then"
-		IL_0238: ldloc.s 11
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_023f: br IL_025c
+		IL_022d: ldloc.s 7
+		IL_022f: ldstr "then"
+		IL_0234: ldloc.s 11
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_023b: br IL_0258
 
-		IL_0244: ldloc.s 7
-		IL_0246: ldstr "then"
-		IL_024b: ldloc.s 11
-		IL_024d: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:46"
-		IL_0252: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0240: ldloc.s 7
+		IL_0242: ldstr "then"
+		IL_0247: ldloc.s 11
+		IL_0249: ldstr "TimersPromises_Abort_RejectsSupportedOneShotApis:Modules.TimersPromises_Abort_RejectsSupportedOneShotApis:__js_module_init__:45"
+		IL_024e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_025c: pop
-		IL_025d: ret
+		IL_0258: pop
+		IL_0259: ret
 	} // end of method TimersPromises_Abort_RejectsSupportedOneShotApis::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -1592,7 +1592,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 1258 (0x4ea)
+			// Code size: 1253 (0x4e5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope,
@@ -1715,418 +1715,417 @@
 
 			IL_00db: ldloc.0
 			IL_00dc: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00e1: switch (IL_00f2, IL_022b, IL_0319)
+			IL_00e1: switch (IL_00f2, IL_0226, IL_0314)
 
-			IL_00f2: ldarg.0
-			IL_00f3: ldc.i4.1
-			IL_00f4: ldelem.ref
-			IL_00f5: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-			IL_00fa: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::createController
-			IL_00ff: ldc.i4.1
-			IL_0100: newarr [System.Runtime]System.Object
-			IL_0105: dup
-			IL_0106: ldc.i4.0
-			IL_0107: ldarg.0
-			IL_0108: ldc.i4.1
-			IL_0109: ldelem.ref
-			IL_010a: stelem.ref
-			IL_010b: stloc.s 5
-			IL_010d: ldloc.s 5
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0114: stloc.1
-			IL_0115: ldarg.0
-			IL_0116: ldc.i4.1
-			IL_0117: ldelem.ref
-			IL_0118: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-			IL_011d: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
-			IL_0122: stloc.s 6
-			IL_0124: volatile.
-			IL_0126: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_012b: brfalse IL_0140
+			IL_00f2: ldc.i4.1
+			IL_00f3: newarr [System.Runtime]System.Object
+			IL_00f8: dup
+			IL_00f9: ldc.i4.0
+			IL_00fa: ldarg.0
+			IL_00fb: ldc.i4.1
+			IL_00fc: ldelem.ref
+			IL_00fd: stelem.ref
+			IL_00fe: stloc.s 5
+			IL_0100: ldloc.s 5
+			IL_0102: ldc.i4.0
+			IL_0103: ldelem.ref
+			IL_0104: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
+			IL_0109: ldnull
+			IL_010a: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
+			IL_010f: stloc.1
+			IL_0110: ldarg.0
+			IL_0111: ldc.i4.1
+			IL_0112: ldelem.ref
+			IL_0113: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
+			IL_0118: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
+			IL_011d: stloc.s 6
+			IL_011f: volatile.
+			IL_0121: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0126: brfalse IL_013b
 
-			IL_0130: ldloc.1
-			IL_0131: ldstr "signal"
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013b: br IL_0155
+			IL_012b: ldloc.1
+			IL_012c: ldstr "signal"
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0136: br IL_0150
 
-			IL_0140: ldloc.1
-			IL_0141: ldstr "signal"
-			IL_0146: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:12"
-			IL_014b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_013b: ldloc.1
+			IL_013c: ldstr "signal"
+			IL_0141: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:11"
+			IL_0146: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0155: stloc.s 7
-			IL_0157: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_015c: dup
-			IL_015d: ldstr "signal"
-			IL_0162: ldloc.s 7
-			IL_0164: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0169: stloc.s 8
-			IL_016b: ldloc.s 6
-			IL_016d: ldc.r8 0.0
-			IL_0176: box [System.Runtime]System.Double
-			IL_017b: ldstr "tick"
-			IL_0180: ldloc.s 8
-			IL_0182: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object, object)
-			IL_0187: stloc.2
-			IL_0188: ldloc.2
-			IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018e: stloc.s 7
-			IL_0190: volatile.
-			IL_0192: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_0197: brfalse IL_01ad
+			IL_0150: stloc.s 7
+			IL_0152: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0157: dup
+			IL_0158: ldstr "signal"
+			IL_015d: ldloc.s 7
+			IL_015f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0164: stloc.s 8
+			IL_0166: ldloc.s 6
+			IL_0168: ldc.r8 0.0
+			IL_0171: box [System.Runtime]System.Double
+			IL_0176: ldstr "tick"
+			IL_017b: ldloc.s 8
+			IL_017d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule::setInterval(object, object, object)
+			IL_0182: stloc.2
+			IL_0183: ldloc.2
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0189: stloc.s 7
+			IL_018b: volatile.
+			IL_018d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_0192: brfalse IL_01a8
 
-			IL_019c: ldloc.s 7
-			IL_019e: ldstr "next"
-			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01a8: br IL_01c3
+			IL_0197: ldloc.s 7
+			IL_0199: ldstr "next"
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_01a3: br IL_01be
 
-			IL_01ad: ldloc.s 7
-			IL_01af: ldstr "next"
-			IL_01b4: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:18"
-			IL_01b9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_01a8: ldloc.s 7
+			IL_01aa: ldstr "next"
+			IL_01af: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:17"
+			IL_01b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_01c3: stloc.s 7
-			IL_01c5: ldloc.0
-			IL_01c6: ldc.i4.1
-			IL_01c7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01be: stloc.s 7
+			IL_01c0: ldloc.0
+			IL_01c1: ldc.i4.1
+			IL_01c2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c7: ldloc.0
+			IL_01c8: ldloc.s 7
+			IL_01ca: ldarg.0
+			IL_01cb: ldc.i4.1
 			IL_01cc: ldloc.0
-			IL_01cd: ldloc.s 7
-			IL_01cf: ldarg.0
-			IL_01d0: ldc.i4.1
-			IL_01d1: ldloc.0
-			IL_01d2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_01dc: ldloc.0
-			IL_01dd: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01e2: dup
-			IL_01e3: ldc.i4.0
-			IL_01e4: ldloc.1
-			IL_01e5: stelem.ref
-			IL_01e6: dup
-			IL_01e7: ldc.i4.1
-			IL_01e8: ldloc.2
-			IL_01e9: stelem.ref
-			IL_01ea: dup
-			IL_01eb: ldc.i4.2
-			IL_01ec: ldloc.3
+			IL_01cd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_01d7: ldloc.0
+			IL_01d8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01dd: dup
+			IL_01de: ldc.i4.0
+			IL_01df: ldloc.1
+			IL_01e0: stelem.ref
+			IL_01e1: dup
+			IL_01e2: ldc.i4.1
+			IL_01e3: ldloc.2
+			IL_01e4: stelem.ref
+			IL_01e5: dup
+			IL_01e6: ldc.i4.2
+			IL_01e7: ldloc.3
+			IL_01e8: stelem.ref
+			IL_01e9: dup
+			IL_01ea: ldc.i4.3
+			IL_01eb: ldloc.s 4
 			IL_01ed: stelem.ref
 			IL_01ee: dup
-			IL_01ef: ldc.i4.3
-			IL_01f0: ldloc.s 4
+			IL_01ef: ldc.i4.4
+			IL_01f0: ldloc.s 5
 			IL_01f2: stelem.ref
 			IL_01f3: dup
-			IL_01f4: ldc.i4.4
-			IL_01f5: ldloc.s 5
+			IL_01f4: ldc.i4.5
+			IL_01f5: ldloc.s 6
 			IL_01f7: stelem.ref
 			IL_01f8: dup
-			IL_01f9: ldc.i4.5
-			IL_01fa: ldloc.s 6
+			IL_01f9: ldc.i4.6
+			IL_01fa: ldloc.s 7
 			IL_01fc: stelem.ref
 			IL_01fd: dup
-			IL_01fe: ldc.i4.6
-			IL_01ff: ldloc.s 7
+			IL_01fe: ldc.i4.7
+			IL_01ff: ldloc.s 8
 			IL_0201: stelem.ref
 			IL_0202: dup
-			IL_0203: ldc.i4.7
-			IL_0204: ldloc.s 8
+			IL_0203: ldc.i4.8
+			IL_0204: ldloc.s 9
 			IL_0206: stelem.ref
 			IL_0207: dup
-			IL_0208: ldc.i4.8
-			IL_0209: ldloc.s 9
-			IL_020b: stelem.ref
-			IL_020c: dup
-			IL_020d: ldc.i4.s 9
-			IL_020f: ldloc.s 10
-			IL_0211: stelem.ref
-			IL_0212: dup
-			IL_0213: ldc.i4.s 10
-			IL_0215: ldloc.s 11
-			IL_0217: stelem.ref
-			IL_0218: dup
-			IL_0219: ldc.i4.s 11
-			IL_021b: ldloc.s 12
-			IL_021d: stelem.ref
-			IL_021e: pop
-			IL_021f: ldloc.0
-			IL_0220: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0225: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_022a: ret
+			IL_0208: ldc.i4.s 9
+			IL_020a: ldloc.s 10
+			IL_020c: stelem.ref
+			IL_020d: dup
+			IL_020e: ldc.i4.s 10
+			IL_0210: ldloc.s 11
+			IL_0212: stelem.ref
+			IL_0213: dup
+			IL_0214: ldc.i4.s 11
+			IL_0216: ldloc.s 12
+			IL_0218: stelem.ref
+			IL_0219: pop
+			IL_021a: ldloc.0
+			IL_021b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0220: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0225: ret
 
-			IL_022b: ldloc.0
-			IL_022c: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
-			IL_0231: stloc.3
-			IL_0232: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0237: stloc.s 9
-			IL_0239: volatile.
-			IL_023b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0240: brfalse IL_0255
+			IL_0226: ldloc.0
+			IL_0227: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
+			IL_022c: stloc.3
+			IL_022d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0232: stloc.s 9
+			IL_0234: volatile.
+			IL_0236: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_023b: brfalse IL_0250
 
-			IL_0245: ldloc.3
-			IL_0246: ldstr "value"
-			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0250: br IL_026a
+			IL_0240: ldloc.3
+			IL_0241: ldstr "value"
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_024b: br IL_0265
 
-			IL_0255: ldloc.3
-			IL_0256: ldstr "value"
-			IL_025b: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:24"
-			IL_0260: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0250: ldloc.3
+			IL_0251: ldstr "value"
+			IL_0256: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:23"
+			IL_025b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+			IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_026a: stloc.s 7
-			IL_026c: ldloc.s 9
-			IL_026e: ldloc.s 7
-			IL_0270: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0275: pop
-			IL_0276: ldloc.2
-			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027c: stloc.s 7
-			IL_027e: volatile.
-			IL_0280: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_0285: brfalse IL_029b
+			IL_0265: stloc.s 7
+			IL_0267: ldloc.s 9
+			IL_0269: ldloc.s 7
+			IL_026b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0270: pop
+			IL_0271: ldloc.2
+			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0277: stloc.s 7
+			IL_0279: volatile.
+			IL_027b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_0280: brfalse IL_0296
 
-			IL_028a: ldloc.s 7
-			IL_028c: ldstr "next"
-			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0296: br IL_02b1
+			IL_0285: ldloc.s 7
+			IL_0287: ldstr "next"
+			IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0291: br IL_02ac
 
-			IL_029b: ldloc.s 7
-			IL_029d: ldstr "next"
-			IL_02a2: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:28"
-			IL_02a7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_0296: ldloc.s 7
+			IL_0298: ldstr "next"
+			IL_029d: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:27"
+			IL_02a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+			IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_02b1: stloc.s 7
-			IL_02b3: ldloc.0
-			IL_02b4: ldc.i4.2
-			IL_02b5: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02ac: stloc.s 7
+			IL_02ae: ldloc.0
+			IL_02af: ldc.i4.2
+			IL_02b0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02b5: ldloc.0
+			IL_02b6: ldloc.s 7
+			IL_02b8: ldarg.0
+			IL_02b9: ldc.i4.2
 			IL_02ba: ldloc.0
-			IL_02bb: ldloc.s 7
-			IL_02bd: ldarg.0
-			IL_02be: ldc.i4.2
-			IL_02bf: ldloc.0
-			IL_02c0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_02ca: ldloc.0
-			IL_02cb: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02d0: dup
-			IL_02d1: ldc.i4.0
-			IL_02d2: ldloc.1
-			IL_02d3: stelem.ref
-			IL_02d4: dup
-			IL_02d5: ldc.i4.1
-			IL_02d6: ldloc.2
-			IL_02d7: stelem.ref
-			IL_02d8: dup
-			IL_02d9: ldc.i4.2
-			IL_02da: ldloc.3
+			IL_02bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_02c5: ldloc.0
+			IL_02c6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02cb: dup
+			IL_02cc: ldc.i4.0
+			IL_02cd: ldloc.1
+			IL_02ce: stelem.ref
+			IL_02cf: dup
+			IL_02d0: ldc.i4.1
+			IL_02d1: ldloc.2
+			IL_02d2: stelem.ref
+			IL_02d3: dup
+			IL_02d4: ldc.i4.2
+			IL_02d5: ldloc.3
+			IL_02d6: stelem.ref
+			IL_02d7: dup
+			IL_02d8: ldc.i4.3
+			IL_02d9: ldloc.s 4
 			IL_02db: stelem.ref
 			IL_02dc: dup
-			IL_02dd: ldc.i4.3
-			IL_02de: ldloc.s 4
+			IL_02dd: ldc.i4.4
+			IL_02de: ldloc.s 5
 			IL_02e0: stelem.ref
 			IL_02e1: dup
-			IL_02e2: ldc.i4.4
-			IL_02e3: ldloc.s 5
+			IL_02e2: ldc.i4.5
+			IL_02e3: ldloc.s 6
 			IL_02e5: stelem.ref
 			IL_02e6: dup
-			IL_02e7: ldc.i4.5
-			IL_02e8: ldloc.s 6
+			IL_02e7: ldc.i4.6
+			IL_02e8: ldloc.s 7
 			IL_02ea: stelem.ref
 			IL_02eb: dup
-			IL_02ec: ldc.i4.6
-			IL_02ed: ldloc.s 7
+			IL_02ec: ldc.i4.7
+			IL_02ed: ldloc.s 8
 			IL_02ef: stelem.ref
 			IL_02f0: dup
-			IL_02f1: ldc.i4.7
-			IL_02f2: ldloc.s 8
+			IL_02f1: ldc.i4.8
+			IL_02f2: ldloc.s 9
 			IL_02f4: stelem.ref
 			IL_02f5: dup
-			IL_02f6: ldc.i4.8
-			IL_02f7: ldloc.s 9
-			IL_02f9: stelem.ref
-			IL_02fa: dup
-			IL_02fb: ldc.i4.s 9
-			IL_02fd: ldloc.s 10
-			IL_02ff: stelem.ref
-			IL_0300: dup
-			IL_0301: ldc.i4.s 10
-			IL_0303: ldloc.s 11
-			IL_0305: stelem.ref
-			IL_0306: dup
-			IL_0307: ldc.i4.s 11
-			IL_0309: ldloc.s 12
-			IL_030b: stelem.ref
-			IL_030c: pop
-			IL_030d: ldloc.0
-			IL_030e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0313: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0318: ret
+			IL_02f6: ldc.i4.s 9
+			IL_02f8: ldloc.s 10
+			IL_02fa: stelem.ref
+			IL_02fb: dup
+			IL_02fc: ldc.i4.s 10
+			IL_02fe: ldloc.s 11
+			IL_0300: stelem.ref
+			IL_0301: dup
+			IL_0302: ldc.i4.s 11
+			IL_0304: ldloc.s 12
+			IL_0306: stelem.ref
+			IL_0307: pop
+			IL_0308: ldloc.0
+			IL_0309: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_030e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0313: ret
 
-			IL_0319: ldloc.0
-			IL_031a: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
-			IL_031f: stloc.s 4
-			IL_0321: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0326: stloc.s 9
-			IL_0328: volatile.
-			IL_032a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_032f: brfalse IL_0345
+			IL_0314: ldloc.0
+			IL_0315: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
+			IL_031a: stloc.s 4
+			IL_031c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0321: stloc.s 9
+			IL_0323: volatile.
+			IL_0325: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_032a: brfalse IL_0340
 
-			IL_0334: ldloc.s 4
-			IL_0336: ldstr "value"
-			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0340: br IL_035b
+			IL_032f: ldloc.s 4
+			IL_0331: ldstr "value"
+			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033b: br IL_0356
 
-			IL_0345: ldloc.s 4
-			IL_0347: ldstr "value"
-			IL_034c: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:34"
-			IL_0351: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0340: ldloc.s 4
+			IL_0342: ldstr "value"
+			IL_0347: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:33"
+			IL_034c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_035b: stloc.s 7
-			IL_035d: ldloc.s 9
-			IL_035f: ldloc.s 7
-			IL_0361: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0366: pop
-			IL_0367: ldloc.1
-			IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_036d: stloc.s 7
-			IL_036f: ldstr "boom-reason"
-			IL_0374: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0379: stloc.s 10
-			IL_037b: volatile.
-			IL_037d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_0382: brfalse IL_039a
+			IL_0356: stloc.s 7
+			IL_0358: ldloc.s 9
+			IL_035a: ldloc.s 7
+			IL_035c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0361: pop
+			IL_0362: ldloc.1
+			IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0368: stloc.s 7
+			IL_036a: ldstr "boom-reason"
+			IL_036f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0374: stloc.s 10
+			IL_0376: volatile.
+			IL_0378: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_037d: brfalse IL_0395
 
-			IL_0387: ldloc.s 7
-			IL_0389: ldstr "abort"
-			IL_038e: ldloc.s 10
-			IL_0390: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0395: br IL_03b2
+			IL_0382: ldloc.s 7
+			IL_0384: ldstr "abort"
+			IL_0389: ldloc.s 10
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0390: br IL_03ad
 
-			IL_039a: ldloc.s 7
-			IL_039c: ldstr "abort"
-			IL_03a1: ldloc.s 10
-			IL_03a3: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:40"
-			IL_03a8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-			IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0395: ldloc.s 7
+			IL_0397: ldstr "abort"
+			IL_039c: ldloc.s 10
+			IL_039e: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:39"
+			IL_03a3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+			IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_03b2: pop
-			IL_03b3: ldloc.2
-			IL_03b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b9: stloc.s 7
-			IL_03bb: volatile.
-			IL_03bd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_03c2: brfalse IL_03d8
+			IL_03ad: pop
+			IL_03ae: ldloc.2
+			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b4: stloc.s 7
+			IL_03b6: volatile.
+			IL_03b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_03bd: brfalse IL_03d3
 
-			IL_03c7: ldloc.s 7
-			IL_03c9: ldstr "next"
-			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_03d3: br IL_03ee
+			IL_03c2: ldloc.s 7
+			IL_03c4: ldstr "next"
+			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_03ce: br IL_03e9
 
-			IL_03d8: ldloc.s 7
-			IL_03da: ldstr "next"
-			IL_03df: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:43"
-			IL_03e4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+			IL_03d3: ldloc.s 7
+			IL_03d5: ldstr "next"
+			IL_03da: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:42"
+			IL_03df: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-			IL_03ee: stloc.s 7
-			IL_03f0: ldloc.s 7
-			IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03f7: stloc.s 7
-			IL_03f9: ldc.i4.1
-			IL_03fa: newarr [System.Runtime]System.Object
-			IL_03ff: dup
-			IL_0400: ldc.i4.0
-			IL_0401: ldarg.0
-			IL_0402: ldc.i4.1
-			IL_0403: ldelem.ref
-			IL_0404: stelem.ref
-			IL_0405: stloc.s 5
-			IL_0407: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject::.ctor()
-			IL_040c: ldc.i4.0
-			IL_040d: conv.r8
-			IL_040e: ldstr ""
-			IL_0413: ldc.i4.0
-			IL_0414: ldc.i4.0
-			IL_0415: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_041a: stloc.s 11
-			IL_041c: volatile.
-			IL_041e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0423: brfalse IL_043b
+			IL_03e9: stloc.s 7
+			IL_03eb: ldloc.s 7
+			IL_03ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03f2: stloc.s 7
+			IL_03f4: ldc.i4.1
+			IL_03f5: newarr [System.Runtime]System.Object
+			IL_03fa: dup
+			IL_03fb: ldc.i4.0
+			IL_03fc: ldarg.0
+			IL_03fd: ldc.i4.1
+			IL_03fe: ldelem.ref
+			IL_03ff: stelem.ref
+			IL_0400: stloc.s 5
+			IL_0402: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject::.ctor()
+			IL_0407: ldc.i4.0
+			IL_0408: conv.r8
+			IL_0409: ldstr ""
+			IL_040e: ldc.i4.0
+			IL_040f: ldc.i4.0
+			IL_0410: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0415: stloc.s 11
+			IL_0417: volatile.
+			IL_0419: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_041e: brfalse IL_0436
 
-			IL_0428: ldloc.s 7
-			IL_042a: ldstr "then"
-			IL_042f: ldloc.s 11
-			IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0436: br IL_0453
+			IL_0423: ldloc.s 7
+			IL_0425: ldstr "then"
+			IL_042a: ldloc.s 11
+			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0431: br IL_044e
 
-			IL_043b: ldloc.s 7
-			IL_043d: ldstr "then"
-			IL_0442: ldloc.s 11
-			IL_0444: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:47"
-			IL_0449: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_0436: ldloc.s 7
+			IL_0438: ldstr "then"
+			IL_043d: ldloc.s 11
+			IL_043f: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:46"
+			IL_0444: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_0453: stloc.s 7
-			IL_0455: ldloc.s 7
-			IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_045c: stloc.s 7
-			IL_045e: ldc.i4.1
-			IL_045f: newarr [System.Runtime]System.Object
-			IL_0464: dup
-			IL_0465: ldc.i4.0
-			IL_0466: ldarg.0
-			IL_0467: ldc.i4.1
-			IL_0468: ldelem.ref
-			IL_0469: stelem.ref
-			IL_046a: stloc.s 5
-			IL_046c: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject::.ctor()
-			IL_0471: ldc.i4.1
-			IL_0472: conv.r8
-			IL_0473: ldstr ""
-			IL_0478: ldc.i4.0
-			IL_0479: ldc.i4.0
-			IL_047a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_047f: stloc.s 12
-			IL_0481: volatile.
-			IL_0483: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_0488: brfalse IL_04a0
+			IL_044e: stloc.s 7
+			IL_0450: ldloc.s 7
+			IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0457: stloc.s 7
+			IL_0459: ldc.i4.1
+			IL_045a: newarr [System.Runtime]System.Object
+			IL_045f: dup
+			IL_0460: ldc.i4.0
+			IL_0461: ldarg.0
+			IL_0462: ldc.i4.1
+			IL_0463: ldelem.ref
+			IL_0464: stelem.ref
+			IL_0465: stloc.s 5
+			IL_0467: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject::.ctor()
+			IL_046c: ldc.i4.1
+			IL_046d: conv.r8
+			IL_046e: ldstr ""
+			IL_0473: ldc.i4.0
+			IL_0474: ldc.i4.0
+			IL_0475: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_047a: stloc.s 12
+			IL_047c: volatile.
+			IL_047e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0483: brfalse IL_049b
 
-			IL_048d: ldloc.s 7
-			IL_048f: ldstr "catch"
-			IL_0494: ldloc.s 12
-			IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_049b: br IL_04b8
+			IL_0488: ldloc.s 7
+			IL_048a: ldstr "catch"
+			IL_048f: ldloc.s 12
+			IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0496: br IL_04b3
 
-			IL_04a0: ldloc.s 7
-			IL_04a2: ldstr "catch"
-			IL_04a7: ldloc.s 12
-			IL_04a9: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:51"
-			IL_04ae: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+			IL_049b: ldloc.s 7
+			IL_049d: ldstr "catch"
+			IL_04a2: ldloc.s 12
+			IL_04a4: ldstr "TimersPromises_SetInterval_Abort_RejectsActiveIterator:<TwoPhaseDummy_M5>:__js_call__:50"
+			IL_04a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-			IL_04b8: stloc.s 7
-			IL_04ba: ldloc.0
-			IL_04bb: ldc.i4.m1
-			IL_04bc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_04c1: ldloc.0
-			IL_04c2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_04cc: ldarg.0
-			IL_04cd: ldc.i4.1
-			IL_04ce: newarr [System.Runtime]System.Object
-			IL_04d3: dup
-			IL_04d4: ldc.i4.0
-			IL_04d5: ldloc.s 7
-			IL_04d7: stelem.ref
-			IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_04dd: pop
-			IL_04de: ldloc.0
-			IL_04df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04e4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04e9: ret
+			IL_04b3: stloc.s 7
+			IL_04b5: ldloc.0
+			IL_04b6: ldc.i4.m1
+			IL_04b7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04bc: ldloc.0
+			IL_04bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_04c7: ldarg.0
+			IL_04c8: ldc.i4.1
+			IL_04c9: newarr [System.Runtime]System.Object
+			IL_04ce: dup
+			IL_04cf: ldc.i4.0
+			IL_04d0: ldloc.s 7
+			IL_04d2: stelem.ref
+			IL_04d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_04d8: pop
+			IL_04d9: ldloc.0
+			IL_04da: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04df: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04e4: ret
 		} // end of method main::__js_call__
 
 	} // end of class main

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -1124,7 +1124,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1218 (0x4c2)
+		// Code size: 1173 (0x495)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_ErrorPaths/Scope,
@@ -1139,19 +1139,18 @@
 			[9] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[11] object,
-			[12] object[],
-			[13] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject,
-			[14] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject,
-			[15] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject,
-			[16] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject,
-			[17] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject,
-			[18] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-			[19] string,
-			[20] bool,
+			[12] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject,
+			[13] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject,
+			[14] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject,
+			[15] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject,
+			[16] class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject,
+			[17] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[18] string,
+			[19] bool,
+			[20] object,
 			[21] object,
 			[22] object,
-			[23] object,
-			[24] object
+			[23] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope::.ctor()
@@ -1273,317 +1272,302 @@
 		IL_0172: ldloc.s 11
 		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 		IL_0179: pop
-		IL_017a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_017f: stloc.s 6
-		IL_0181: ldc.i4.1
-		IL_0182: newarr [System.Runtime]System.Object
-		IL_0187: dup
+		IL_017a: ldc.i4.1
+		IL_017b: newarr [System.Runtime]System.Object
+		IL_0180: dup
+		IL_0181: ldc.i4.0
+		IL_0182: ldloc.0
+		IL_0183: stelem.ref
+		IL_0184: stloc.s 6
+		IL_0186: ldloc.s 6
 		IL_0188: ldc.i4.0
-		IL_0189: ldloc.0
-		IL_018a: stelem.ref
-		IL_018b: stloc.s 12
-		IL_018d: ldloc.s 12
-		IL_018f: ldc.i4.0
-		IL_0190: ldelem.ref
-		IL_0191: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0196: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_0189: ldelem.ref
+		IL_018a: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_018f: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_0194: ldc.i4.0
+		IL_0195: conv.r8
+		IL_0196: ldstr ""
 		IL_019b: ldc.i4.0
-		IL_019c: conv.r8
-		IL_019d: ldstr ""
-		IL_01a2: ldc.i4.0
-		IL_01a3: ldc.i4.0
-		IL_01a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject>(!!0)
-		IL_01ae: stloc.s 13
-		IL_01b0: ldloc.1
-		IL_01b1: ldloc.s 6
-		IL_01b3: ldstr "gzip unsupported option"
-		IL_01b8: ldloc.s 13
-		IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01bf: pop
-		IL_01c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01c5: stloc.s 6
-		IL_01c7: ldc.i4.1
-		IL_01c8: newarr [System.Runtime]System.Object
-		IL_01cd: dup
-		IL_01ce: ldc.i4.0
-		IL_01cf: ldloc.0
-		IL_01d0: stelem.ref
-		IL_01d1: stloc.s 12
-		IL_01d3: ldloc.s 12
-		IL_01d5: ldc.i4.0
-		IL_01d6: ldelem.ref
-		IL_01d7: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_01dc: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
-		IL_01e1: ldc.i4.0
-		IL_01e2: conv.r8
-		IL_01e3: ldstr ""
-		IL_01e8: ldc.i4.0
-		IL_01e9: ldc.i4.0
-		IL_01ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject>(!!0)
-		IL_01f4: stloc.s 14
-		IL_01f6: ldloc.1
-		IL_01f7: ldloc.s 6
-		IL_01f9: ldstr "gunzip unsupported option"
-		IL_01fe: ldloc.s 14
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0205: pop
-		IL_0206: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_020b: stloc.s 6
-		IL_020d: ldc.i4.1
-		IL_020e: newarr [System.Runtime]System.Object
-		IL_0213: dup
-		IL_0214: ldc.i4.0
-		IL_0215: ldloc.0
-		IL_0216: stelem.ref
-		IL_0217: stloc.s 12
-		IL_0219: ldloc.s 12
-		IL_021b: ldc.i4.0
-		IL_021c: ldelem.ref
-		IL_021d: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0222: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
-		IL_0227: ldc.i4.0
-		IL_0228: conv.r8
-		IL_0229: ldstr ""
-		IL_022e: ldc.i4.0
-		IL_022f: ldc.i4.0
-		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject>(!!0)
-		IL_023a: stloc.s 15
-		IL_023c: ldloc.1
+		IL_019c: ldc.i4.0
+		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37/FunctionObject>(!!0)
+		IL_01a7: stloc.s 12
+		IL_01a9: ldnull
+		IL_01aa: ldstr "gzip unsupported option"
+		IL_01af: ldloc.s 12
+		IL_01b1: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_01b6: pop
+		IL_01b7: ldc.i4.1
+		IL_01b8: newarr [System.Runtime]System.Object
+		IL_01bd: dup
+		IL_01be: ldc.i4.0
+		IL_01bf: ldloc.0
+		IL_01c0: stelem.ref
+		IL_01c1: stloc.s 6
+		IL_01c3: ldloc.s 6
+		IL_01c5: ldc.i4.0
+		IL_01c6: ldelem.ref
+		IL_01c7: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_01cc: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_01d1: ldc.i4.0
+		IL_01d2: conv.r8
+		IL_01d3: ldstr ""
+		IL_01d8: ldc.i4.0
+		IL_01d9: ldc.i4.0
+		IL_01da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39/FunctionObject>(!!0)
+		IL_01e4: stloc.s 13
+		IL_01e6: ldnull
+		IL_01e7: ldstr "gunzip unsupported option"
+		IL_01ec: ldloc.s 13
+		IL_01ee: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_01f3: pop
+		IL_01f4: ldc.i4.1
+		IL_01f5: newarr [System.Runtime]System.Object
+		IL_01fa: dup
+		IL_01fb: ldc.i4.0
+		IL_01fc: ldloc.0
+		IL_01fd: stelem.ref
+		IL_01fe: stloc.s 6
+		IL_0200: ldloc.s 6
+		IL_0202: ldc.i4.0
+		IL_0203: ldelem.ref
+		IL_0204: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0209: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_020e: ldc.i4.0
+		IL_020f: conv.r8
+		IL_0210: ldstr ""
+		IL_0215: ldc.i4.0
+		IL_0216: ldc.i4.0
+		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_021c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28/FunctionObject>(!!0)
+		IL_0221: stloc.s 14
+		IL_0223: ldnull
+		IL_0224: ldstr "gzip bad level"
+		IL_0229: ldloc.s 14
+		IL_022b: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_0230: pop
+		IL_0231: ldc.i4.1
+		IL_0232: newarr [System.Runtime]System.Object
+		IL_0237: dup
+		IL_0238: ldc.i4.0
+		IL_0239: ldloc.0
+		IL_023a: stelem.ref
+		IL_023b: stloc.s 6
 		IL_023d: ldloc.s 6
-		IL_023f: ldstr "gzip bad level"
-		IL_0244: ldloc.s 15
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_024b: pop
-		IL_024c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0251: stloc.s 6
-		IL_0253: ldc.i4.1
-		IL_0254: newarr [System.Runtime]System.Object
-		IL_0259: dup
-		IL_025a: ldc.i4.0
-		IL_025b: ldloc.0
-		IL_025c: stelem.ref
-		IL_025d: stloc.s 12
-		IL_025f: ldloc.s 12
-		IL_0261: ldc.i4.0
-		IL_0262: ldelem.ref
-		IL_0263: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0268: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
-		IL_026d: ldc.i4.0
-		IL_026e: conv.r8
-		IL_026f: ldstr ""
-		IL_0274: ldc.i4.0
+		IL_023f: ldc.i4.0
+		IL_0240: ldelem.ref
+		IL_0241: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0246: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_024b: ldc.i4.0
+		IL_024c: conv.r8
+		IL_024d: ldstr ""
+		IL_0252: ldc.i4.0
+		IL_0253: ldc.i4.0
+		IL_0254: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0259: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject>(!!0)
+		IL_025e: stloc.s 15
+		IL_0260: ldnull
+		IL_0261: ldstr "gzip NaN level"
+		IL_0266: ldloc.s 15
+		IL_0268: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_026d: pop
+		IL_026e: ldc.i4.1
+		IL_026f: newarr [System.Runtime]System.Object
+		IL_0274: dup
 		IL_0275: ldc.i4.0
-		IL_0276: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_027b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28/FunctionObject>(!!0)
-		IL_0280: stloc.s 16
-		IL_0282: ldloc.1
-		IL_0283: ldloc.s 6
-		IL_0285: ldstr "gzip NaN level"
-		IL_028a: ldloc.s 16
-		IL_028c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0291: pop
-		IL_0292: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0297: stloc.s 6
-		IL_0299: ldc.i4.1
-		IL_029a: newarr [System.Runtime]System.Object
-		IL_029f: dup
-		IL_02a0: ldc.i4.0
-		IL_02a1: ldloc.0
-		IL_02a2: stelem.ref
-		IL_02a3: stloc.s 12
-		IL_02a5: ldloc.s 12
-		IL_02a7: ldc.i4.0
-		IL_02a8: ldelem.ref
-		IL_02a9: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_02ae: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
-		IL_02b3: ldc.i4.0
-		IL_02b4: conv.r8
-		IL_02b5: ldstr ""
-		IL_02ba: ldc.i4.0
-		IL_02bb: ldc.i4.0
-		IL_02bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0)
-		IL_02c6: stloc.s 17
-		IL_02c8: ldloc.1
-		IL_02c9: ldloc.s 6
-		IL_02cb: ldstr "gzip Infinity level"
-		IL_02d0: ldloc.s 17
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02d7: pop
+		IL_0276: ldloc.0
+		IL_0277: stelem.ref
+		IL_0278: stloc.s 6
+		IL_027a: ldloc.s 6
+		IL_027c: ldc.i4.0
+		IL_027d: ldelem.ref
+		IL_027e: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0283: newobj instance void Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject::.ctor(class Modules.Require_Zlib_ErrorPaths/Scope)
+		IL_0288: ldc.i4.0
+		IL_0289: conv.r8
+		IL_028a: ldstr ""
+		IL_028f: ldc.i4.0
+		IL_0290: ldc.i4.0
+		IL_0291: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0296: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33/FunctionObject>(!!0)
+		IL_029b: stloc.s 16
+		IL_029d: ldnull
+		IL_029e: ldstr "gzip Infinity level"
+		IL_02a3: ldloc.s 16
+		IL_02a5: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
+		IL_02aa: pop
 		.try
 		{
-			IL_02d8: nop
-			IL_02d9: ldloc.0
-			IL_02da: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_02df: stloc.s 7
-			IL_02e1: ldstr "not gzip"
-			IL_02e6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_02eb: stloc.s 18
-			IL_02ed: ldloc.s 7
-			IL_02ef: ldloc.s 18
-			IL_02f1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
-			IL_02f6: pop
-			IL_02f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02fc: stloc.s 8
-			IL_02fe: ldloc.s 8
-			IL_0300: ldstr "gunzip invalid data threw:"
-			IL_0305: ldc.i4.0
-			IL_0306: box [System.Runtime]System.Boolean
-			IL_030b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0310: pop
-			IL_0311: leave IL_04be
+			IL_02ab: nop
+			IL_02ac: ldloc.0
+			IL_02ad: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_02b2: stloc.s 7
+			IL_02b4: ldstr "not gzip"
+			IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_02be: stloc.s 17
+			IL_02c0: ldloc.s 7
+			IL_02c2: ldloc.s 17
+			IL_02c4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IZlibModule::gunzipSync(object)
+			IL_02c9: pop
+			IL_02ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02cf: stloc.s 8
+			IL_02d1: ldloc.s 8
+			IL_02d3: ldstr "gunzip invalid data threw:"
+			IL_02d8: ldc.i4.0
+			IL_02d9: box [System.Runtime]System.Boolean
+			IL_02de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_02e3: pop
+			IL_02e4: leave IL_0491
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0316: stloc.2
-			IL_0317: ldloc.2
-			IL_0318: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_031d: dup
-			IL_031e: brtrue IL_0333
+			IL_02e9: stloc.2
+			IL_02ea: ldloc.2
+			IL_02eb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02f0: dup
+			IL_02f1: brtrue IL_0306
 
-			IL_0323: pop
-			IL_0324: ldloc.2
-			IL_0325: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_032a: dup
-			IL_032b: brtrue IL_033e
+			IL_02f6: pop
+			IL_02f7: ldloc.2
+			IL_02f8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02fd: dup
+			IL_02fe: brtrue IL_0311
 
-			IL_0330: pop
-			IL_0331: rethrow
+			IL_0303: pop
+			IL_0304: rethrow
 
-			IL_0333: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0338: stloc.3
-			IL_0339: br IL_033f
+			IL_0306: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_030b: stloc.3
+			IL_030c: br IL_0312
 
-			IL_033e: stloc.3
+			IL_0311: stloc.3
 
-			IL_033f: ldloc.3
-			IL_0340: stloc.s 4
-			IL_0342: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0347: stloc.s 8
-			IL_0349: ldloc.s 8
-			IL_034b: ldstr "gunzip invalid data threw:"
-			IL_0350: ldc.i4.1
-			IL_0351: box [System.Runtime]System.Boolean
-			IL_0356: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_035b: pop
-			IL_035c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0361: stloc.s 8
-			IL_0363: volatile.
-			IL_0365: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_036a: brfalse IL_0380
+			IL_0312: ldloc.3
+			IL_0313: stloc.s 4
+			IL_0315: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_031a: stloc.s 8
+			IL_031c: ldloc.s 8
+			IL_031e: ldstr "gunzip invalid data threw:"
+			IL_0323: ldc.i4.1
+			IL_0324: box [System.Runtime]System.Boolean
+			IL_0329: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_032e: pop
+			IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0334: stloc.s 8
+			IL_0336: volatile.
+			IL_0338: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_033d: brfalse IL_0353
 
-			IL_036f: ldloc.s 4
-			IL_0371: ldstr "name"
-			IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_037b: br IL_0396
+			IL_0342: ldloc.s 4
+			IL_0344: ldstr "name"
+			IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_034e: br IL_0369
 
-			IL_0380: ldloc.s 4
-			IL_0382: ldstr "name"
-			IL_0387: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:102"
-			IL_038c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-			IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0353: ldloc.s 4
+			IL_0355: ldstr "name"
+			IL_035a: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:102"
+			IL_035f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+			IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0396: stloc.s 11
-			IL_0398: ldloc.s 8
-			IL_039a: ldstr "gunzip invalid data name:"
-			IL_039f: ldloc.s 11
-			IL_03a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_03a6: pop
-			IL_03a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03ac: stloc.s 8
-			IL_03ae: volatile.
-			IL_03b0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_03b5: brfalse IL_03cb
+			IL_0369: stloc.s 11
+			IL_036b: ldloc.s 8
+			IL_036d: ldstr "gunzip invalid data name:"
+			IL_0372: ldloc.s 11
+			IL_0374: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0379: pop
+			IL_037a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_037f: stloc.s 8
+			IL_0381: volatile.
+			IL_0383: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_0388: brfalse IL_039e
 
-			IL_03ba: ldloc.s 4
-			IL_03bc: ldstr "message"
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c6: br IL_03e1
+			IL_038d: ldloc.s 4
+			IL_038f: ldstr "message"
+			IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0399: br IL_03b4
 
-			IL_03cb: ldloc.s 4
-			IL_03cd: ldstr "message"
-			IL_03d2: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:108"
-			IL_03d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-			IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_039e: ldloc.s 4
+			IL_03a0: ldstr "message"
+			IL_03a5: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:108"
+			IL_03aa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_03e1: stloc.s 11
-			IL_03e3: ldloc.s 11
-			IL_03e5: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_03ea: stloc.s 19
-			IL_03ec: ldloc.s 19
-			IL_03ee: ldstr "string"
-			IL_03f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_03f8: stloc.s 20
-			IL_03fa: ldloc.s 20
-			IL_03fc: box [System.Runtime]System.Boolean
-			IL_0401: stloc.s 21
-			IL_0403: ldloc.s 21
-			IL_0405: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_040a: stloc.s 20
-			IL_040c: ldloc.s 20
-			IL_040e: brfalse IL_04a6
+			IL_03b4: stloc.s 11
+			IL_03b6: ldloc.s 11
+			IL_03b8: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_03bd: stloc.s 18
+			IL_03bf: ldloc.s 18
+			IL_03c1: ldstr "string"
+			IL_03c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_03cb: stloc.s 19
+			IL_03cd: ldloc.s 19
+			IL_03cf: box [System.Runtime]System.Boolean
+			IL_03d4: stloc.s 20
+			IL_03d6: ldloc.s 20
+			IL_03d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03dd: stloc.s 19
+			IL_03df: ldloc.s 19
+			IL_03e1: brfalse IL_0479
 
-			IL_0413: volatile.
-			IL_0415: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_041a: brfalse IL_0430
+			IL_03e6: volatile.
+			IL_03e8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_03ed: brfalse IL_0403
 
-			IL_041f: ldloc.s 4
-			IL_0421: ldstr "message"
-			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_042b: br IL_0446
+			IL_03f2: ldloc.s 4
+			IL_03f4: ldstr "message"
+			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03fe: br IL_0419
 
-			IL_0430: ldloc.s 4
-			IL_0432: ldstr "message"
-			IL_0437: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:116"
-			IL_043c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0403: ldloc.s 4
+			IL_0405: ldstr "message"
+			IL_040a: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:116"
+			IL_040f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0446: stloc.s 11
-			IL_0448: volatile.
-			IL_044a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_044f: brfalse IL_0465
+			IL_0419: stloc.s 11
+			IL_041b: volatile.
+			IL_041d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0422: brfalse IL_0438
 
-			IL_0454: ldloc.s 11
-			IL_0456: ldstr "length"
-			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0460: br IL_047b
+			IL_0427: ldloc.s 11
+			IL_0429: ldstr "length"
+			IL_042e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0433: br IL_044e
 
-			IL_0465: ldloc.s 11
-			IL_0467: ldstr "length"
-			IL_046c: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:118"
-			IL_0471: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-			IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0438: ldloc.s 11
+			IL_043a: ldstr "length"
+			IL_043f: ldstr "Require_Zlib_ErrorPaths:Modules.Require_Zlib_ErrorPaths:__js_module_init__:118"
+			IL_0444: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+			IL_0449: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_047b: stloc.s 11
-			IL_047d: ldloc.s 11
-			IL_047f: ldc.r8 0.0
-			IL_0488: box [System.Runtime]System.Double
-			IL_048d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThan(object, object)
-			IL_0492: stloc.s 20
-			IL_0494: ldloc.s 20
-			IL_0496: box [System.Runtime]System.Boolean
-			IL_049b: stloc.s 22
-			IL_049d: ldloc.s 22
-			IL_049f: stloc.s 24
-			IL_04a1: br IL_04aa
+			IL_044e: stloc.s 11
+			IL_0450: ldloc.s 11
+			IL_0452: ldc.r8 0.0
+			IL_045b: box [System.Runtime]System.Double
+			IL_0460: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::GreaterThan(object, object)
+			IL_0465: stloc.s 19
+			IL_0467: ldloc.s 19
+			IL_0469: box [System.Runtime]System.Boolean
+			IL_046e: stloc.s 21
+			IL_0470: ldloc.s 21
+			IL_0472: stloc.s 23
+			IL_0474: br IL_047d
 
-			IL_04a6: ldloc.s 21
-			IL_04a8: stloc.s 24
+			IL_0479: ldloc.s 20
+			IL_047b: stloc.s 23
 
-			IL_04aa: ldloc.s 8
-			IL_04ac: ldstr "gunzip invalid data message length > 0:"
-			IL_04b1: ldloc.s 24
-			IL_04b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_04b8: pop
-			IL_04b9: leave IL_04be
+			IL_047d: ldloc.s 8
+			IL_047f: ldstr "gunzip invalid data message length > 0:"
+			IL_0484: ldloc.s 23
+			IL_0486: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_048b: pop
+			IL_048c: leave IL_0491
 		} // end handler
 
-		IL_04be: ldnull
-		IL_04bf: stloc.s 5
-		IL_04c1: ret
+		IL_0491: ldnull
+		IL_0492: stloc.s 5
+		IL_0494: ret
 	} // end of method Require_Zlib_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Zlib_ErrorPaths

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
@@ -602,7 +602,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 382 (0x17e)
+		// Code size: 385 (0x181)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope,
@@ -683,85 +683,88 @@
 		IL_008d: nop
 		IL_008e: nop
 		IL_008f: nop
-		IL_0090: ldloc.1
-		IL_0091: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_009b: stloc.s 6
-		IL_009d: ldloc.2
-		IL_009e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00a8: stloc.s 7
-		IL_00aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00af: stloc.s 8
-		IL_00b1: ldloc.s 8
-		IL_00b3: ldloc.s 6
-		IL_00b5: ldloc.s 7
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_00bc: pop
-		IL_00bd: ldloc.3
-		IL_00be: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00c8: stloc.s 7
-		IL_00ca: ldloc.s 8
-		IL_00cc: ldloc.s 7
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
-		IL_00d3: pop
-		IL_00d4: ldloc.s 8
-		IL_00d6: stloc.s 4
-		IL_00d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00dd: stloc.s 9
-		IL_00df: ldloc.0
-		IL_00e0: ldfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-		IL_00e5: stloc.s 7
-		IL_00e7: ldloc.s 9
-		IL_00e9: ldloc.s 7
-		IL_00eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f0: pop
-		IL_00f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f6: stloc.s 9
-		IL_00f8: volatile.
-		IL_00fa: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_00ff: brfalse IL_0115
+		IL_0090: ldloc.0
+		IL_0091: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
+		IL_0096: ldnull
+		IL_0097: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+		IL_009c: stloc.s 6
+		IL_009e: ldloc.0
+		IL_009f: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
+		IL_00a4: ldnull
+		IL_00a5: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+		IL_00aa: stloc.s 7
+		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00b1: stloc.s 8
+		IL_00b3: ldloc.s 8
+		IL_00b5: ldloc.s 6
+		IL_00b7: ldloc.s 7
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_00be: pop
+		IL_00bf: ldloc.0
+		IL_00c0: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
+		IL_00c5: ldnull
+		IL_00c6: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+		IL_00cb: stloc.s 7
+		IL_00cd: ldloc.s 8
+		IL_00cf: ldloc.s 7
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
+		IL_00d6: pop
+		IL_00d7: ldloc.s 8
+		IL_00d9: stloc.s 4
+		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e0: stloc.s 9
+		IL_00e2: ldloc.0
+		IL_00e3: ldfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
+		IL_00e8: stloc.s 7
+		IL_00ea: ldloc.s 9
+		IL_00ec: ldloc.s 7
+		IL_00ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f3: pop
+		IL_00f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f9: stloc.s 9
+		IL_00fb: volatile.
+		IL_00fd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0102: brfalse IL_0118
 
-		IL_0104: ldloc.s 4
-		IL_0106: ldstr "k"
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0110: br IL_012b
+		IL_0107: ldloc.s 4
+		IL_0109: ldstr "k"
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0113: br IL_012e
 
-		IL_0115: ldloc.s 4
-		IL_0117: ldstr "k"
-		IL_011c: ldstr "ObjectLiteral_ComputedKey_EvaluationOrder:Modules.ObjectLiteral_ComputedKey_EvaluationOrder:__js_module_init__:36"
-		IL_0121: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0118: ldloc.s 4
+		IL_011a: ldstr "k"
+		IL_011f: ldstr "ObjectLiteral_ComputedKey_EvaluationOrder:Modules.ObjectLiteral_ComputedKey_EvaluationOrder:__js_module_init__:36"
+		IL_0124: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_012b: stloc.s 7
-		IL_012d: ldloc.s 9
-		IL_012f: ldloc.s 7
-		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0136: pop
-		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013c: stloc.s 9
-		IL_013e: volatile.
-		IL_0140: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0145: brfalse IL_015b
+		IL_012e: stloc.s 7
+		IL_0130: ldloc.s 9
+		IL_0132: ldloc.s 7
+		IL_0134: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0139: pop
+		IL_013a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013f: stloc.s 9
+		IL_0141: volatile.
+		IL_0143: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0148: brfalse IL_015e
 
-		IL_014a: ldloc.s 4
-		IL_014c: ldstr "a"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0156: br IL_0171
+		IL_014d: ldloc.s 4
+		IL_014f: ldstr "a"
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0159: br IL_0174
 
-		IL_015b: ldloc.s 4
-		IL_015d: ldstr "a"
-		IL_0162: ldstr "ObjectLiteral_ComputedKey_EvaluationOrder:Modules.ObjectLiteral_ComputedKey_EvaluationOrder:__js_module_init__:41"
-		IL_0167: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_015e: ldloc.s 4
+		IL_0160: ldstr "a"
+		IL_0165: ldstr "ObjectLiteral_ComputedKey_EvaluationOrder:Modules.ObjectLiteral_ComputedKey_EvaluationOrder:__js_module_init__:41"
+		IL_016a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0171: stloc.s 7
-		IL_0173: ldloc.s 9
-		IL_0175: ldloc.s 7
-		IL_0177: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017c: pop
-		IL_017d: ret
+		IL_0174: stloc.s 7
+		IL_0176: ldloc.s 9
+		IL_0178: ldloc.s 7
+		IL_017a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_017f: pop
+		IL_0180: ret
 	} // end of method ObjectLiteral_ComputedKey_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_ComputedKey_EvaluationOrder

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
@@ -1324,7 +1324,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2606 (0xa2e)
+		// Code size: 2597 (0xa25)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope,
@@ -1383,828 +1383,825 @@
 		IL_0033: stloc.1
 		IL_0034: nop
 		IL_0035: nop
-		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003b: stloc.s 15
-		IL_003d: ldloc.1
-		IL_003e: ldloc.s 15
-		IL_0040: ldc.r8 2
-		IL_0049: box [System.Runtime]System.Double
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0053: stloc.2
-		IL_0054: ldloc.2
-		IL_0055: ldstr "add"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_005f: stloc.3
-		IL_0060: ldloc.2
-		IL_0061: ldstr "current"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_006b: stloc.s 4
-		IL_006d: ldloc.2
-		IL_006e: ldstr "computed"
-		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0078: stloc.s 5
-		IL_007a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007f: stloc.s 16
-		IL_0081: ldloc.2
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0087: volatile.
-		IL_0089: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_008e: brfalse IL_00b0
-
-		IL_0093: ldstr "add"
-		IL_0098: ldc.r8 4
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ab: br IL_00d2
-
-		IL_00b0: ldstr "add"
-		IL_00b5: ldc.r8 4
-		IL_00be: box [System.Runtime]System.Double
-		IL_00c3: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:31"
-		IL_00c8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
-
-		IL_00d2: stloc.s 17
-		IL_00d4: volatile.
-		IL_00d6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_00db: brfalse IL_00f0
-
-		IL_00e0: ldloc.3
-		IL_00e1: ldstr "value"
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00eb: br IL_0105
-
-		IL_00f0: ldloc.3
-		IL_00f1: ldstr "value"
-		IL_00f6: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:33"
-		IL_00fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0105: stloc.s 18
-		IL_0107: ldloc.s 18
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0113: dup
-		IL_0114: ldstr "value"
-		IL_0119: ldc.r8 10
-		IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0127: stloc.s 19
-		IL_0129: ldstr "call"
-		IL_012e: ldloc.s 19
-		IL_0130: ldc.r8 5
-		IL_0139: box [System.Runtime]System.Double
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0143: stloc.s 18
-		IL_0145: ldloc.s 16
-		IL_0147: ldstr "calls"
-		IL_014c: ldloc.s 17
-		IL_014e: ldloc.s 18
-		IL_0150: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0155: pop
-		IL_0156: ldloc.2
-		IL_0157: ldstr "current"
-		IL_015c: ldc.r8 12
-		IL_0165: ldc.i4.1
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_016b: pop
-		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0171: stloc.s 16
-		IL_0173: volatile.
-		IL_0175: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_017a: brfalse IL_018f
-
-		IL_017f: ldloc.2
-		IL_0180: ldstr "value"
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018a: br IL_01a4
-
-		IL_018f: ldloc.2
-		IL_0190: ldstr "value"
-		IL_0195: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:49"
-		IL_019a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_01a4: stloc.s 18
-		IL_01a6: volatile.
-		IL_01a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_01ad: brfalse IL_01c2
-
-		IL_01b2: ldloc.2
-		IL_01b3: ldstr "current"
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01bd: br IL_01d7
-
-		IL_01c2: ldloc.2
-		IL_01c3: ldstr "current"
-		IL_01c8: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:51"
-		IL_01cd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_01d7: stloc.s 17
-		IL_01d9: volatile.
-		IL_01db: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_01e0: brfalse IL_01f6
-
-		IL_01e5: ldloc.s 4
-		IL_01e7: ldstr "get"
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f1: br IL_020c
-
-		IL_01f6: ldloc.s 4
-		IL_01f8: ldstr "get"
-		IL_01fd: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:53"
-		IL_0202: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_020c: stloc.s 20
-		IL_020e: ldloc.s 20
-		IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0215: volatile.
-		IL_0217: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_021c: brfalse IL_0231
-
-		IL_0221: ldstr "call"
-		IL_0226: ldloc.2
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_022c: br IL_0246
-
-		IL_0231: ldstr "call"
-		IL_0236: ldloc.2
-		IL_0237: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:55"
-		IL_023c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
-
-		IL_0246: stloc.s 20
-		IL_0248: ldloc.s 16
-		IL_024a: ldc.i4.4
-		IL_024b: newarr [System.Runtime]System.Object
-		IL_0250: dup
-		IL_0251: ldc.i4.0
-		IL_0252: ldstr "accessors"
-		IL_0257: stelem.ref
-		IL_0258: dup
-		IL_0259: ldc.i4.1
-		IL_025a: ldloc.s 18
-		IL_025c: stelem.ref
-		IL_025d: dup
-		IL_025e: ldc.i4.2
-		IL_025f: ldloc.s 17
-		IL_0261: stelem.ref
-		IL_0262: dup
-		IL_0263: ldc.i4.3
-		IL_0264: ldloc.s 20
-		IL_0266: stelem.ref
-		IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_026c: pop
-		IL_026d: volatile.
-		IL_026f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0274: brfalse IL_028a
-
-		IL_0279: ldloc.s 4
-		IL_027b: ldstr "set"
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0285: br IL_02a0
-
-		IL_028a: ldloc.s 4
-		IL_028c: ldstr "set"
-		IL_0291: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:59"
-		IL_0296: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_02a0: stloc.s 20
-		IL_02a2: ldloc.s 20
-		IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a9: ldstr "call"
-		IL_02ae: ldloc.2
-		IL_02af: ldc.r8 20
-		IL_02b8: box [System.Runtime]System.Double
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02c2: pop
-		IL_02c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c8: stloc.s 16
-		IL_02ca: volatile.
-		IL_02cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_02d1: brfalse IL_02e6
-
-		IL_02d6: ldloc.2
-		IL_02d7: ldstr "value"
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e1: br IL_02fb
-
-		IL_02e6: ldloc.2
-		IL_02e7: ldstr "value"
-		IL_02ec: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:68"
-		IL_02f1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_02fb: stloc.s 20
-		IL_02fd: ldloc.s 16
-		IL_02ff: ldstr "setter"
-		IL_0304: ldloc.s 20
-		IL_0306: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_030b: pop
-		IL_030c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0311: stloc.s 16
-		IL_0313: ldloc.2
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0319: volatile.
-		IL_031b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0320: brfalse IL_0342
-
-		IL_0325: ldstr "computed"
-		IL_032a: ldc.r8 1
-		IL_0333: box [System.Runtime]System.Double
-		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_033d: br IL_0364
-
-		IL_0342: ldstr "computed"
-		IL_0347: ldc.r8 1
-		IL_0350: box [System.Runtime]System.Double
-		IL_0355: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:76"
-		IL_035a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
-
-		IL_0364: stloc.s 20
-		IL_0366: volatile.
-		IL_0368: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_036d: brfalse IL_0383
-
-		IL_0372: ldloc.s 5
-		IL_0374: ldstr "value"
-		IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_037e: br IL_0399
-
-		IL_0383: ldloc.s 5
-		IL_0385: ldstr "value"
-		IL_038a: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:78"
-		IL_038f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0399: stloc.s 17
-		IL_039b: ldloc.s 17
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03a7: dup
-		IL_03a8: ldstr "value"
-		IL_03ad: ldc.r8 30
-		IL_03b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_03bb: stloc.s 19
-		IL_03bd: ldstr "call"
-		IL_03c2: ldloc.s 19
-		IL_03c4: ldc.r8 2
-		IL_03cd: box [System.Runtime]System.Double
-		IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03d7: stloc.s 17
-		IL_03d9: ldloc.s 16
-		IL_03db: ldstr "computed"
-		IL_03e0: ldloc.s 20
-		IL_03e2: ldloc.s 17
-		IL_03e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_03e9: pop
-		IL_03ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03ef: stloc.s 16
-		IL_03f1: volatile.
-		IL_03f3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_03f8: brfalse IL_040d
-
-		IL_03fd: ldloc.3
-		IL_03fe: ldstr "value"
-		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0408: br IL_0422
-
-		IL_040d: ldloc.3
-		IL_040e: ldstr "value"
-		IL_0413: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:90"
-		IL_0418: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0422: stloc.s 17
-		IL_0424: volatile.
-		IL_0426: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_042b: brfalse IL_0441
-
-		IL_0430: ldloc.s 17
-		IL_0432: ldstr "name"
-		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_043c: br IL_0457
-
-		IL_0441: ldloc.s 17
-		IL_0443: ldstr "name"
-		IL_0448: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:92"
-		IL_044d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0452: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0457: stloc.s 17
-		IL_0459: volatile.
-		IL_045b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0460: brfalse IL_0475
-
-		IL_0465: ldloc.3
-		IL_0466: ldstr "value"
-		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0470: br IL_048a
-
-		IL_0475: ldloc.3
-		IL_0476: ldstr "value"
-		IL_047b: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:94"
-		IL_0480: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_048a: stloc.s 20
-		IL_048c: volatile.
-		IL_048e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0493: brfalse IL_04a9
-
-		IL_0498: ldloc.s 20
-		IL_049a: ldstr "length"
-		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04a4: br IL_04bf
-
-		IL_04a9: ldloc.s 20
-		IL_04ab: ldstr "length"
-		IL_04b0: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:96"
-		IL_04b5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_04bf: stloc.s 20
-		IL_04c1: volatile.
-		IL_04c3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_04c8: brfalse IL_04de
-
-		IL_04cd: ldloc.s 4
-		IL_04cf: ldstr "get"
-		IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04d9: br IL_04f4
-
-		IL_04de: ldloc.s 4
-		IL_04e0: ldstr "get"
-		IL_04e5: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:98"
-		IL_04ea: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_04f4: stloc.s 18
-		IL_04f6: volatile.
-		IL_04f8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_04fd: brfalse IL_0513
-
-		IL_0502: ldloc.s 18
-		IL_0504: ldstr "name"
-		IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_050e: br IL_0529
-
-		IL_0513: ldloc.s 18
-		IL_0515: ldstr "name"
-		IL_051a: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:100"
-		IL_051f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0529: stloc.s 18
-		IL_052b: volatile.
-		IL_052d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0532: brfalse IL_0548
-
-		IL_0537: ldloc.s 4
-		IL_0539: ldstr "set"
-		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0543: br IL_055e
-
-		IL_0548: ldloc.s 4
-		IL_054a: ldstr "set"
-		IL_054f: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:102"
-		IL_0554: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_055e: stloc.s 21
-		IL_0560: volatile.
-		IL_0562: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0567: brfalse IL_057d
-
-		IL_056c: ldloc.s 21
-		IL_056e: ldstr "name"
-		IL_0573: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0578: br IL_0593
-
-		IL_057d: ldloc.s 21
-		IL_057f: ldstr "name"
-		IL_0584: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:104"
-		IL_0589: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0593: stloc.s 21
-		IL_0595: volatile.
-		IL_0597: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_059c: brfalse IL_05b2
-
-		IL_05a1: ldloc.s 5
-		IL_05a3: ldstr "value"
-		IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05ad: br IL_05c8
-
-		IL_05b2: ldloc.s 5
-		IL_05b4: ldstr "value"
-		IL_05b9: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:106"
-		IL_05be: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_05c3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_05c8: stloc.s 22
-		IL_05ca: volatile.
-		IL_05cc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_05d1: brfalse IL_05e7
-
-		IL_05d6: ldloc.s 22
-		IL_05d8: ldstr "name"
-		IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05e2: br IL_05fd
-
-		IL_05e7: ldloc.s 22
-		IL_05e9: ldstr "name"
-		IL_05ee: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:108"
-		IL_05f3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_05fd: stloc.s 22
-		IL_05ff: ldloc.s 16
-		IL_0601: ldc.i4.6
-		IL_0602: newarr [System.Runtime]System.Object
-		IL_0607: dup
-		IL_0608: ldc.i4.0
-		IL_0609: ldstr "metadata"
-		IL_060e: stelem.ref
-		IL_060f: dup
-		IL_0610: ldc.i4.1
-		IL_0611: ldloc.s 17
-		IL_0613: stelem.ref
-		IL_0614: dup
-		IL_0615: ldc.i4.2
-		IL_0616: ldloc.s 20
-		IL_0618: stelem.ref
-		IL_0619: dup
-		IL_061a: ldc.i4.3
-		IL_061b: ldloc.s 18
-		IL_061d: stelem.ref
-		IL_061e: dup
-		IL_061f: ldc.i4.4
-		IL_0620: ldloc.s 21
-		IL_0622: stelem.ref
-		IL_0623: dup
-		IL_0624: ldc.i4.5
-		IL_0625: ldloc.s 22
-		IL_0627: stelem.ref
-		IL_0628: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_062d: pop
-		IL_062e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0633: stloc.s 16
-		IL_0635: volatile.
-		IL_0637: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_063c: brfalse IL_0651
-
-		IL_0641: ldloc.3
-		IL_0642: ldstr "value"
-		IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_064c: br IL_0666
-
-		IL_0651: ldloc.3
-		IL_0652: ldstr "value"
-		IL_0657: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:114"
-		IL_065c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
-		IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0666: stloc.s 22
-		IL_0668: volatile.
-		IL_066a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_066f: brfalse IL_0684
-
-		IL_0674: ldloc.2
-		IL_0675: ldstr "add"
-		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_067f: br IL_0699
-
-		IL_0684: ldloc.2
-		IL_0685: ldstr "add"
-		IL_068a: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:116"
-		IL_068f: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
-		IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0699: stloc.s 21
-		IL_069b: ldloc.s 22
-		IL_069d: ldloc.s 21
-		IL_069f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_06a4: stloc.s 23
-		IL_06a6: ldloc.s 23
-		IL_06a8: box [System.Runtime]System.Boolean
-		IL_06ad: stloc.s 24
-		IL_06af: volatile.
-		IL_06b1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_06b6: brfalse IL_06cc
-
-		IL_06bb: ldloc.s 4
-		IL_06bd: ldstr "get"
-		IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06c7: br IL_06e2
-
-		IL_06cc: ldloc.s 4
-		IL_06ce: ldstr "get"
-		IL_06d3: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:120"
-		IL_06d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-		IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_06e2: stloc.s 21
-		IL_06e4: ldloc.2
-		IL_06e5: ldstr "current"
-		IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_06ef: volatile.
-		IL_06f1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_06f6: brfalse IL_070a
-
-		IL_06fb: ldstr "get"
-		IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0705: br IL_071e
-
-		IL_070a: ldstr "get"
-		IL_070f: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:124"
-		IL_0714: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0719: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_071e: stloc.s 22
-		IL_0720: ldloc.s 21
-		IL_0722: ldloc.s 22
-		IL_0724: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0729: stloc.s 23
-		IL_072b: ldloc.s 23
-		IL_072d: box [System.Runtime]System.Boolean
-		IL_0732: stloc.s 25
-		IL_0734: volatile.
-		IL_0736: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_073b: brfalse IL_0750
-
-		IL_0740: ldloc.3
-		IL_0741: ldstr "value"
-		IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_074b: br IL_0765
-
-		IL_0750: ldloc.3
-		IL_0751: ldstr "value"
-		IL_0756: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:128"
-		IL_075b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-		IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
-
-		IL_0765: stloc.s 22
-		IL_0767: ldloc.s 22
-		IL_0769: ldstr "prototype"
-		IL_076e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0773: box [System.Runtime]System.Boolean
-		IL_0778: stloc.s 26
-		IL_077a: ldloc.s 16
-		IL_077c: ldc.i4.4
-		IL_077d: newarr [System.Runtime]System.Object
-		IL_0782: dup
-		IL_0783: ldc.i4.0
-		IL_0784: ldstr "descriptors"
-		IL_0789: stelem.ref
-		IL_078a: dup
-		IL_078b: ldc.i4.1
-		IL_078c: ldloc.s 24
-		IL_078e: stelem.ref
-		IL_078f: dup
-		IL_0790: ldc.i4.2
-		IL_0791: ldloc.s 25
-		IL_0793: stelem.ref
-		IL_0794: dup
-		IL_0795: ldc.i4.3
-		IL_0796: ldloc.s 26
-		IL_0798: stelem.ref
-		IL_0799: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_079e: pop
-		IL_079f: ldc.i4.0
-		IL_07a0: box [System.Runtime]System.Boolean
-		IL_07a5: stloc.s 6
+		IL_0036: ldloc.0
+		IL_0037: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope
+		IL_003c: ldnull
+		IL_003d: ldc.r8 2
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject::__js_call__(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope, object, object)
+		IL_0050: stloc.2
+		IL_0051: ldloc.2
+		IL_0052: ldstr "add"
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_005c: stloc.3
+		IL_005d: ldloc.2
+		IL_005e: ldstr "current"
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0068: stloc.s 4
+		IL_006a: ldloc.2
+		IL_006b: ldstr "computed"
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0075: stloc.s 5
+		IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007c: stloc.s 16
+		IL_007e: ldloc.2
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0084: volatile.
+		IL_0086: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_008b: brfalse IL_00ad
+
+		IL_0090: ldstr "add"
+		IL_0095: ldc.r8 4
+		IL_009e: box [System.Runtime]System.Double
+		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a8: br IL_00cf
+
+		IL_00ad: ldstr "add"
+		IL_00b2: ldc.r8 4
+		IL_00bb: box [System.Runtime]System.Double
+		IL_00c0: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:31"
+		IL_00c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_00cf: stloc.s 17
+		IL_00d1: volatile.
+		IL_00d3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00d8: brfalse IL_00ed
+
+		IL_00dd: ldloc.3
+		IL_00de: ldstr "value"
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e8: br IL_0102
+
+		IL_00ed: ldloc.3
+		IL_00ee: ldstr "value"
+		IL_00f3: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:33"
+		IL_00f8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0102: stloc.s 18
+		IL_0104: ldloc.s 18
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0110: dup
+		IL_0111: ldstr "value"
+		IL_0116: ldc.r8 10
+		IL_011f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0124: stloc.s 19
+		IL_0126: ldstr "call"
+		IL_012b: ldloc.s 19
+		IL_012d: ldc.r8 5
+		IL_0136: box [System.Runtime]System.Double
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0140: stloc.s 18
+		IL_0142: ldloc.s 16
+		IL_0144: ldstr "calls"
+		IL_0149: ldloc.s 17
+		IL_014b: ldloc.s 18
+		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0152: pop
+		IL_0153: ldloc.2
+		IL_0154: ldstr "current"
+		IL_0159: ldc.r8 12
+		IL_0162: ldc.i4.1
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0168: pop
+		IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016e: stloc.s 16
+		IL_0170: volatile.
+		IL_0172: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0177: brfalse IL_018c
+
+		IL_017c: ldloc.2
+		IL_017d: ldstr "value"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0187: br IL_01a1
+
+		IL_018c: ldloc.2
+		IL_018d: ldstr "value"
+		IL_0192: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:49"
+		IL_0197: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_01a1: stloc.s 18
+		IL_01a3: volatile.
+		IL_01a5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_01aa: brfalse IL_01bf
+
+		IL_01af: ldloc.2
+		IL_01b0: ldstr "current"
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ba: br IL_01d4
+
+		IL_01bf: ldloc.2
+		IL_01c0: ldstr "current"
+		IL_01c5: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:51"
+		IL_01ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_01d4: stloc.s 17
+		IL_01d6: volatile.
+		IL_01d8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_01dd: brfalse IL_01f3
+
+		IL_01e2: ldloc.s 4
+		IL_01e4: ldstr "get"
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ee: br IL_0209
+
+		IL_01f3: ldloc.s 4
+		IL_01f5: ldstr "get"
+		IL_01fa: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:53"
+		IL_01ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0209: stloc.s 20
+		IL_020b: ldloc.s 20
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0212: volatile.
+		IL_0214: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_0219: brfalse IL_022e
+
+		IL_021e: ldstr "call"
+		IL_0223: ldloc.2
+		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0229: br IL_0243
+
+		IL_022e: ldstr "call"
+		IL_0233: ldloc.2
+		IL_0234: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:55"
+		IL_0239: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0243: stloc.s 20
+		IL_0245: ldloc.s 16
+		IL_0247: ldc.i4.4
+		IL_0248: newarr [System.Runtime]System.Object
+		IL_024d: dup
+		IL_024e: ldc.i4.0
+		IL_024f: ldstr "accessors"
+		IL_0254: stelem.ref
+		IL_0255: dup
+		IL_0256: ldc.i4.1
+		IL_0257: ldloc.s 18
+		IL_0259: stelem.ref
+		IL_025a: dup
+		IL_025b: ldc.i4.2
+		IL_025c: ldloc.s 17
+		IL_025e: stelem.ref
+		IL_025f: dup
+		IL_0260: ldc.i4.3
+		IL_0261: ldloc.s 20
+		IL_0263: stelem.ref
+		IL_0264: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0269: pop
+		IL_026a: volatile.
+		IL_026c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0271: brfalse IL_0287
+
+		IL_0276: ldloc.s 4
+		IL_0278: ldstr "set"
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0282: br IL_029d
+
+		IL_0287: ldloc.s 4
+		IL_0289: ldstr "set"
+		IL_028e: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:59"
+		IL_0293: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_029d: stloc.s 20
+		IL_029f: ldloc.s 20
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a6: ldstr "call"
+		IL_02ab: ldloc.2
+		IL_02ac: ldc.r8 20
+		IL_02b5: box [System.Runtime]System.Double
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02bf: pop
+		IL_02c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c5: stloc.s 16
+		IL_02c7: volatile.
+		IL_02c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_02ce: brfalse IL_02e3
+
+		IL_02d3: ldloc.2
+		IL_02d4: ldstr "value"
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02de: br IL_02f8
+
+		IL_02e3: ldloc.2
+		IL_02e4: ldstr "value"
+		IL_02e9: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:68"
+		IL_02ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02f8: stloc.s 20
+		IL_02fa: ldloc.s 16
+		IL_02fc: ldstr "setter"
+		IL_0301: ldloc.s 20
+		IL_0303: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0308: pop
+		IL_0309: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_030e: stloc.s 16
+		IL_0310: ldloc.2
+		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0316: volatile.
+		IL_0318: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_031d: brfalse IL_033f
+
+		IL_0322: ldstr "computed"
+		IL_0327: ldc.r8 1
+		IL_0330: box [System.Runtime]System.Double
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_033a: br IL_0361
+
+		IL_033f: ldstr "computed"
+		IL_0344: ldc.r8 1
+		IL_034d: box [System.Runtime]System.Double
+		IL_0352: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:76"
+		IL_0357: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+
+		IL_0361: stloc.s 20
+		IL_0363: volatile.
+		IL_0365: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_036a: brfalse IL_0380
+
+		IL_036f: ldloc.s 5
+		IL_0371: ldstr "value"
+		IL_0376: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_037b: br IL_0396
+
+		IL_0380: ldloc.s 5
+		IL_0382: ldstr "value"
+		IL_0387: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:78"
+		IL_038c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0396: stloc.s 17
+		IL_0398: ldloc.s 17
+		IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_039f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03a4: dup
+		IL_03a5: ldstr "value"
+		IL_03aa: ldc.r8 30
+		IL_03b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03b8: stloc.s 19
+		IL_03ba: ldstr "call"
+		IL_03bf: ldloc.s 19
+		IL_03c1: ldc.r8 2
+		IL_03ca: box [System.Runtime]System.Double
+		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03d4: stloc.s 17
+		IL_03d6: ldloc.s 16
+		IL_03d8: ldstr "computed"
+		IL_03dd: ldloc.s 20
+		IL_03df: ldloc.s 17
+		IL_03e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_03e6: pop
+		IL_03e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03ec: stloc.s 16
+		IL_03ee: volatile.
+		IL_03f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_03f5: brfalse IL_040a
+
+		IL_03fa: ldloc.3
+		IL_03fb: ldstr "value"
+		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0405: br IL_041f
+
+		IL_040a: ldloc.3
+		IL_040b: ldstr "value"
+		IL_0410: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:90"
+		IL_0415: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_041f: stloc.s 17
+		IL_0421: volatile.
+		IL_0423: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0428: brfalse IL_043e
+
+		IL_042d: ldloc.s 17
+		IL_042f: ldstr "name"
+		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0439: br IL_0454
+
+		IL_043e: ldloc.s 17
+		IL_0440: ldstr "name"
+		IL_0445: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:92"
+		IL_044a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0454: stloc.s 17
+		IL_0456: volatile.
+		IL_0458: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_045d: brfalse IL_0472
+
+		IL_0462: ldloc.3
+		IL_0463: ldstr "value"
+		IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_046d: br IL_0487
+
+		IL_0472: ldloc.3
+		IL_0473: ldstr "value"
+		IL_0478: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:94"
+		IL_047d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0487: stloc.s 20
+		IL_0489: volatile.
+		IL_048b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0490: brfalse IL_04a6
+
+		IL_0495: ldloc.s 20
+		IL_0497: ldstr "length"
+		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04a1: br IL_04bc
+
+		IL_04a6: ldloc.s 20
+		IL_04a8: ldstr "length"
+		IL_04ad: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:96"
+		IL_04b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_04b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04bc: stloc.s 20
+		IL_04be: volatile.
+		IL_04c0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_04c5: brfalse IL_04db
+
+		IL_04ca: ldloc.s 4
+		IL_04cc: ldstr "get"
+		IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04d6: br IL_04f1
+
+		IL_04db: ldloc.s 4
+		IL_04dd: ldstr "get"
+		IL_04e2: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:98"
+		IL_04e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_04f1: stloc.s 18
+		IL_04f3: volatile.
+		IL_04f5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_04fa: brfalse IL_0510
+
+		IL_04ff: ldloc.s 18
+		IL_0501: ldstr "name"
+		IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050b: br IL_0526
+
+		IL_0510: ldloc.s 18
+		IL_0512: ldstr "name"
+		IL_0517: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:100"
+		IL_051c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0526: stloc.s 18
+		IL_0528: volatile.
+		IL_052a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_052f: brfalse IL_0545
+
+		IL_0534: ldloc.s 4
+		IL_0536: ldstr "set"
+		IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0540: br IL_055b
+
+		IL_0545: ldloc.s 4
+		IL_0547: ldstr "set"
+		IL_054c: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:102"
+		IL_0551: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_055b: stloc.s 21
+		IL_055d: volatile.
+		IL_055f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0564: brfalse IL_057a
+
+		IL_0569: ldloc.s 21
+		IL_056b: ldstr "name"
+		IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0575: br IL_0590
+
+		IL_057a: ldloc.s 21
+		IL_057c: ldstr "name"
+		IL_0581: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:104"
+		IL_0586: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0590: stloc.s 21
+		IL_0592: volatile.
+		IL_0594: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0599: brfalse IL_05af
+
+		IL_059e: ldloc.s 5
+		IL_05a0: ldstr "value"
+		IL_05a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05aa: br IL_05c5
+
+		IL_05af: ldloc.s 5
+		IL_05b1: ldstr "value"
+		IL_05b6: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:106"
+		IL_05bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05c5: stloc.s 22
+		IL_05c7: volatile.
+		IL_05c9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_05ce: brfalse IL_05e4
+
+		IL_05d3: ldloc.s 22
+		IL_05d5: ldstr "name"
+		IL_05da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05df: br IL_05fa
+
+		IL_05e4: ldloc.s 22
+		IL_05e6: ldstr "name"
+		IL_05eb: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:108"
+		IL_05f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_05fa: stloc.s 22
+		IL_05fc: ldloc.s 16
+		IL_05fe: ldc.i4.6
+		IL_05ff: newarr [System.Runtime]System.Object
+		IL_0604: dup
+		IL_0605: ldc.i4.0
+		IL_0606: ldstr "metadata"
+		IL_060b: stelem.ref
+		IL_060c: dup
+		IL_060d: ldc.i4.1
+		IL_060e: ldloc.s 17
+		IL_0610: stelem.ref
+		IL_0611: dup
+		IL_0612: ldc.i4.2
+		IL_0613: ldloc.s 20
+		IL_0615: stelem.ref
+		IL_0616: dup
+		IL_0617: ldc.i4.3
+		IL_0618: ldloc.s 18
+		IL_061a: stelem.ref
+		IL_061b: dup
+		IL_061c: ldc.i4.4
+		IL_061d: ldloc.s 21
+		IL_061f: stelem.ref
+		IL_0620: dup
+		IL_0621: ldc.i4.5
+		IL_0622: ldloc.s 22
+		IL_0624: stelem.ref
+		IL_0625: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_062a: pop
+		IL_062b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0630: stloc.s 16
+		IL_0632: volatile.
+		IL_0634: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_0639: brfalse IL_064e
+
+		IL_063e: ldloc.3
+		IL_063f: ldstr "value"
+		IL_0644: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0649: br IL_0663
+
+		IL_064e: ldloc.3
+		IL_064f: ldstr "value"
+		IL_0654: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:114"
+		IL_0659: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_32
+		IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0663: stloc.s 22
+		IL_0665: volatile.
+		IL_0667: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_066c: brfalse IL_0681
+
+		IL_0671: ldloc.2
+		IL_0672: ldstr "add"
+		IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_067c: br IL_0696
+
+		IL_0681: ldloc.2
+		IL_0682: ldstr "add"
+		IL_0687: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:116"
+		IL_068c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_33
+		IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0696: stloc.s 21
+		IL_0698: ldloc.s 22
+		IL_069a: ldloc.s 21
+		IL_069c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_06a1: stloc.s 23
+		IL_06a3: ldloc.s 23
+		IL_06a5: box [System.Runtime]System.Boolean
+		IL_06aa: stloc.s 24
+		IL_06ac: volatile.
+		IL_06ae: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_06b3: brfalse IL_06c9
+
+		IL_06b8: ldloc.s 4
+		IL_06ba: ldstr "get"
+		IL_06bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06c4: br IL_06df
+
+		IL_06c9: ldloc.s 4
+		IL_06cb: ldstr "get"
+		IL_06d0: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:120"
+		IL_06d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+		IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_06df: stloc.s 21
+		IL_06e1: ldloc.2
+		IL_06e2: ldstr "current"
+		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_06ec: volatile.
+		IL_06ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_06f3: brfalse IL_0707
+
+		IL_06f8: ldstr "get"
+		IL_06fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0702: br IL_071b
+
+		IL_0707: ldstr "get"
+		IL_070c: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:124"
+		IL_0711: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0716: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_071b: stloc.s 22
+		IL_071d: ldloc.s 21
+		IL_071f: ldloc.s 22
+		IL_0721: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0726: stloc.s 23
+		IL_0728: ldloc.s 23
+		IL_072a: box [System.Runtime]System.Boolean
+		IL_072f: stloc.s 25
+		IL_0731: volatile.
+		IL_0733: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_0738: brfalse IL_074d
+
+		IL_073d: ldloc.3
+		IL_073e: ldstr "value"
+		IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0748: br IL_0762
+
+		IL_074d: ldloc.3
+		IL_074e: ldstr "value"
+		IL_0753: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:128"
+		IL_0758: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+		IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0762: stloc.s 22
+		IL_0764: ldloc.s 22
+		IL_0766: ldstr "prototype"
+		IL_076b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0770: box [System.Runtime]System.Boolean
+		IL_0775: stloc.s 26
+		IL_0777: ldloc.s 16
+		IL_0779: ldc.i4.4
+		IL_077a: newarr [System.Runtime]System.Object
+		IL_077f: dup
+		IL_0780: ldc.i4.0
+		IL_0781: ldstr "descriptors"
+		IL_0786: stelem.ref
+		IL_0787: dup
+		IL_0788: ldc.i4.1
+		IL_0789: ldloc.s 24
+		IL_078b: stelem.ref
+		IL_078c: dup
+		IL_078d: ldc.i4.2
+		IL_078e: ldloc.s 25
+		IL_0790: stelem.ref
+		IL_0791: dup
+		IL_0792: ldc.i4.3
+		IL_0793: ldloc.s 26
+		IL_0795: stelem.ref
+		IL_0796: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_079b: pop
+		IL_079c: ldc.i4.0
+		IL_079d: box [System.Runtime]System.Boolean
+		IL_07a2: stloc.s 6
 		.try
 		{
-			IL_07a7: nop
-			IL_07a8: ldstr "Reflect"
-			IL_07ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07b7: stloc.s 22
-			IL_07b9: volatile.
-			IL_07bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-			IL_07c0: brfalse IL_07d5
+			IL_07a4: nop
+			IL_07a5: ldstr "Reflect"
+			IL_07aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_07b4: stloc.s 22
+			IL_07b6: volatile.
+			IL_07b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_07bd: brfalse IL_07d2
 
-			IL_07c5: ldloc.3
-			IL_07c6: ldstr "value"
-			IL_07cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07d0: br IL_07ea
+			IL_07c2: ldloc.3
+			IL_07c3: ldstr "value"
+			IL_07c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07cd: br IL_07e7
 
-			IL_07d5: ldloc.3
-			IL_07d6: ldstr "value"
-			IL_07db: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:145"
-			IL_07e0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-			IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_07d2: ldloc.3
+			IL_07d3: ldstr "value"
+			IL_07d8: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:145"
+			IL_07dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+			IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_07ea: stloc.s 21
-			IL_07ec: ldc.i4.0
-			IL_07ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_07f2: stloc.s 27
-			IL_07f4: ldloc.s 22
-			IL_07f6: ldstr "construct"
-			IL_07fb: ldloc.s 21
-			IL_07fd: ldloc.s 27
-			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0804: pop
-			IL_0805: leave IL_0869
+			IL_07e7: stloc.s 21
+			IL_07e9: ldc.i4.0
+			IL_07ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_07ef: stloc.s 27
+			IL_07f1: ldloc.s 22
+			IL_07f3: ldstr "construct"
+			IL_07f8: ldloc.s 21
+			IL_07fa: ldloc.s 27
+			IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0801: pop
+			IL_0802: leave IL_0866
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_080a: stloc.s 7
-			IL_080c: ldloc.s 7
-			IL_080e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0813: dup
-			IL_0814: brtrue IL_082a
+			IL_0807: stloc.s 7
+			IL_0809: ldloc.s 7
+			IL_080b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0810: dup
+			IL_0811: brtrue IL_0827
 
-			IL_0819: pop
-			IL_081a: ldloc.s 7
-			IL_081c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0821: dup
-			IL_0822: brtrue IL_0836
+			IL_0816: pop
+			IL_0817: ldloc.s 7
+			IL_0819: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_081e: dup
+			IL_081f: brtrue IL_0833
 
-			IL_0827: pop
-			IL_0828: rethrow
+			IL_0824: pop
+			IL_0825: rethrow
 
-			IL_082a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_082f: stloc.s 8
-			IL_0831: br IL_0838
+			IL_0827: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_082c: stloc.s 8
+			IL_082e: br IL_0835
 
-			IL_0836: stloc.s 8
+			IL_0833: stloc.s 8
 
-			IL_0838: ldloc.s 8
-			IL_083a: stloc.s 9
-			IL_083c: ldloc.s 9
-			IL_083e: stloc.s 21
-			IL_0840: ldstr "TypeError"
-			IL_0845: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_084a: stloc.s 22
-			IL_084c: ldloc.s 21
-			IL_084e: ldloc.s 22
-			IL_0850: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0855: stloc.s 23
-			IL_0857: ldloc.s 23
-			IL_0859: box [System.Runtime]System.Boolean
-			IL_085e: stloc.s 26
-			IL_0860: ldloc.s 26
-			IL_0862: stloc.s 6
-			IL_0864: leave IL_0869
+			IL_0835: ldloc.s 8
+			IL_0837: stloc.s 9
+			IL_0839: ldloc.s 9
+			IL_083b: stloc.s 21
+			IL_083d: ldstr "TypeError"
+			IL_0842: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0847: stloc.s 22
+			IL_0849: ldloc.s 21
+			IL_084b: ldloc.s 22
+			IL_084d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0852: stloc.s 23
+			IL_0854: ldloc.s 23
+			IL_0856: box [System.Runtime]System.Boolean
+			IL_085b: stloc.s 26
+			IL_085d: ldloc.s 26
+			IL_085f: stloc.s 6
+			IL_0861: leave IL_0866
 		} // end handler
 
-		IL_0869: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_086e: stloc.s 16
-		IL_0870: ldloc.s 16
-		IL_0872: ldstr "nonconstructor"
-		IL_0877: ldloc.s 6
-		IL_0879: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_087e: pop
-		IL_087f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0884: stloc.s 19
-		IL_0886: ldc.i4.1
-		IL_0887: newarr [System.Runtime]System.Object
-		IL_088c: dup
-		IL_088d: ldc.i4.0
-		IL_088e: ldloc.0
-		IL_088f: stelem.ref
-		IL_0890: stloc.s 15
-		IL_0892: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject::.ctor()
-		IL_0897: ldc.i4.0
-		IL_0898: conv.r8
-		IL_0899: ldstr ""
-		IL_089e: ldc.i4.0
-		IL_089f: ldc.i4.0
-		IL_08a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0)
-		IL_08aa: stloc.s 28
-		IL_08ac: ldloc.s 19
-		IL_08ae: ldstr "label"
-		IL_08b3: ldloc.s 28
-		IL_08b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_08ba: pop
-		IL_08bb: ldloc.s 19
-		IL_08bd: stloc.s 10
-		IL_08bf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_08c4: stloc.s 19
-		IL_08c6: ldloc.s 19
-		IL_08c8: ldloc.s 10
-		IL_08ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetObjectLiteralPrototype(object, object)
-		IL_08cf: pop
-		IL_08d0: ldc.i4.1
-		IL_08d1: newarr [System.Runtime]System.Object
-		IL_08d6: dup
-		IL_08d7: ldc.i4.0
-		IL_08d8: ldloc.0
-		IL_08d9: stelem.ref
-		IL_08da: stloc.s 15
-		IL_08dc: ldloc.s 19
-		IL_08de: ldloc.s 15
-		IL_08e0: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
-		IL_08e5: ldc.i4.0
-		IL_08e6: conv.r8
-		IL_08e7: ldstr ""
-		IL_08ec: ldc.i4.1
-		IL_08ed: ldc.i4.0
-		IL_08ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0)
-		IL_08f8: stloc.s 29
-		IL_08fa: ldloc.s 19
-		IL_08fc: ldstr "label"
-		IL_0901: ldloc.s 29
-		IL_0903: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0908: pop
-		IL_0909: ldloc.s 19
-		IL_090b: stloc.s 11
-		IL_090d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0912: stloc.s 16
-		IL_0914: volatile.
-		IL_0916: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_091b: brfalse IL_0931
+		IL_0866: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_086b: stloc.s 16
+		IL_086d: ldloc.s 16
+		IL_086f: ldstr "nonconstructor"
+		IL_0874: ldloc.s 6
+		IL_0876: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_087b: pop
+		IL_087c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0881: stloc.s 19
+		IL_0883: ldc.i4.1
+		IL_0884: newarr [System.Runtime]System.Object
+		IL_0889: dup
+		IL_088a: ldc.i4.0
+		IL_088b: ldloc.0
+		IL_088c: stelem.ref
+		IL_088d: stloc.s 15
+		IL_088f: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject::.ctor()
+		IL_0894: ldc.i4.0
+		IL_0895: conv.r8
+		IL_0896: ldstr ""
+		IL_089b: ldc.i4.0
+		IL_089c: ldc.i4.0
+		IL_089d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0)
+		IL_08a7: stloc.s 28
+		IL_08a9: ldloc.s 19
+		IL_08ab: ldstr "label"
+		IL_08b0: ldloc.s 28
+		IL_08b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_08b7: pop
+		IL_08b8: ldloc.s 19
+		IL_08ba: stloc.s 10
+		IL_08bc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_08c1: stloc.s 19
+		IL_08c3: ldloc.s 19
+		IL_08c5: ldloc.s 10
+		IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetObjectLiteralPrototype(object, object)
+		IL_08cc: pop
+		IL_08cd: ldc.i4.1
+		IL_08ce: newarr [System.Runtime]System.Object
+		IL_08d3: dup
+		IL_08d4: ldc.i4.0
+		IL_08d5: ldloc.0
+		IL_08d6: stelem.ref
+		IL_08d7: stloc.s 15
+		IL_08d9: ldloc.s 19
+		IL_08db: ldloc.s 15
+		IL_08dd: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
+		IL_08e2: ldc.i4.0
+		IL_08e3: conv.r8
+		IL_08e4: ldstr ""
+		IL_08e9: ldc.i4.1
+		IL_08ea: ldc.i4.0
+		IL_08eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0)
+		IL_08f5: stloc.s 29
+		IL_08f7: ldloc.s 19
+		IL_08f9: ldstr "label"
+		IL_08fe: ldloc.s 29
+		IL_0900: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0905: pop
+		IL_0906: ldloc.s 19
+		IL_0908: stloc.s 11
+		IL_090a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_090f: stloc.s 16
+		IL_0911: volatile.
+		IL_0913: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_0918: brfalse IL_092e
 
-		IL_0920: ldloc.s 11
-		IL_0922: ldstr "label"
-		IL_0927: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_092c: br IL_0947
+		IL_091d: ldloc.s 11
+		IL_091f: ldstr "label"
+		IL_0924: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0929: br IL_0944
 
-		IL_0931: ldloc.s 11
-		IL_0933: ldstr "label"
-		IL_0938: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:189"
-		IL_093d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-		IL_0942: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_092e: ldloc.s 11
+		IL_0930: ldstr "label"
+		IL_0935: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:189"
+		IL_093a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+		IL_093f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0947: stloc.s 22
-		IL_0949: ldloc.s 16
-		IL_094b: ldstr "super"
-		IL_0950: ldloc.s 22
-		IL_0952: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0957: pop
-		IL_0958: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_095d: stloc.s 15
-		IL_095f: ldloc.1
-		IL_0960: ldloc.s 15
-		IL_0962: ldc.r8 0.0
-		IL_096b: box [System.Runtime]System.Double
-		IL_0970: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0975: stloc.s 12
-		IL_0977: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_097c: stloc.s 15
-		IL_097e: ldloc.1
-		IL_097f: ldloc.s 15
-		IL_0981: ldc.r8 0.0
-		IL_098a: box [System.Runtime]System.Double
-		IL_098f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0994: stloc.s 13
-		IL_0996: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_099b: stloc.s 16
-		IL_099d: volatile.
-		IL_099f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_09a4: brfalse IL_09ba
+		IL_0944: stloc.s 22
+		IL_0946: ldloc.s 16
+		IL_0948: ldstr "super"
+		IL_094d: ldloc.s 22
+		IL_094f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0954: pop
+		IL_0955: ldloc.0
+		IL_0956: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope
+		IL_095b: ldnull
+		IL_095c: ldc.r8 0.0
+		IL_0965: box [System.Runtime]System.Double
+		IL_096a: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject::__js_call__(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope, object, object)
+		IL_096f: stloc.s 12
+		IL_0971: ldloc.0
+		IL_0972: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope
+		IL_0977: ldnull
+		IL_0978: ldc.r8 0.0
+		IL_0981: box [System.Runtime]System.Double
+		IL_0986: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject::__js_call__(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope, object, object)
+		IL_098b: stloc.s 13
+		IL_098d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0992: stloc.s 16
+		IL_0994: volatile.
+		IL_0996: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_099b: brfalse IL_09b1
 
-		IL_09a9: ldloc.s 12
-		IL_09ab: ldstr "add"
-		IL_09b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09b5: br IL_09d0
+		IL_09a0: ldloc.s 12
+		IL_09a2: ldstr "add"
+		IL_09a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09ac: br IL_09c7
 
-		IL_09ba: ldloc.s 12
-		IL_09bc: ldstr "add"
-		IL_09c1: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:207"
-		IL_09c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_09cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09b1: ldloc.s 12
+		IL_09b3: ldstr "add"
+		IL_09b8: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:207"
+		IL_09bd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_09c2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_09d0: stloc.s 22
-		IL_09d2: volatile.
-		IL_09d4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_09d9: brfalse IL_09ef
+		IL_09c7: stloc.s 22
+		IL_09c9: volatile.
+		IL_09cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_09d0: brfalse IL_09e6
 
-		IL_09de: ldloc.s 13
-		IL_09e0: ldstr "add"
-		IL_09e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_09ea: br IL_0a05
+		IL_09d5: ldloc.s 13
+		IL_09d7: ldstr "add"
+		IL_09dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_09e1: br IL_09fc
 
-		IL_09ef: ldloc.s 13
-		IL_09f1: ldstr "add"
-		IL_09f6: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:209"
-		IL_09fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_0a00: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_09e6: ldloc.s 13
+		IL_09e8: ldstr "add"
+		IL_09ed: ldstr "ObjectLiteral_GeneratedMethodFunctionObjects:Modules.ObjectLiteral_GeneratedMethodFunctionObjects:__js_module_init__:209"
+		IL_09f2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_09f7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0a05: stloc.s 21
-		IL_0a07: ldloc.s 22
-		IL_0a09: ldloc.s 21
-		IL_0a0b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-		IL_0a10: stloc.s 23
-		IL_0a12: ldloc.s 23
-		IL_0a14: box [System.Runtime]System.Boolean
-		IL_0a19: stloc.s 26
-		IL_0a1b: ldloc.s 16
-		IL_0a1d: ldstr "identity"
-		IL_0a22: ldloc.s 26
-		IL_0a24: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0a29: pop
-		IL_0a2a: ldnull
-		IL_0a2b: stloc.s 14
-		IL_0a2d: ret
+		IL_09fc: stloc.s 21
+		IL_09fe: ldloc.s 22
+		IL_0a00: ldloc.s 21
+		IL_0a02: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+		IL_0a07: stloc.s 23
+		IL_0a09: ldloc.s 23
+		IL_0a0b: box [System.Runtime]System.Boolean
+		IL_0a10: stloc.s 26
+		IL_0a12: ldloc.s 16
+		IL_0a14: ldstr "identity"
+		IL_0a19: ldloc.s 26
+		IL_0a1b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0a20: pop
+		IL_0a21: ldnull
+		IL_0a22: stloc.s 14
+		IL_0a24: ret
 	} // end of method ObjectLiteral_GeneratedMethodFunctionObjects::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_GeneratedMethodFunctionObjects

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
@@ -287,7 +287,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 306 (0x132)
+		// Code size: 307 (0x133)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InlinePropertyInit/Scope,
@@ -387,15 +387,16 @@
 		IL_0114: nop
 		IL_0115: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_011a: stloc.3
-		IL_011b: ldloc.1
-		IL_011c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0126: stloc.s 5
-		IL_0128: ldloc.3
-		IL_0129: ldloc.s 5
-		IL_012b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0130: pop
-		IL_0131: ret
+		IL_011b: ldloc.0
+		IL_011c: castclass Modules.ObjectLiteral_InlinePropertyInit/Scope
+		IL_0121: ldnull
+		IL_0122: call object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
+		IL_0127: stloc.s 5
+		IL_0129: ldloc.3
+		IL_012a: ldloc.s 5
+		IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0131: pop
+		IL_0132: ret
 	} // end of method ObjectLiteral_InlinePropertyInit::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_InlinePropertyInit

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DynamicInlineCache_Invalidation.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DynamicInlineCache_Invalidation.verified.txt
@@ -2678,7 +2678,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2697 (0xa89)
+		// Code size: 2534 (0x9e6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_DynamicInlineCache_Invalidation/Scope,
@@ -2855,633 +2855,647 @@
 			IL_0130: ldloc.s 25
 			IL_0132: ldc.r8 3
 			IL_013b: clt
-			IL_013d: brfalse IL_0171
+			IL_013d: brfalse IL_0167
 
-			IL_0142: ldloc.1
-			IL_0143: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0148: ldloc.s 7
-			IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_014f: pop
-			IL_0150: ldloc.2
-			IL_0151: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0156: ldloc.s 7
-			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_015d: pop
-			IL_015e: ldloc.s 8
-			IL_0160: ldc.r8 1
-			IL_0169: add
-			IL_016a: stloc.s 8
-			IL_016c: br IL_012c
+			IL_0142: ldnull
+			IL_0143: ldloc.s 7
+			IL_0145: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+			IL_014a: pop
+			IL_014b: ldnull
+			IL_014c: ldloc.s 7
+			IL_014e: call object Modules.Object_DynamicInlineCache_Invalidation/'call'::__js_call__(object, object)
+			IL_0153: pop
+			IL_0154: ldloc.s 8
+			IL_0156: ldc.r8 1
+			IL_015f: add
+			IL_0160: stloc.s 8
+			IL_0162: br IL_012c
 		// end loop
 
-		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0176: stloc.s 26
-		IL_0178: ldloc.1
-		IL_0179: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_017e: ldloc.s 7
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0185: stloc.s 27
-		IL_0187: ldloc.s 26
-		IL_0189: ldloc.s 27
-		IL_018b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0190: pop
-		IL_0191: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0196: stloc.s 26
-		IL_0198: ldloc.2
-		IL_0199: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_019e: ldloc.s 7
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01a5: stloc.s 27
-		IL_01a7: ldloc.s 26
-		IL_01a9: ldloc.s 27
-		IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b0: pop
-		IL_01b1: ldloc.s 7
-		IL_01b3: ldstr "value"
-		IL_01b8: ldstr "own"
-		IL_01bd: ldc.i4.1
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_01c3: pop
-		IL_01c4: ldc.i4.1
-		IL_01c5: newarr [System.Runtime]System.Object
-		IL_01ca: dup
-		IL_01cb: ldc.i4.0
-		IL_01cc: ldloc.0
-		IL_01cd: stelem.ref
-		IL_01ce: stloc.s 22
-		IL_01d0: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L41C18/FunctionObject::.ctor()
-		IL_01d5: ldc.i4.0
-		IL_01d6: conv.r8
-		IL_01d7: ldstr ""
-		IL_01dc: ldc.i4.0
-		IL_01dd: ldc.i4.0
-		IL_01de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L41C18/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01e3: stloc.s 28
-		IL_01e5: ldloc.s 7
-		IL_01e7: ldstr "method"
-		IL_01ec: ldloc.s 28
-		IL_01ee: ldc.i4.1
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_01f4: pop
-		IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01fa: stloc.s 26
-		IL_01fc: ldloc.1
-		IL_01fd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0202: ldloc.s 7
-		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0209: stloc.s 27
-		IL_020b: ldloc.s 26
-		IL_020d: ldloc.s 27
-		IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0214: pop
-		IL_0215: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021a: stloc.s 26
-		IL_021c: ldloc.2
-		IL_021d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0222: ldloc.s 7
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0229: stloc.s 27
-		IL_022b: ldloc.s 26
-		IL_022d: ldloc.s 27
-		IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0234: pop
-		IL_0235: ldloc.s 7
-		IL_0237: ldstr "value"
-		IL_023c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_0241: stloc.s 29
-		IL_0243: ldloc.s 7
-		IL_0245: ldstr "method"
-		IL_024a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_024f: stloc.s 29
-		IL_0251: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0256: stloc.s 26
-		IL_0258: ldloc.1
-		IL_0259: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_025e: ldloc.s 7
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0265: stloc.s 27
-		IL_0267: ldloc.s 26
-		IL_0269: ldloc.s 27
-		IL_026b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0270: pop
-		IL_0271: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0276: stloc.s 26
-		IL_0278: ldloc.2
-		IL_0279: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_027e: ldloc.s 7
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0285: stloc.s 27
-		IL_0287: ldloc.s 26
-		IL_0289: ldloc.s 27
-		IL_028b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0290: pop
-		IL_0291: ldloc.0
-		IL_0292: ldc.r8 0.0
-		IL_029b: box [System.Runtime]System.Double
-		IL_02a0: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope::valueGetterCalls
-		IL_02a5: ldloc.0
-		IL_02a6: ldc.r8 0.0
-		IL_02af: box [System.Runtime]System.Double
-		IL_02b4: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope::methodGetterCalls
-		IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02be: stloc.s 23
-		IL_02c0: ldloc.s 23
-		IL_02c2: ldstr "configurable"
-		IL_02c7: ldc.i4.1
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
-		IL_02cd: pop
-		IL_02ce: ldc.i4.1
-		IL_02cf: newarr [System.Runtime]System.Object
-		IL_02d4: dup
-		IL_02d5: ldc.i4.0
-		IL_02d6: ldloc.0
-		IL_02d7: stelem.ref
-		IL_02d8: stloc.s 22
-		IL_02da: ldloc.s 22
-		IL_02dc: ldc.i4.0
-		IL_02dd: ldelem.ref
-		IL_02de: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope
-		IL_02e3: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L56C7/FunctionObject::.ctor(class Modules.Object_DynamicInlineCache_Invalidation/Scope)
-		IL_02e8: ldc.i4.0
-		IL_02e9: conv.r8
-		IL_02ea: ldstr ""
-		IL_02ef: ldc.i4.0
-		IL_02f0: ldc.i4.0
-		IL_02f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L56C7/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L56C7/FunctionObject>(!!0)
-		IL_02fb: stloc.s 30
-		IL_02fd: ldloc.s 23
-		IL_02ff: ldstr "get"
-		IL_0304: ldloc.s 30
-		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_030b: pop
-		IL_030c: ldloc.s 7
-		IL_030e: ldstr "value"
-		IL_0313: ldloc.s 23
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_031a: pop
-		IL_031b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0320: stloc.s 23
-		IL_0322: ldloc.s 23
-		IL_0324: ldstr "configurable"
-		IL_0329: ldc.i4.1
-		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
-		IL_032f: pop
-		IL_0330: ldc.i4.1
-		IL_0331: newarr [System.Runtime]System.Object
-		IL_0336: dup
-		IL_0337: ldc.i4.0
-		IL_0338: ldloc.0
-		IL_0339: stelem.ref
-		IL_033a: stloc.s 22
-		IL_033c: ldloc.s 22
-		IL_033e: ldc.i4.0
-		IL_033f: ldelem.ref
-		IL_0340: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope
-		IL_0345: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L63C7/FunctionObject::.ctor(class Modules.Object_DynamicInlineCache_Invalidation/Scope)
-		IL_034a: ldc.i4.0
-		IL_034b: conv.r8
-		IL_034c: ldstr ""
-		IL_0351: ldc.i4.0
-		IL_0352: ldc.i4.0
-		IL_0353: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L63C7/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0358: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L63C7/FunctionObject>(!!0)
-		IL_035d: stloc.s 31
-		IL_035f: ldloc.s 23
-		IL_0361: ldstr "get"
-		IL_0366: ldloc.s 31
-		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_036d: pop
-		IL_036e: ldloc.s 7
-		IL_0370: ldstr "method"
-		IL_0375: ldloc.s 23
-		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_037c: pop
-		IL_037d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0382: stloc.s 26
-		IL_0384: ldloc.1
-		IL_0385: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_038a: ldloc.s 7
-		IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0391: stloc.s 27
-		IL_0393: ldloc.s 26
-		IL_0395: ldloc.s 27
-		IL_0397: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_039c: pop
-		IL_039d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03a2: stloc.s 26
-		IL_03a4: ldloc.1
-		IL_03a5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03aa: ldloc.s 7
-		IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03b1: stloc.s 27
-		IL_03b3: ldloc.s 26
-		IL_03b5: ldloc.s 27
-		IL_03b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03bc: pop
-		IL_03bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03c2: stloc.s 26
-		IL_03c4: ldloc.2
-		IL_03c5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03ca: ldloc.s 7
-		IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03d1: stloc.s 27
-		IL_03d3: ldloc.s 26
-		IL_03d5: ldloc.s 27
-		IL_03d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03dc: pop
-		IL_03dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03e2: stloc.s 26
-		IL_03e4: ldloc.2
-		IL_03e5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03ea: ldloc.s 7
-		IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03f1: stloc.s 27
-		IL_03f3: ldloc.s 26
-		IL_03f5: ldloc.s 27
-		IL_03f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03fc: pop
-		IL_03fd: ldloc.s 7
-		IL_03ff: ldstr "value"
-		IL_0404: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_0409: stloc.s 29
-		IL_040b: ldloc.s 7
-		IL_040d: ldstr "method"
-		IL_0412: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_0417: stloc.s 29
-		IL_0419: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_041e: stloc.s 23
-		IL_0420: ldloc.s 23
-		IL_0422: ldstr "value"
-		IL_0427: ldstr "prototype:second"
-		IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0431: pop
-		IL_0432: ldc.i4.1
-		IL_0433: newarr [System.Runtime]System.Object
-		IL_0438: dup
-		IL_0439: ldc.i4.0
-		IL_043a: ldloc.0
-		IL_043b: stelem.ref
-		IL_043c: stloc.s 22
-		IL_043e: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_secondPrototype/FunctionObject::.ctor()
-		IL_0443: ldc.i4.0
-		IL_0444: conv.r8
-		IL_0445: ldstr ""
-		IL_044a: ldc.i4.0
-		IL_044b: ldc.i4.0
-		IL_044c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_secondPrototype/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0451: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_secondPrototype/FunctionObject>(!!0)
-		IL_0456: stloc.s 32
-		IL_0458: ldloc.s 23
-		IL_045a: ldstr "method"
-		IL_045f: ldloc.s 32
-		IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0466: pop
-		IL_0467: ldloc.s 23
-		IL_0469: stloc.s 9
-		IL_046b: ldloc.s 7
-		IL_046d: ldloc.s 9
-		IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_0474: pop
-		IL_0475: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_047a: stloc.s 26
-		IL_047c: ldloc.1
-		IL_047d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0482: ldloc.s 7
-		IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0489: stloc.s 27
-		IL_048b: ldloc.s 26
-		IL_048d: ldloc.s 27
-		IL_048f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0494: pop
-		IL_0495: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_049a: stloc.s 26
-		IL_049c: ldloc.2
-		IL_049d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04a2: ldloc.s 7
-		IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_04a9: stloc.s 27
-		IL_04ab: ldloc.s 26
-		IL_04ad: ldloc.s 27
-		IL_04af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04b4: pop
-		IL_04b5: ldloc.0
-		IL_04b6: ldc.r8 0.0
-		IL_04bf: box [System.Runtime]System.Double
-		IL_04c4: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope::proxyGetCalls
-		IL_04c9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04ce: stloc.s 23
-		IL_04d0: ldc.i4.1
-		IL_04d1: newarr [System.Runtime]System.Object
-		IL_04d6: dup
-		IL_04d7: ldc.i4.0
-		IL_04d8: ldloc.0
-		IL_04d9: stelem.ref
-		IL_04da: stloc.s 22
-		IL_04dc: ldloc.s 22
-		IL_04de: ldc.i4.0
-		IL_04df: ldelem.ref
-		IL_04e0: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope
-		IL_04e5: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_proxy/FunctionObject::.ctor(class Modules.Object_DynamicInlineCache_Invalidation/Scope)
-		IL_04ea: ldc.i4.2
-		IL_04eb: conv.r8
-		IL_04ec: ldstr ""
-		IL_04f1: ldc.i4.0
-		IL_04f2: ldc.i4.0
-		IL_04f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_proxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_proxy/FunctionObject>(!!0)
-		IL_04fd: stloc.s 33
-		IL_04ff: ldloc.s 23
-		IL_0501: ldstr "get"
-		IL_0506: ldloc.s 33
-		IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_050d: pop
-		IL_050e: ldloc.s 7
-		IL_0510: ldloc.s 23
-		IL_0512: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0517: stloc.s 10
-		IL_0519: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_051e: stloc.s 26
-		IL_0520: ldloc.1
-		IL_0521: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0526: ldloc.s 10
-		IL_0528: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_052d: stloc.s 27
-		IL_052f: ldloc.s 26
-		IL_0531: ldloc.s 27
-		IL_0533: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0538: pop
-		IL_0539: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_053e: stloc.s 26
-		IL_0540: ldloc.1
-		IL_0541: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0546: ldloc.s 10
-		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_054d: stloc.s 27
-		IL_054f: ldloc.s 26
-		IL_0551: ldloc.s 27
-		IL_0553: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0558: pop
-		IL_0559: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_055e: stloc.s 26
-		IL_0560: ldloc.2
-		IL_0561: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0566: ldloc.s 10
-		IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_056d: stloc.s 27
-		IL_056f: ldloc.s 26
-		IL_0571: ldloc.s 27
-		IL_0573: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0578: pop
-		IL_0579: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_057e: stloc.s 26
-		IL_0580: ldloc.0
-		IL_0581: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope::proxyGetCalls
-		IL_0586: stloc.s 27
-		IL_0588: ldloc.s 26
-		IL_058a: ldloc.s 27
-		IL_058c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0591: pop
-		IL_0592: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0597: stloc.s 26
-		IL_0599: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_059e: stloc.s 22
-		IL_05a0: ldloc.3
-		IL_05a1: ldloc.s 22
-		IL_05a3: ldstr "abc"
-		IL_05a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_05ad: stloc.s 27
-		IL_05af: ldloc.s 26
-		IL_05b1: ldloc.s 27
-		IL_05b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05b8: pop
-		IL_05b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05be: stloc.s 26
-		IL_05c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05c5: stloc.s 22
-		IL_05c7: ldc.i4.2
-		IL_05c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_05cd: dup
-		IL_05ce: ldc.r8 1
-		IL_05d7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_05dc: dup
-		IL_05dd: ldc.r8 2
-		IL_05e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_05eb: stloc.s 34
-		IL_05ed: ldloc.3
-		IL_05ee: ldloc.s 22
-		IL_05f0: ldloc.s 34
-		IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_05f7: stloc.s 27
-		IL_05f9: ldloc.s 26
-		IL_05fb: ldloc.s 27
-		IL_05fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0602: pop
-		IL_0603: ldc.i4.0
-		IL_0604: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0609: stloc.s 11
-		IL_060b: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::.ctor()
-		IL_0610: stloc.s 12
-		IL_0612: ldloc.s 12
-		IL_0614: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
-		IL_0619: ldc.r8 0.0
-		IL_0622: box [System.Runtime]System.Double
-		IL_0627: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
-		// loop start (head: IL_062c)
-			IL_062c: ldloc.s 12
-			IL_062e: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
-			IL_0633: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
-			IL_0638: stloc.s 27
-			IL_063a: ldloc.s 27
-			IL_063c: ldc.r8 5
-			IL_0645: box [System.Runtime]System.Double
-			IL_064a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
-			IL_064f: stloc.s 29
-			IL_0651: ldloc.s 29
-			IL_0653: brfalse IL_0788
+		IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016c: stloc.s 26
+		IL_016e: ldnull
+		IL_016f: ldloc.s 7
+		IL_0171: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+		IL_0176: stloc.s 27
+		IL_0178: ldloc.s 26
+		IL_017a: ldloc.s 27
+		IL_017c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0181: pop
+		IL_0182: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0187: stloc.s 26
+		IL_0189: ldnull
+		IL_018a: ldloc.s 7
+		IL_018c: call object Modules.Object_DynamicInlineCache_Invalidation/'call'::__js_call__(object, object)
+		IL_0191: stloc.s 27
+		IL_0193: ldloc.s 26
+		IL_0195: ldloc.s 27
+		IL_0197: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019c: pop
+		IL_019d: ldloc.s 7
+		IL_019f: ldstr "value"
+		IL_01a4: ldstr "own"
+		IL_01a9: ldc.i4.1
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_01af: pop
+		IL_01b0: ldc.i4.1
+		IL_01b1: newarr [System.Runtime]System.Object
+		IL_01b6: dup
+		IL_01b7: ldc.i4.0
+		IL_01b8: ldloc.0
+		IL_01b9: stelem.ref
+		IL_01ba: stloc.s 22
+		IL_01bc: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L41C18/FunctionObject::.ctor()
+		IL_01c1: ldc.i4.0
+		IL_01c2: conv.r8
+		IL_01c3: ldstr ""
+		IL_01c8: ldc.i4.0
+		IL_01c9: ldc.i4.0
+		IL_01ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L41C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01cf: stloc.s 28
+		IL_01d1: ldloc.s 7
+		IL_01d3: ldstr "method"
+		IL_01d8: ldloc.s 28
+		IL_01da: ldc.i4.1
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_01e0: pop
+		IL_01e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e6: stloc.s 26
+		IL_01e8: ldnull
+		IL_01e9: ldloc.s 7
+		IL_01eb: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+		IL_01f0: stloc.s 27
+		IL_01f2: ldloc.s 26
+		IL_01f4: ldloc.s 27
+		IL_01f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01fb: pop
+		IL_01fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0201: stloc.s 26
+		IL_0203: ldnull
+		IL_0204: ldloc.s 7
+		IL_0206: call object Modules.Object_DynamicInlineCache_Invalidation/'call'::__js_call__(object, object)
+		IL_020b: stloc.s 27
+		IL_020d: ldloc.s 26
+		IL_020f: ldloc.s 27
+		IL_0211: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0216: pop
+		IL_0217: ldloc.s 7
+		IL_0219: ldstr "value"
+		IL_021e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_0223: stloc.s 29
+		IL_0225: ldloc.s 7
+		IL_0227: ldstr "method"
+		IL_022c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_0231: stloc.s 29
+		IL_0233: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0238: stloc.s 26
+		IL_023a: ldnull
+		IL_023b: ldloc.s 7
+		IL_023d: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+		IL_0242: stloc.s 27
+		IL_0244: ldloc.s 26
+		IL_0246: ldloc.s 27
+		IL_0248: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_024d: pop
+		IL_024e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0253: stloc.s 26
+		IL_0255: ldnull
+		IL_0256: ldloc.s 7
+		IL_0258: call object Modules.Object_DynamicInlineCache_Invalidation/'call'::__js_call__(object, object)
+		IL_025d: stloc.s 27
+		IL_025f: ldloc.s 26
+		IL_0261: ldloc.s 27
+		IL_0263: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0268: pop
+		IL_0269: ldloc.0
+		IL_026a: ldc.r8 0.0
+		IL_0273: box [System.Runtime]System.Double
+		IL_0278: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope::valueGetterCalls
+		IL_027d: ldloc.0
+		IL_027e: ldc.r8 0.0
+		IL_0287: box [System.Runtime]System.Double
+		IL_028c: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope::methodGetterCalls
+		IL_0291: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0296: stloc.s 23
+		IL_0298: ldloc.s 23
+		IL_029a: ldstr "configurable"
+		IL_029f: ldc.i4.1
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+		IL_02a5: pop
+		IL_02a6: ldc.i4.1
+		IL_02a7: newarr [System.Runtime]System.Object
+		IL_02ac: dup
+		IL_02ad: ldc.i4.0
+		IL_02ae: ldloc.0
+		IL_02af: stelem.ref
+		IL_02b0: stloc.s 22
+		IL_02b2: ldloc.s 22
+		IL_02b4: ldc.i4.0
+		IL_02b5: ldelem.ref
+		IL_02b6: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope
+		IL_02bb: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L56C7/FunctionObject::.ctor(class Modules.Object_DynamicInlineCache_Invalidation/Scope)
+		IL_02c0: ldc.i4.0
+		IL_02c1: conv.r8
+		IL_02c2: ldstr ""
+		IL_02c7: ldc.i4.0
+		IL_02c8: ldc.i4.0
+		IL_02c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L56C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L56C7/FunctionObject>(!!0)
+		IL_02d3: stloc.s 30
+		IL_02d5: ldloc.s 23
+		IL_02d7: ldstr "get"
+		IL_02dc: ldloc.s 30
+		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_02e3: pop
+		IL_02e4: ldloc.s 7
+		IL_02e6: ldstr "value"
+		IL_02eb: ldloc.s 23
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_02f2: pop
+		IL_02f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02f8: stloc.s 23
+		IL_02fa: ldloc.s 23
+		IL_02fc: ldstr "configurable"
+		IL_0301: ldc.i4.1
+		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+		IL_0307: pop
+		IL_0308: ldc.i4.1
+		IL_0309: newarr [System.Runtime]System.Object
+		IL_030e: dup
+		IL_030f: ldc.i4.0
+		IL_0310: ldloc.0
+		IL_0311: stelem.ref
+		IL_0312: stloc.s 22
+		IL_0314: ldloc.s 22
+		IL_0316: ldc.i4.0
+		IL_0317: ldelem.ref
+		IL_0318: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope
+		IL_031d: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L63C7/FunctionObject::.ctor(class Modules.Object_DynamicInlineCache_Invalidation/Scope)
+		IL_0322: ldc.i4.0
+		IL_0323: conv.r8
+		IL_0324: ldstr ""
+		IL_0329: ldc.i4.0
+		IL_032a: ldc.i4.0
+		IL_032b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L63C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L63C7/FunctionObject>(!!0)
+		IL_0335: stloc.s 31
+		IL_0337: ldloc.s 23
+		IL_0339: ldstr "get"
+		IL_033e: ldloc.s 31
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0345: pop
+		IL_0346: ldloc.s 7
+		IL_0348: ldstr "method"
+		IL_034d: ldloc.s 23
+		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0354: pop
+		IL_0355: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_035a: stloc.s 26
+		IL_035c: ldnull
+		IL_035d: ldloc.s 7
+		IL_035f: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+		IL_0364: stloc.s 27
+		IL_0366: ldloc.s 26
+		IL_0368: ldloc.s 27
+		IL_036a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_036f: pop
+		IL_0370: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0375: stloc.s 26
+		IL_0377: ldnull
+		IL_0378: ldloc.s 7
+		IL_037a: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+		IL_037f: stloc.s 27
+		IL_0381: ldloc.s 26
+		IL_0383: ldloc.s 27
+		IL_0385: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_038a: pop
+		IL_038b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0390: stloc.s 26
+		IL_0392: ldnull
+		IL_0393: ldloc.s 7
+		IL_0395: call object Modules.Object_DynamicInlineCache_Invalidation/'call'::__js_call__(object, object)
+		IL_039a: stloc.s 27
+		IL_039c: ldloc.s 26
+		IL_039e: ldloc.s 27
+		IL_03a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03a5: pop
+		IL_03a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03ab: stloc.s 26
+		IL_03ad: ldnull
+		IL_03ae: ldloc.s 7
+		IL_03b0: call object Modules.Object_DynamicInlineCache_Invalidation/'call'::__js_call__(object, object)
+		IL_03b5: stloc.s 27
+		IL_03b7: ldloc.s 26
+		IL_03b9: ldloc.s 27
+		IL_03bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03c0: pop
+		IL_03c1: ldloc.s 7
+		IL_03c3: ldstr "value"
+		IL_03c8: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_03cd: stloc.s 29
+		IL_03cf: ldloc.s 7
+		IL_03d1: ldstr "method"
+		IL_03d6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_03db: stloc.s 29
+		IL_03dd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03e2: stloc.s 23
+		IL_03e4: ldloc.s 23
+		IL_03e6: ldstr "value"
+		IL_03eb: ldstr "prototype:second"
+		IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_03f5: pop
+		IL_03f6: ldc.i4.1
+		IL_03f7: newarr [System.Runtime]System.Object
+		IL_03fc: dup
+		IL_03fd: ldc.i4.0
+		IL_03fe: ldloc.0
+		IL_03ff: stelem.ref
+		IL_0400: stloc.s 22
+		IL_0402: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_secondPrototype/FunctionObject::.ctor()
+		IL_0407: ldc.i4.0
+		IL_0408: conv.r8
+		IL_0409: ldstr ""
+		IL_040e: ldc.i4.0
+		IL_040f: ldc.i4.0
+		IL_0410: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_secondPrototype/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0415: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_secondPrototype/FunctionObject>(!!0)
+		IL_041a: stloc.s 32
+		IL_041c: ldloc.s 23
+		IL_041e: ldstr "method"
+		IL_0423: ldloc.s 32
+		IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_042a: pop
+		IL_042b: ldloc.s 23
+		IL_042d: stloc.s 9
+		IL_042f: ldloc.s 7
+		IL_0431: ldloc.s 9
+		IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0438: pop
+		IL_0439: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_043e: stloc.s 26
+		IL_0440: ldnull
+		IL_0441: ldloc.s 7
+		IL_0443: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+		IL_0448: stloc.s 27
+		IL_044a: ldloc.s 26
+		IL_044c: ldloc.s 27
+		IL_044e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0453: pop
+		IL_0454: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0459: stloc.s 26
+		IL_045b: ldnull
+		IL_045c: ldloc.s 7
+		IL_045e: call object Modules.Object_DynamicInlineCache_Invalidation/'call'::__js_call__(object, object)
+		IL_0463: stloc.s 27
+		IL_0465: ldloc.s 26
+		IL_0467: ldloc.s 27
+		IL_0469: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_046e: pop
+		IL_046f: ldloc.0
+		IL_0470: ldc.r8 0.0
+		IL_0479: box [System.Runtime]System.Double
+		IL_047e: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope::proxyGetCalls
+		IL_0483: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0488: stloc.s 23
+		IL_048a: ldc.i4.1
+		IL_048b: newarr [System.Runtime]System.Object
+		IL_0490: dup
+		IL_0491: ldc.i4.0
+		IL_0492: ldloc.0
+		IL_0493: stelem.ref
+		IL_0494: stloc.s 22
+		IL_0496: ldloc.s 22
+		IL_0498: ldc.i4.0
+		IL_0499: ldelem.ref
+		IL_049a: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope
+		IL_049f: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_proxy/FunctionObject::.ctor(class Modules.Object_DynamicInlineCache_Invalidation/Scope)
+		IL_04a4: ldc.i4.2
+		IL_04a5: conv.r8
+		IL_04a6: ldstr ""
+		IL_04ab: ldc.i4.0
+		IL_04ac: ldc.i4.0
+		IL_04ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_proxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_proxy/FunctionObject>(!!0)
+		IL_04b7: stloc.s 33
+		IL_04b9: ldloc.s 23
+		IL_04bb: ldstr "get"
+		IL_04c0: ldloc.s 33
+		IL_04c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_04c7: pop
+		IL_04c8: ldloc.s 7
+		IL_04ca: ldloc.s 23
+		IL_04cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_04d1: stloc.s 10
+		IL_04d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04d8: stloc.s 26
+		IL_04da: ldnull
+		IL_04db: ldloc.s 10
+		IL_04dd: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+		IL_04e2: stloc.s 27
+		IL_04e4: ldloc.s 26
+		IL_04e6: ldloc.s 27
+		IL_04e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04ed: pop
+		IL_04ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04f3: stloc.s 26
+		IL_04f5: ldnull
+		IL_04f6: ldloc.s 10
+		IL_04f8: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+		IL_04fd: stloc.s 27
+		IL_04ff: ldloc.s 26
+		IL_0501: ldloc.s 27
+		IL_0503: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0508: pop
+		IL_0509: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_050e: stloc.s 26
+		IL_0510: ldnull
+		IL_0511: ldloc.s 10
+		IL_0513: call object Modules.Object_DynamicInlineCache_Invalidation/'call'::__js_call__(object, object)
+		IL_0518: stloc.s 27
+		IL_051a: ldloc.s 26
+		IL_051c: ldloc.s 27
+		IL_051e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0523: pop
+		IL_0524: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0529: stloc.s 26
+		IL_052b: ldloc.0
+		IL_052c: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope::proxyGetCalls
+		IL_0531: stloc.s 27
+		IL_0533: ldloc.s 26
+		IL_0535: ldloc.s 27
+		IL_0537: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_053c: pop
+		IL_053d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0542: stloc.s 26
+		IL_0544: ldnull
+		IL_0545: ldstr "abc"
+		IL_054a: call object Modules.Object_DynamicInlineCache_Invalidation/readLength::__js_call__(object, object)
+		IL_054f: stloc.s 27
+		IL_0551: ldloc.s 26
+		IL_0553: ldloc.s 27
+		IL_0555: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_055a: pop
+		IL_055b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0560: stloc.s 26
+		IL_0562: ldc.i4.2
+		IL_0563: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0568: dup
+		IL_0569: ldc.r8 1
+		IL_0572: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0577: dup
+		IL_0578: ldc.r8 2
+		IL_0581: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0586: stloc.s 34
+		IL_0588: ldnull
+		IL_0589: ldloc.s 34
+		IL_058b: call object Modules.Object_DynamicInlineCache_Invalidation/readLength::__js_call__(object, object)
+		IL_0590: stloc.s 27
+		IL_0592: ldloc.s 26
+		IL_0594: ldloc.s 27
+		IL_0596: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_059b: pop
+		IL_059c: ldc.i4.0
+		IL_059d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_05a2: stloc.s 11
+		IL_05a4: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::.ctor()
+		IL_05a9: stloc.s 12
+		IL_05ab: ldloc.s 12
+		IL_05ad: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
+		IL_05b2: ldc.r8 0.0
+		IL_05bb: box [System.Runtime]System.Double
+		IL_05c0: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
+		// loop start (head: IL_05c5)
+			IL_05c5: ldloc.s 12
+			IL_05c7: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
+			IL_05cc: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
+			IL_05d1: stloc.s 27
+			IL_05d3: ldloc.s 27
+			IL_05d5: ldc.r8 5
+			IL_05de: box [System.Runtime]System.Double
+			IL_05e3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::LessThan(object, object)
+			IL_05e8: stloc.s 29
+			IL_05ea: ldloc.s 29
+			IL_05ec: brfalse IL_0715
 
-			IL_0658: ldloc.s 12
-			IL_065a: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
-			IL_065f: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
-			IL_0664: stloc.s 27
-			IL_0666: ldstr "mega:value:"
-			IL_066b: ldloc.s 27
-			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0672: stloc.s 35
-			IL_0674: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0679: stloc.s 23
-			IL_067b: ldloc.s 23
-			IL_067d: ldstr "value"
-			IL_0682: ldloc.s 35
-			IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0689: pop
-			IL_068a: ldc.i4.2
-			IL_068b: newarr [System.Runtime]System.Object
-			IL_0690: dup
-			IL_0691: ldc.i4.0
-			IL_0692: ldloc.0
-			IL_0693: stelem.ref
-			IL_0694: dup
-			IL_0695: ldc.i4.1
-			IL_0696: ldloc.s 12
-			IL_0698: stelem.ref
-			IL_0699: stloc.s 22
-			IL_069b: ldloc.s 22
-			IL_069d: ldc.i4.0
-			IL_069e: ldelem.ref
-			IL_069f: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope
-			IL_06a4: ldloc.s 22
-			IL_06a6: ldc.i4.1
-			IL_06a7: ldelem.ref
-			IL_06a8: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
-			IL_06ad: ldloc.s 22
-			IL_06af: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_item/FunctionObject::.ctor(class Modules.Object_DynamicInlineCache_Invalidation/Scope, class Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5, object[])
-			IL_06b4: ldc.i4.0
-			IL_06b5: conv.r8
-			IL_06b6: ldstr ""
-			IL_06bb: ldc.i4.0
-			IL_06bc: ldc.i4.0
-			IL_06bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_item/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_06c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_item/FunctionObject>(!!0)
-			IL_06c7: stloc.s 36
-			IL_06c9: ldloc.s 23
-			IL_06cb: ldstr "method"
-			IL_06d0: ldloc.s 36
-			IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_06d7: pop
-			IL_06d8: ldloc.s 23
-			IL_06da: stloc.s 13
-			IL_06dc: ldloc.s 11
-			IL_06de: ldloc.s 13
-			IL_06e0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_06e5: pop
-			IL_06e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06eb: stloc.s 26
-			IL_06ed: ldloc.s 4
-			IL_06ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_06f4: ldloc.s 13
-			IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_06fb: stloc.s 27
-			IL_06fd: ldloc.s 26
-			IL_06ff: ldloc.s 27
-			IL_0701: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0706: pop
-			IL_0707: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_070c: stloc.s 26
-			IL_070e: ldloc.s 5
-			IL_0710: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0715: ldloc.s 13
-			IL_0717: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_071c: stloc.s 27
-			IL_071e: ldloc.s 26
-			IL_0720: ldloc.s 27
-			IL_0722: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0727: pop
-			IL_0728: ldloc.s 12
-			IL_072a: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
-			IL_072f: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
-			IL_0734: stloc.s 27
-			IL_0736: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::.ctor()
-			IL_073b: stloc.s 37
-			IL_073d: ldloc.s 37
-			IL_073f: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
-			IL_0744: ldloc.s 27
-			IL_0746: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
-			IL_074b: ldloc.s 37
-			IL_074d: stloc.s 12
-			IL_074f: ldloc.s 12
-			IL_0751: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
-			IL_0756: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
-			IL_075b: stloc.s 27
-			IL_075d: ldloc.s 27
-			IL_075f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
-			IL_0764: stloc.s 27
-			IL_0766: ldloc.s 27
-			IL_0768: ldc.i4.1
-			IL_0769: box [System.Runtime]System.Boolean
-			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
-			IL_0773: stloc.s 27
-			IL_0775: ldloc.s 12
-			IL_0777: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
-			IL_077c: ldloc.s 27
-			IL_077e: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
-			IL_0783: br IL_062c
+			IL_05f1: ldloc.s 12
+			IL_05f3: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
+			IL_05f8: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
+			IL_05fd: stloc.s 27
+			IL_05ff: ldstr "mega:value:"
+			IL_0604: ldloc.s 27
+			IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_060b: stloc.s 35
+			IL_060d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0612: stloc.s 23
+			IL_0614: ldloc.s 23
+			IL_0616: ldstr "value"
+			IL_061b: ldloc.s 35
+			IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0622: pop
+			IL_0623: ldc.i4.2
+			IL_0624: newarr [System.Runtime]System.Object
+			IL_0629: dup
+			IL_062a: ldc.i4.0
+			IL_062b: ldloc.0
+			IL_062c: stelem.ref
+			IL_062d: dup
+			IL_062e: ldc.i4.1
+			IL_062f: ldloc.s 12
+			IL_0631: stelem.ref
+			IL_0632: stloc.s 22
+			IL_0634: ldloc.s 22
+			IL_0636: ldc.i4.0
+			IL_0637: ldelem.ref
+			IL_0638: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope
+			IL_063d: ldloc.s 22
+			IL_063f: ldc.i4.1
+			IL_0640: ldelem.ref
+			IL_0641: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
+			IL_0646: ldloc.s 22
+			IL_0648: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_item/FunctionObject::.ctor(class Modules.Object_DynamicInlineCache_Invalidation/Scope, class Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5, object[])
+			IL_064d: ldc.i4.0
+			IL_064e: conv.r8
+			IL_064f: ldstr ""
+			IL_0654: ldc.i4.0
+			IL_0655: ldc.i4.0
+			IL_0656: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_item/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_065b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_item/FunctionObject>(!!0)
+			IL_0660: stloc.s 36
+			IL_0662: ldloc.s 23
+			IL_0664: ldstr "method"
+			IL_0669: ldloc.s 36
+			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0670: pop
+			IL_0671: ldloc.s 23
+			IL_0673: stloc.s 13
+			IL_0675: ldloc.s 11
+			IL_0677: ldloc.s 13
+			IL_0679: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_067e: pop
+			IL_067f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0684: stloc.s 26
+			IL_0686: ldnull
+			IL_0687: ldloc.s 13
+			IL_0689: call object Modules.Object_DynamicInlineCache_Invalidation/readMegamorphic::__js_call__(object, object)
+			IL_068e: stloc.s 27
+			IL_0690: ldloc.s 26
+			IL_0692: ldloc.s 27
+			IL_0694: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0699: pop
+			IL_069a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_069f: stloc.s 26
+			IL_06a1: ldnull
+			IL_06a2: ldloc.s 13
+			IL_06a4: call object Modules.Object_DynamicInlineCache_Invalidation/callMegamorphic::__js_call__(object, object)
+			IL_06a9: stloc.s 27
+			IL_06ab: ldloc.s 26
+			IL_06ad: ldloc.s 27
+			IL_06af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06b4: pop
+			IL_06b5: ldloc.s 12
+			IL_06b7: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
+			IL_06bc: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
+			IL_06c1: stloc.s 27
+			IL_06c3: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::.ctor()
+			IL_06c8: stloc.s 37
+			IL_06ca: ldloc.s 37
+			IL_06cc: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
+			IL_06d1: ldloc.s 27
+			IL_06d3: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
+			IL_06d8: ldloc.s 37
+			IL_06da: stloc.s 12
+			IL_06dc: ldloc.s 12
+			IL_06de: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
+			IL_06e3: ldfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
+			IL_06e8: stloc.s 27
+			IL_06ea: ldloc.s 27
+			IL_06ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
+			IL_06f1: stloc.s 27
+			IL_06f3: ldloc.s 27
+			IL_06f5: ldc.i4.1
+			IL_06f6: box [System.Runtime]System.Boolean
+			IL_06fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
+			IL_0700: stloc.s 27
+			IL_0702: ldloc.s 12
+			IL_0704: castclass Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5
+			IL_0709: ldloc.s 27
+			IL_070b: stfld object Modules.Object_DynamicInlineCache_Invalidation/Scope_For_L108C5::index
+			IL_0710: br IL_05c5
 		// end loop
 
-		IL_0788: ldloc.s 11
-		IL_078a: ldc.r8 0.0
-		IL_0793: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0798: stloc.s 27
-		IL_079a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_079f: stloc.s 23
-		IL_07a1: ldloc.s 23
-		IL_07a3: ldstr "configurable"
-		IL_07a8: ldc.i4.1
-		IL_07a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
-		IL_07ae: pop
-		IL_07af: ldc.i4.1
-		IL_07b0: newarr [System.Runtime]System.Object
-		IL_07b5: dup
-		IL_07b6: ldc.i4.0
-		IL_07b7: ldloc.0
-		IL_07b8: stelem.ref
-		IL_07b9: stloc.s 22
-		IL_07bb: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L122C7/FunctionObject::.ctor()
-		IL_07c0: ldc.i4.0
-		IL_07c1: conv.r8
-		IL_07c2: ldstr ""
-		IL_07c7: ldc.i4.0
-		IL_07c8: ldc.i4.0
-		IL_07c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L122C7/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L122C7/FunctionObject>(!!0)
-		IL_07d3: stloc.s 38
-		IL_07d5: ldloc.s 23
-		IL_07d7: ldstr "get"
-		IL_07dc: ldloc.s 38
-		IL_07de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_07e3: pop
-		IL_07e4: ldloc.s 27
-		IL_07e6: ldstr "value"
-		IL_07eb: ldloc.s 23
-		IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_07f2: pop
-		IL_07f3: ldloc.s 11
-		IL_07f5: ldc.r8 0.0
-		IL_07fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0803: stloc.s 27
-		IL_0805: ldc.i4.1
-		IL_0806: newarr [System.Runtime]System.Object
-		IL_080b: dup
-		IL_080c: ldc.i4.0
-		IL_080d: ldloc.0
-		IL_080e: stelem.ref
-		IL_080f: stloc.s 22
-		IL_0811: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L126C33/FunctionObject::.ctor()
-		IL_0816: ldc.i4.0
-		IL_0817: conv.r8
-		IL_0818: ldstr ""
-		IL_081d: ldc.i4.0
-		IL_081e: ldc.i4.0
-		IL_081f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L126C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0824: stloc.s 39
-		IL_0826: ldloc.s 27
-		IL_0828: ldstr "method"
-		IL_082d: ldloc.s 39
-		IL_082f: ldc.i4.1
-		IL_0830: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0835: pop
-		IL_0836: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_083b: stloc.s 26
-		IL_083d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0842: stloc.s 22
-		IL_0844: ldloc.s 11
-		IL_0846: ldc.r8 0.0
-		IL_084f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0854: stloc.s 27
-		IL_0856: ldloc.s 4
-		IL_0858: ldloc.s 22
-		IL_085a: ldloc.s 27
-		IL_085c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0715: ldloc.s 11
+		IL_0717: ldc.r8 0.0
+		IL_0720: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0725: stloc.s 27
+		IL_0727: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_072c: stloc.s 23
+		IL_072e: ldloc.s 23
+		IL_0730: ldstr "configurable"
+		IL_0735: ldc.i4.1
+		IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+		IL_073b: pop
+		IL_073c: ldc.i4.1
+		IL_073d: newarr [System.Runtime]System.Object
+		IL_0742: dup
+		IL_0743: ldc.i4.0
+		IL_0744: ldloc.0
+		IL_0745: stelem.ref
+		IL_0746: stloc.s 22
+		IL_0748: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L122C7/FunctionObject::.ctor()
+		IL_074d: ldc.i4.0
+		IL_074e: conv.r8
+		IL_074f: ldstr ""
+		IL_0754: ldc.i4.0
+		IL_0755: ldc.i4.0
+		IL_0756: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L122C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_075b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L122C7/FunctionObject>(!!0)
+		IL_0760: stloc.s 38
+		IL_0762: ldloc.s 23
+		IL_0764: ldstr "get"
+		IL_0769: ldloc.s 38
+		IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0770: pop
+		IL_0771: ldloc.s 27
+		IL_0773: ldstr "value"
+		IL_0778: ldloc.s 23
+		IL_077a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_077f: pop
+		IL_0780: ldloc.s 11
+		IL_0782: ldc.r8 0.0
+		IL_078b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0790: stloc.s 27
+		IL_0792: ldc.i4.1
+		IL_0793: newarr [System.Runtime]System.Object
+		IL_0798: dup
+		IL_0799: ldc.i4.0
+		IL_079a: ldloc.0
+		IL_079b: stelem.ref
+		IL_079c: stloc.s 22
+		IL_079e: newobj instance void Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L126C33/FunctionObject::.ctor()
+		IL_07a3: ldc.i4.0
+		IL_07a4: conv.r8
+		IL_07a5: ldstr ""
+		IL_07aa: ldc.i4.0
+		IL_07ab: ldc.i4.0
+		IL_07ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DynamicInlineCache_Invalidation/FunctionExpression_L126C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07b1: stloc.s 39
+		IL_07b3: ldloc.s 27
+		IL_07b5: ldstr "method"
+		IL_07ba: ldloc.s 39
+		IL_07bc: ldc.i4.1
+		IL_07bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_07c2: pop
+		IL_07c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07c8: stloc.s 26
+		IL_07ca: ldloc.s 11
+		IL_07cc: ldc.r8 0.0
+		IL_07d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_07da: stloc.s 27
+		IL_07dc: ldnull
+		IL_07dd: ldloc.s 27
+		IL_07df: call object Modules.Object_DynamicInlineCache_Invalidation/readMegamorphic::__js_call__(object, object)
+		IL_07e4: stloc.s 27
+		IL_07e6: ldloc.s 26
+		IL_07e8: ldloc.s 27
+		IL_07ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07ef: pop
+		IL_07f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07f5: stloc.s 26
+		IL_07f7: ldloc.s 11
+		IL_07f9: ldc.r8 0.0
+		IL_0802: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0807: stloc.s 27
+		IL_0809: ldnull
+		IL_080a: ldloc.s 27
+		IL_080c: call object Modules.Object_DynamicInlineCache_Invalidation/callMegamorphic::__js_call__(object, object)
+		IL_0811: stloc.s 27
+		IL_0813: ldloc.s 26
+		IL_0815: ldloc.s 27
+		IL_0817: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_081c: pop
+		IL_081d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0822: stloc.s 14
+		IL_0824: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0829: stloc.s 26
+		IL_082b: ldnull
+		IL_082c: ldloc.s 14
+		IL_082e: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+		IL_0833: stloc.s 27
+		IL_0835: ldloc.s 26
+		IL_0837: ldloc.s 27
+		IL_0839: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_083e: pop
+		IL_083f: ldloc.s 14
+		IL_0841: ldstr "value"
+		IL_0846: ldstr "appeared"
+		IL_084b: ldc.i4.1
+		IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0851: pop
+		IL_0852: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0857: stloc.s 26
+		IL_0859: ldnull
+		IL_085a: ldloc.s 14
+		IL_085c: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
 		IL_0861: stloc.s 27
 		IL_0863: ldloc.s 26
 		IL_0865: ldloc.s 27
@@ -3489,207 +3503,154 @@
 		IL_086c: pop
 		IL_086d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0872: stloc.s 26
-		IL_0874: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0879: stloc.s 22
-		IL_087b: ldloc.s 11
-		IL_087d: ldc.r8 0.0
-		IL_0886: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_088b: stloc.s 27
-		IL_088d: ldloc.s 5
-		IL_088f: ldloc.s 22
-		IL_0891: ldloc.s 27
-		IL_0893: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0898: stloc.s 27
-		IL_089a: ldloc.s 26
-		IL_089c: ldloc.s 27
-		IL_089e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08a3: pop
-		IL_08a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_08a9: stloc.s 14
-		IL_08ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08b0: stloc.s 26
-		IL_08b2: ldloc.1
-		IL_08b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08b8: ldloc.s 14
-		IL_08ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_08bf: stloc.s 27
-		IL_08c1: ldloc.s 26
-		IL_08c3: ldloc.s 27
-		IL_08c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08ca: pop
-		IL_08cb: ldloc.s 14
-		IL_08cd: ldstr "value"
-		IL_08d2: ldstr "appeared"
-		IL_08d7: ldc.i4.1
-		IL_08d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_08dd: pop
-		IL_08de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08e3: stloc.s 26
-		IL_08e5: ldloc.1
-		IL_08e6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08eb: ldloc.s 14
-		IL_08ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_08f2: stloc.s 27
-		IL_08f4: ldloc.s 26
-		IL_08f6: ldloc.s 27
-		IL_08f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08fd: pop
-		IL_08fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0903: stloc.s 26
-		IL_0905: volatile.
-		IL_0907: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_090c: brfalse IL_0922
+		IL_0874: volatile.
+		IL_0876: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_087b: brfalse IL_0891
 
-		IL_0911: ldloc.s 7
-		IL_0913: ldstr "__proto__"
-		IL_0918: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_091d: br IL_0938
+		IL_0880: ldloc.s 7
+		IL_0882: ldstr "__proto__"
+		IL_0887: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_088c: br IL_08a7
 
-		IL_0922: ldloc.s 7
-		IL_0924: ldstr "__proto__"
-		IL_0929: ldstr "Object_DynamicInlineCache_Invalidation:Modules.Object_DynamicInlineCache_Invalidation:__js_module_init__:336"
-		IL_092e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_0933: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0891: ldloc.s 7
+		IL_0893: ldstr "__proto__"
+		IL_0898: ldstr "Object_DynamicInlineCache_Invalidation:Modules.Object_DynamicInlineCache_Invalidation:__js_module_init__:336"
+		IL_089d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_08a2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0938: stloc.s 27
-		IL_093a: ldloc.s 27
-		IL_093c: ldloc.s 9
-		IL_093e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0943: stloc.s 29
-		IL_0945: ldloc.s 29
-		IL_0947: box [System.Runtime]System.Boolean
-		IL_094c: stloc.s 40
-		IL_094e: ldloc.s 26
-		IL_0950: ldloc.s 40
-		IL_0952: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0957: pop
+		IL_08a7: stloc.s 27
+		IL_08a9: ldloc.s 27
+		IL_08ab: ldloc.s 9
+		IL_08ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_08b2: stloc.s 29
+		IL_08b4: ldloc.s 29
+		IL_08b6: box [System.Runtime]System.Boolean
+		IL_08bb: stloc.s 40
+		IL_08bd: ldloc.s 26
+		IL_08bf: ldloc.s 40
+		IL_08c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08c6: pop
 		.try
 		{
-			IL_0958: nop
-			IL_0959: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_095e: stloc.s 22
-			IL_0960: ldloc.1
-			IL_0961: ldloc.s 22
-			IL_0963: ldc.i4.0
-			IL_0964: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0969: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_096e: pop
-			IL_096f: leave IL_09f1
+			IL_08c7: nop
+			IL_08c8: ldnull
+			IL_08c9: ldc.i4.0
+			IL_08ca: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_08cf: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+			IL_08d4: pop
+			IL_08d5: leave IL_0957
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0974: stloc.s 15
-			IL_0976: ldloc.s 15
-			IL_0978: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_097d: dup
-			IL_097e: brtrue IL_0994
+			IL_08da: stloc.s 15
+			IL_08dc: ldloc.s 15
+			IL_08de: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_08e3: dup
+			IL_08e4: brtrue IL_08fa
 
-			IL_0983: pop
-			IL_0984: ldloc.s 15
-			IL_0986: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_098b: dup
-			IL_098c: brtrue IL_09a0
+			IL_08e9: pop
+			IL_08ea: ldloc.s 15
+			IL_08ec: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_08f1: dup
+			IL_08f2: brtrue IL_0906
 
-			IL_0991: pop
-			IL_0992: rethrow
+			IL_08f7: pop
+			IL_08f8: rethrow
 
-			IL_0994: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0999: stloc.s 16
-			IL_099b: br IL_09a2
+			IL_08fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_08ff: stloc.s 16
+			IL_0901: br IL_0908
 
-			IL_09a0: stloc.s 16
+			IL_0906: stloc.s 16
 
-			IL_09a2: ldloc.s 16
-			IL_09a4: stloc.s 17
-			IL_09a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09ab: stloc.s 26
-			IL_09ad: volatile.
-			IL_09af: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_09b4: brfalse IL_09ca
+			IL_0908: ldloc.s 16
+			IL_090a: stloc.s 17
+			IL_090c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0911: stloc.s 26
+			IL_0913: volatile.
+			IL_0915: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_091a: brfalse IL_0930
 
-			IL_09b9: ldloc.s 17
-			IL_09bb: ldstr "name"
-			IL_09c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09c5: br IL_09e0
+			IL_091f: ldloc.s 17
+			IL_0921: ldstr "name"
+			IL_0926: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_092b: br IL_0946
 
-			IL_09ca: ldloc.s 17
-			IL_09cc: ldstr "name"
-			IL_09d1: ldstr "Object_DynamicInlineCache_Invalidation:Modules.Object_DynamicInlineCache_Invalidation:__js_module_init__:358"
-			IL_09d6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-			IL_09db: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0930: ldloc.s 17
+			IL_0932: ldstr "name"
+			IL_0937: ldstr "Object_DynamicInlineCache_Invalidation:Modules.Object_DynamicInlineCache_Invalidation:__js_module_init__:358"
+			IL_093c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+			IL_0941: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_09e0: stloc.s 27
-			IL_09e2: ldloc.s 26
-			IL_09e4: ldloc.s 27
-			IL_09e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_09eb: pop
-			IL_09ec: leave IL_09f1
+			IL_0946: stloc.s 27
+			IL_0948: ldloc.s 26
+			IL_094a: ldloc.s 27
+			IL_094c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0951: pop
+			IL_0952: leave IL_0957
 		} // end handler
 		.try
 		{
-			IL_09f1: nop
-			IL_09f2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_09f7: stloc.s 22
-			IL_09f9: ldloc.1
-			IL_09fa: ldloc.s 22
-			IL_09fc: ldnull
-			IL_09fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0a02: pop
-			IL_0a03: leave IL_0a85
+			IL_0957: nop
+			IL_0958: ldnull
+			IL_0959: ldnull
+			IL_095a: call object Modules.Object_DynamicInlineCache_Invalidation/read::__js_call__(object, object)
+			IL_095f: pop
+			IL_0960: leave IL_09e2
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0a08: stloc.s 18
-			IL_0a0a: ldloc.s 18
-			IL_0a0c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0a11: dup
-			IL_0a12: brtrue IL_0a28
+			IL_0965: stloc.s 18
+			IL_0967: ldloc.s 18
+			IL_0969: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_096e: dup
+			IL_096f: brtrue IL_0985
 
-			IL_0a17: pop
-			IL_0a18: ldloc.s 18
-			IL_0a1a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0a1f: dup
-			IL_0a20: brtrue IL_0a34
+			IL_0974: pop
+			IL_0975: ldloc.s 18
+			IL_0977: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_097c: dup
+			IL_097d: brtrue IL_0991
 
-			IL_0a25: pop
-			IL_0a26: rethrow
+			IL_0982: pop
+			IL_0983: rethrow
 
-			IL_0a28: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0a2d: stloc.s 19
-			IL_0a2f: br IL_0a36
+			IL_0985: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_098a: stloc.s 19
+			IL_098c: br IL_0993
 
-			IL_0a34: stloc.s 19
+			IL_0991: stloc.s 19
 
-			IL_0a36: ldloc.s 19
-			IL_0a38: stloc.s 20
-			IL_0a3a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a3f: stloc.s 26
-			IL_0a41: volatile.
-			IL_0a43: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0a48: brfalse IL_0a5e
+			IL_0993: ldloc.s 19
+			IL_0995: stloc.s 20
+			IL_0997: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_099c: stloc.s 26
+			IL_099e: volatile.
+			IL_09a0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_09a5: brfalse IL_09bb
 
-			IL_0a4d: ldloc.s 20
-			IL_0a4f: ldstr "name"
-			IL_0a54: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a59: br IL_0a74
+			IL_09aa: ldloc.s 20
+			IL_09ac: ldstr "name"
+			IL_09b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09b6: br IL_09d1
 
-			IL_0a5e: ldloc.s 20
-			IL_0a60: ldstr "name"
-			IL_0a65: ldstr "Object_DynamicInlineCache_Invalidation:Modules.Object_DynamicInlineCache_Invalidation:__js_module_init__:381"
-			IL_0a6a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-			IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_09bb: ldloc.s 20
+			IL_09bd: ldstr "name"
+			IL_09c2: ldstr "Object_DynamicInlineCache_Invalidation:Modules.Object_DynamicInlineCache_Invalidation:__js_module_init__:381"
+			IL_09c7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+			IL_09cc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0a74: stloc.s 27
-			IL_0a76: ldloc.s 26
-			IL_0a78: ldloc.s 27
-			IL_0a7a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a7f: pop
-			IL_0a80: leave IL_0a85
+			IL_09d1: stloc.s 27
+			IL_09d3: ldloc.s 26
+			IL_09d5: ldloc.s 27
+			IL_09d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_09dc: pop
+			IL_09dd: leave IL_09e2
 		} // end handler
 
-		IL_0a85: ldnull
-		IL_0a86: stloc.s 21
-		IL_0a88: ret
+		IL_09e2: ldnull
+		IL_09e3: stloc.s 21
+		IL_09e5: ret
 	} // end of method Object_DynamicInlineCache_Invalidation::__js_module_init__
 
 } // end of class Modules.Object_DynamicInlineCache_Invalidation

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -2607,7 +2607,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1325 (0x52d)
+		// Code size: 1298 (0x512)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope,
@@ -2619,18 +2619,17 @@
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[9] object[],
-			[10] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject,
-			[11] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject,
-			[12] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject,
-			[13] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject,
-			[14] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject,
-			[15] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject,
-			[16] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject,
-			[17] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject,
-			[18] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject,
-			[19] class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject,
-			[20] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject
+			[9] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject,
+			[10] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject,
+			[11] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject,
+			[12] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject,
+			[13] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject,
+			[14] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject,
+			[15] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject,
+			[16] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject,
+			[17] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject,
+			[18] class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject,
+			[19] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -2809,332 +2808,323 @@
 		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
 		IL_020a: pop
-		IL_020b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0210: stloc.3
-		IL_0211: ldc.i4.1
-		IL_0212: newarr [System.Runtime]System.Object
-		IL_0217: dup
-		IL_0218: ldc.i4.0
-		IL_0219: ldloc.0
-		IL_021a: stelem.ref
-		IL_021b: stloc.s 9
-		IL_021d: ldloc.s 9
-		IL_021f: ldc.i4.0
-		IL_0220: ldelem.ref
-		IL_0221: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0226: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_020b: ldc.i4.1
+		IL_020c: newarr [System.Runtime]System.Object
+		IL_0211: dup
+		IL_0212: ldc.i4.0
+		IL_0213: ldloc.0
+		IL_0214: stelem.ref
+		IL_0215: stloc.3
+		IL_0216: ldloc.3
+		IL_0217: ldc.i4.0
+		IL_0218: ldelem.ref
+		IL_0219: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_021e: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0223: ldc.i4.0
+		IL_0224: conv.r8
+		IL_0225: ldstr ""
+		IL_022a: ldc.i4.0
 		IL_022b: ldc.i4.0
-		IL_022c: conv.r8
-		IL_022d: ldstr ""
-		IL_0232: ldc.i4.0
-		IL_0233: ldc.i4.0
-		IL_0234: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0239: stloc.s 10
-		IL_023b: ldloc.1
-		IL_023c: ldloc.3
-		IL_023d: ldstr "get"
-		IL_0242: ldloc.s 10
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0249: pop
-		IL_024a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_024f: stloc.3
-		IL_0250: ldc.i4.1
-		IL_0251: newarr [System.Runtime]System.Object
-		IL_0256: dup
-		IL_0257: ldc.i4.0
-		IL_0258: ldloc.0
-		IL_0259: stelem.ref
-		IL_025a: stloc.s 9
-		IL_025c: ldloc.s 9
-		IL_025e: ldc.i4.0
-		IL_025f: ldelem.ref
-		IL_0260: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0265: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
-		IL_026a: ldc.i4.0
-		IL_026b: conv.r8
-		IL_026c: ldstr ""
-		IL_0271: ldc.i4.0
-		IL_0272: ldc.i4.0
-		IL_0273: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0278: stloc.s 11
-		IL_027a: ldloc.1
-		IL_027b: ldloc.3
-		IL_027c: ldstr "set"
-		IL_0281: ldloc.s 11
-		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0288: pop
-		IL_0289: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_028e: stloc.3
-		IL_028f: ldc.i4.1
-		IL_0290: newarr [System.Runtime]System.Object
-		IL_0295: dup
-		IL_0296: ldc.i4.0
-		IL_0297: ldloc.0
-		IL_0298: stelem.ref
-		IL_0299: stloc.s 9
-		IL_029b: ldloc.s 9
-		IL_029d: ldc.i4.0
-		IL_029e: ldelem.ref
-		IL_029f: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02a4: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
-		IL_02a9: ldc.i4.0
-		IL_02aa: conv.r8
-		IL_02ab: ldstr ""
-		IL_02b0: ldc.i4.0
-		IL_02b1: ldc.i4.0
-		IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02b7: stloc.s 12
-		IL_02b9: ldloc.1
-		IL_02ba: ldloc.3
-		IL_02bb: ldstr "has"
-		IL_02c0: ldloc.s 12
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02c7: pop
-		IL_02c8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02cd: stloc.3
-		IL_02ce: ldc.i4.1
-		IL_02cf: newarr [System.Runtime]System.Object
-		IL_02d4: dup
-		IL_02d5: ldc.i4.0
-		IL_02d6: ldloc.0
-		IL_02d7: stelem.ref
-		IL_02d8: stloc.s 9
-		IL_02da: ldloc.s 9
-		IL_02dc: ldc.i4.0
-		IL_02dd: ldelem.ref
-		IL_02de: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02e3: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
-		IL_02e8: ldc.i4.0
-		IL_02e9: conv.r8
-		IL_02ea: ldstr ""
-		IL_02ef: ldc.i4.0
-		IL_02f0: ldc.i4.0
-		IL_02f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02f6: stloc.s 13
-		IL_02f8: ldloc.1
-		IL_02f9: ldloc.3
-		IL_02fa: ldstr "delete"
-		IL_02ff: ldloc.s 13
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0306: pop
-		IL_0307: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_030c: stloc.3
-		IL_030d: ldc.i4.1
-		IL_030e: newarr [System.Runtime]System.Object
-		IL_0313: dup
-		IL_0314: ldc.i4.0
-		IL_0315: ldloc.0
-		IL_0316: stelem.ref
-		IL_0317: stloc.s 9
-		IL_0319: ldloc.s 9
+		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0231: stloc.s 9
+		IL_0233: ldloc.0
+		IL_0234: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0239: ldnull
+		IL_023a: ldstr "get"
+		IL_023f: ldloc.s 9
+		IL_0241: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_0246: pop
+		IL_0247: ldc.i4.1
+		IL_0248: newarr [System.Runtime]System.Object
+		IL_024d: dup
+		IL_024e: ldc.i4.0
+		IL_024f: ldloc.0
+		IL_0250: stelem.ref
+		IL_0251: stloc.3
+		IL_0252: ldloc.3
+		IL_0253: ldc.i4.0
+		IL_0254: ldelem.ref
+		IL_0255: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_025a: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_025f: ldc.i4.0
+		IL_0260: conv.r8
+		IL_0261: ldstr ""
+		IL_0266: ldc.i4.0
+		IL_0267: ldc.i4.0
+		IL_0268: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_026d: stloc.s 10
+		IL_026f: ldloc.0
+		IL_0270: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0275: ldnull
+		IL_0276: ldstr "set"
+		IL_027b: ldloc.s 10
+		IL_027d: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_0282: pop
+		IL_0283: ldc.i4.1
+		IL_0284: newarr [System.Runtime]System.Object
+		IL_0289: dup
+		IL_028a: ldc.i4.0
+		IL_028b: ldloc.0
+		IL_028c: stelem.ref
+		IL_028d: stloc.3
+		IL_028e: ldloc.3
+		IL_028f: ldc.i4.0
+		IL_0290: ldelem.ref
+		IL_0291: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0296: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_029b: ldc.i4.0
+		IL_029c: conv.r8
+		IL_029d: ldstr ""
+		IL_02a2: ldc.i4.0
+		IL_02a3: ldc.i4.0
+		IL_02a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02a9: stloc.s 11
+		IL_02ab: ldloc.0
+		IL_02ac: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_02b1: ldnull
+		IL_02b2: ldstr "has"
+		IL_02b7: ldloc.s 11
+		IL_02b9: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_02be: pop
+		IL_02bf: ldc.i4.1
+		IL_02c0: newarr [System.Runtime]System.Object
+		IL_02c5: dup
+		IL_02c6: ldc.i4.0
+		IL_02c7: ldloc.0
+		IL_02c8: stelem.ref
+		IL_02c9: stloc.3
+		IL_02ca: ldloc.3
+		IL_02cb: ldc.i4.0
+		IL_02cc: ldelem.ref
+		IL_02cd: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_02d2: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_02d7: ldc.i4.0
+		IL_02d8: conv.r8
+		IL_02d9: ldstr ""
+		IL_02de: ldc.i4.0
+		IL_02df: ldc.i4.0
+		IL_02e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02e5: stloc.s 12
+		IL_02e7: ldloc.0
+		IL_02e8: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_02ed: ldnull
+		IL_02ee: ldstr "delete"
+		IL_02f3: ldloc.s 12
+		IL_02f5: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_02fa: pop
+		IL_02fb: ldc.i4.1
+		IL_02fc: newarr [System.Runtime]System.Object
+		IL_0301: dup
+		IL_0302: ldc.i4.0
+		IL_0303: ldloc.0
+		IL_0304: stelem.ref
+		IL_0305: stloc.3
+		IL_0306: ldloc.3
+		IL_0307: ldc.i4.0
+		IL_0308: ldelem.ref
+		IL_0309: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_030e: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0313: ldc.i4.0
+		IL_0314: conv.r8
+		IL_0315: ldstr ""
+		IL_031a: ldc.i4.0
 		IL_031b: ldc.i4.0
-		IL_031c: ldelem.ref
-		IL_031d: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0322: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
-		IL_0327: ldc.i4.0
-		IL_0328: conv.r8
-		IL_0329: ldstr ""
-		IL_032e: ldc.i4.0
-		IL_032f: ldc.i4.0
-		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0335: stloc.s 14
-		IL_0337: ldloc.1
-		IL_0338: ldloc.3
-		IL_0339: ldstr "keys"
-		IL_033e: ldloc.s 14
-		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0345: pop
-		IL_0346: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_034b: stloc.3
-		IL_034c: ldc.i4.1
-		IL_034d: newarr [System.Runtime]System.Object
-		IL_0352: dup
-		IL_0353: ldc.i4.0
-		IL_0354: ldloc.0
-		IL_0355: stelem.ref
-		IL_0356: stloc.s 9
-		IL_0358: ldloc.s 9
-		IL_035a: ldc.i4.0
-		IL_035b: ldelem.ref
-		IL_035c: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0361: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
-		IL_0366: ldc.i4.0
-		IL_0367: conv.r8
-		IL_0368: ldstr ""
-		IL_036d: ldc.i4.0
-		IL_036e: ldc.i4.0
-		IL_036f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0374: stloc.s 15
-		IL_0376: ldloc.1
-		IL_0377: ldloc.3
-		IL_0378: ldstr "getPrototypeOf"
-		IL_037d: ldloc.s 15
-		IL_037f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0384: pop
-		IL_0385: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_038a: stloc.3
-		IL_038b: ldc.i4.1
-		IL_038c: newarr [System.Runtime]System.Object
-		IL_0391: dup
+		IL_031c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0321: stloc.s 13
+		IL_0323: ldloc.0
+		IL_0324: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0329: ldnull
+		IL_032a: ldstr "keys"
+		IL_032f: ldloc.s 13
+		IL_0331: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_0336: pop
+		IL_0337: ldc.i4.1
+		IL_0338: newarr [System.Runtime]System.Object
+		IL_033d: dup
+		IL_033e: ldc.i4.0
+		IL_033f: ldloc.0
+		IL_0340: stelem.ref
+		IL_0341: stloc.3
+		IL_0342: ldloc.3
+		IL_0343: ldc.i4.0
+		IL_0344: ldelem.ref
+		IL_0345: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_034a: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_034f: ldc.i4.0
+		IL_0350: conv.r8
+		IL_0351: ldstr ""
+		IL_0356: ldc.i4.0
+		IL_0357: ldc.i4.0
+		IL_0358: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_035d: stloc.s 14
+		IL_035f: ldloc.0
+		IL_0360: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0365: ldnull
+		IL_0366: ldstr "getPrototypeOf"
+		IL_036b: ldloc.s 14
+		IL_036d: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_0372: pop
+		IL_0373: ldc.i4.1
+		IL_0374: newarr [System.Runtime]System.Object
+		IL_0379: dup
+		IL_037a: ldc.i4.0
+		IL_037b: ldloc.0
+		IL_037c: stelem.ref
+		IL_037d: stloc.3
+		IL_037e: ldloc.3
+		IL_037f: ldc.i4.0
+		IL_0380: ldelem.ref
+		IL_0381: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0386: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_038b: ldc.i4.0
+		IL_038c: conv.r8
+		IL_038d: ldstr ""
 		IL_0392: ldc.i4.0
-		IL_0393: ldloc.0
-		IL_0394: stelem.ref
-		IL_0395: stloc.s 9
-		IL_0397: ldloc.s 9
-		IL_0399: ldc.i4.0
-		IL_039a: ldelem.ref
-		IL_039b: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_03a0: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
-		IL_03a5: ldc.i4.0
-		IL_03a6: conv.r8
-		IL_03a7: ldstr ""
-		IL_03ac: ldc.i4.0
-		IL_03ad: ldc.i4.0
-		IL_03ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03b3: stloc.s 16
-		IL_03b5: ldloc.1
-		IL_03b6: ldloc.3
-		IL_03b7: ldstr "setPrototypeOf"
-		IL_03bc: ldloc.s 16
-		IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_03c3: pop
-		IL_03c4: ldc.i4.1
-		IL_03c5: newarr [System.Runtime]System.Object
-		IL_03ca: dup
-		IL_03cb: ldc.i4.0
-		IL_03cc: ldloc.0
-		IL_03cd: stelem.ref
-		IL_03ce: stloc.3
-		IL_03cf: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject::.ctor()
-		IL_03d4: ldc.i4.1
-		IL_03d5: conv.r8
-		IL_03d6: ldstr ""
-		IL_03db: ldc.i4.0
-		IL_03dc: ldc.i4.0
-		IL_03dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03e2: stloc.s 17
-		IL_03e4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03e9: stloc.s 6
-		IL_03eb: ldloc.s 17
-		IL_03ed: ldloc.s 6
-		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
-		IL_03f4: stloc.s 7
-		IL_03f6: ldloc.0
-		IL_03f7: ldloc.s 7
-		IL_03f9: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-		IL_03fe: ldloc.0
-		IL_03ff: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-		IL_0404: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0409: volatile.
-		IL_040b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0410: brfalse IL_0424
+		IL_0393: ldc.i4.0
+		IL_0394: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0399: stloc.s 15
+		IL_039b: ldloc.0
+		IL_039c: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_03a1: ldnull
+		IL_03a2: ldstr "setPrototypeOf"
+		IL_03a7: ldloc.s 15
+		IL_03a9: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_03ae: pop
+		IL_03af: ldc.i4.1
+		IL_03b0: newarr [System.Runtime]System.Object
+		IL_03b5: dup
+		IL_03b6: ldc.i4.0
+		IL_03b7: ldloc.0
+		IL_03b8: stelem.ref
+		IL_03b9: stloc.3
+		IL_03ba: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject::.ctor()
+		IL_03bf: ldc.i4.1
+		IL_03c0: conv.r8
+		IL_03c1: ldstr ""
+		IL_03c6: ldc.i4.0
+		IL_03c7: ldc.i4.0
+		IL_03c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03cd: stloc.s 16
+		IL_03cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03d4: stloc.s 6
+		IL_03d6: ldloc.s 16
+		IL_03d8: ldloc.s 6
+		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
+		IL_03df: stloc.s 7
+		IL_03e1: ldloc.0
+		IL_03e2: ldloc.s 7
+		IL_03e4: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
+		IL_03e9: ldloc.0
+		IL_03ea: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
+		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03f4: volatile.
+		IL_03f6: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_03fb: brfalse IL_040f
 
-		IL_0415: ldstr "revoke"
-		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_041f: br IL_0438
+		IL_0400: ldstr "revoke"
+		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_040a: br IL_0423
 
-		IL_0424: ldstr "revoke"
-		IL_0429: ldstr "Proxy_Revocable_ThrowsAfterRevoke:Modules.Proxy_Revocable_ThrowsAfterRevoke:__js_module_init__:94"
-		IL_042e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-		IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_040f: ldstr "revoke"
+		IL_0414: ldstr "Proxy_Revocable_ThrowsAfterRevoke:Modules.Proxy_Revocable_ThrowsAfterRevoke:__js_module_init__:94"
+		IL_0419: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0438: pop
-		IL_0439: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_043e: stloc.3
-		IL_043f: ldc.i4.1
-		IL_0440: newarr [System.Runtime]System.Object
-		IL_0445: dup
-		IL_0446: ldc.i4.0
-		IL_0447: ldloc.0
-		IL_0448: stelem.ref
-		IL_0449: stloc.s 9
-		IL_044b: ldloc.s 9
-		IL_044d: ldc.i4.0
-		IL_044e: ldelem.ref
-		IL_044f: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0454: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
-		IL_0459: ldc.i4.0
-		IL_045a: conv.r8
-		IL_045b: ldstr ""
-		IL_0460: ldc.i4.0
-		IL_0461: ldc.i4.0
-		IL_0462: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0467: stloc.s 18
-		IL_0469: ldloc.1
-		IL_046a: ldloc.3
-		IL_046b: ldstr "call"
-		IL_0470: ldloc.s 18
-		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0477: pop
-		IL_0478: ldc.i4.1
-		IL_0479: newarr [System.Runtime]System.Object
-		IL_047e: dup
-		IL_047f: ldc.i4.0
-		IL_0480: ldloc.0
-		IL_0481: stelem.ref
-		IL_0482: stloc.3
-		IL_0483: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject::.ctor()
-		IL_0488: ldc.i4.1
-		IL_0489: conv.r8
-		IL_048a: ldstr "C"
-		IL_048f: ldc.i4.1
-		IL_0490: ldc.i4.0
-		IL_0491: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0496: stloc.s 19
-		IL_0498: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_049d: stloc.s 6
-		IL_049f: ldloc.s 19
-		IL_04a1: ldloc.s 6
-		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
-		IL_04a8: stloc.s 7
-		IL_04aa: ldloc.0
-		IL_04ab: ldloc.s 7
-		IL_04ad: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-		IL_04b2: ldloc.0
-		IL_04b3: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04bd: volatile.
-		IL_04bf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_04c4: brfalse IL_04d8
+		IL_0423: pop
+		IL_0424: ldc.i4.1
+		IL_0425: newarr [System.Runtime]System.Object
+		IL_042a: dup
+		IL_042b: ldc.i4.0
+		IL_042c: ldloc.0
+		IL_042d: stelem.ref
+		IL_042e: stloc.3
+		IL_042f: ldloc.3
+		IL_0430: ldc.i4.0
+		IL_0431: ldelem.ref
+		IL_0432: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0437: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_043c: ldc.i4.0
+		IL_043d: conv.r8
+		IL_043e: ldstr ""
+		IL_0443: ldc.i4.0
+		IL_0444: ldc.i4.0
+		IL_0445: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_044a: stloc.s 17
+		IL_044c: ldloc.0
+		IL_044d: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0452: ldnull
+		IL_0453: ldstr "call"
+		IL_0458: ldloc.s 17
+		IL_045a: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_045f: pop
+		IL_0460: ldc.i4.1
+		IL_0461: newarr [System.Runtime]System.Object
+		IL_0466: dup
+		IL_0467: ldc.i4.0
+		IL_0468: ldloc.0
+		IL_0469: stelem.ref
+		IL_046a: stloc.3
+		IL_046b: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject::.ctor()
+		IL_0470: ldc.i4.1
+		IL_0471: conv.r8
+		IL_0472: ldstr "C"
+		IL_0477: ldc.i4.1
+		IL_0478: ldc.i4.0
+		IL_0479: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_047e: stloc.s 18
+		IL_0480: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0485: stloc.s 6
+		IL_0487: ldloc.s 18
+		IL_0489: ldloc.s 6
+		IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
+		IL_0490: stloc.s 7
+		IL_0492: ldloc.0
+		IL_0493: ldloc.s 7
+		IL_0495: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
+		IL_049a: ldloc.0
+		IL_049b: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
+		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04a5: volatile.
+		IL_04a7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_04ac: brfalse IL_04c0
 
-		IL_04c9: ldstr "revoke"
-		IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_04d3: br IL_04ec
+		IL_04b1: ldstr "revoke"
+		IL_04b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_04bb: br IL_04d4
 
-		IL_04d8: ldstr "revoke"
-		IL_04dd: ldstr "Proxy_Revocable_ThrowsAfterRevoke:Modules.Proxy_Revocable_ThrowsAfterRevoke:__js_module_init__:110"
-		IL_04e2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_04c0: ldstr "revoke"
+		IL_04c5: ldstr "Proxy_Revocable_ThrowsAfterRevoke:Modules.Proxy_Revocable_ThrowsAfterRevoke:__js_module_init__:110"
+		IL_04ca: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_04ec: pop
-		IL_04ed: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04f2: stloc.3
-		IL_04f3: ldc.i4.1
-		IL_04f4: newarr [System.Runtime]System.Object
-		IL_04f9: dup
-		IL_04fa: ldc.i4.0
-		IL_04fb: ldloc.0
-		IL_04fc: stelem.ref
-		IL_04fd: stloc.s 9
-		IL_04ff: ldloc.s 9
-		IL_0501: ldc.i4.0
-		IL_0502: ldelem.ref
-		IL_0503: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0508: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
-		IL_050d: ldc.i4.0
-		IL_050e: conv.r8
-		IL_050f: ldstr ""
-		IL_0514: ldc.i4.0
-		IL_0515: ldc.i4.0
-		IL_0516: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_051b: stloc.s 20
-		IL_051d: ldloc.1
-		IL_051e: ldloc.3
-		IL_051f: ldstr "construct"
-		IL_0524: ldloc.s 20
-		IL_0526: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_052b: pop
-		IL_052c: ret
+		IL_04d4: pop
+		IL_04d5: ldc.i4.1
+		IL_04d6: newarr [System.Runtime]System.Object
+		IL_04db: dup
+		IL_04dc: ldc.i4.0
+		IL_04dd: ldloc.0
+		IL_04de: stelem.ref
+		IL_04df: stloc.3
+		IL_04e0: ldloc.3
+		IL_04e1: ldc.i4.0
+		IL_04e2: ldelem.ref
+		IL_04e3: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_04e8: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_04ed: ldc.i4.0
+		IL_04ee: conv.r8
+		IL_04ef: ldstr ""
+		IL_04f4: ldc.i4.0
+		IL_04f5: ldc.i4.0
+		IL_04f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04fb: stloc.s 19
+		IL_04fd: ldloc.0
+		IL_04fe: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0503: ldnull
+		IL_0504: ldstr "construct"
+		IL_0509: ldloc.s 19
+		IL_050b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+		IL_0510: pop
+		IL_0511: ret
 	} // end of method Proxy_Revocable_ThrowsAfterRevoke::__js_module_init__
 
 } // end of class Modules.Proxy_Revocable_ThrowsAfterRevoke

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -3396,7 +3396,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1631 (0x65f)
+		// Code size: 1601 (0x641)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Validation_EdgeCases/Scope,
@@ -3405,34 +3405,33 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[5] object[],
-			[6] object[],
-			[7] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject,
-			[8] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject,
-			[9] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject,
-			[10] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[12] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject,
-			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[14] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
-			[15] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject,
-			[16] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject,
-			[17] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject,
-			[18] class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject,
-			[19] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject,
-			[20] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject,
-			[21] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject,
-			[22] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[23] object,
-			[24] bool,
-			[25] object,
-			[26] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject,
-			[27] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject,
-			[28] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject,
-			[29] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject,
-			[30] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject,
-			[31] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject,
-			[32] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject,
-			[33] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject
+			[6] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject,
+			[7] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject,
+			[8] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject,
+			[9] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject,
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[11] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
+			[14] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject,
+			[15] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject,
+			[16] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject,
+			[17] class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject,
+			[18] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject,
+			[19] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject,
+			[20] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject,
+			[21] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[22] object,
+			[23] bool,
+			[24] object,
+			[25] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject,
+			[26] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject,
+			[27] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject,
+			[28] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject,
+			[29] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject,
+			[30] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject,
+			[31] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject,
+			[32] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -3459,614 +3458,604 @@
 		IL_0033: stloc.1
 		IL_0034: nop
 		IL_0035: nop
-		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003b: stloc.s 5
-		IL_003d: ldc.i4.1
-		IL_003e: newarr [System.Runtime]System.Object
-		IL_0043: dup
-		IL_0044: ldc.i4.0
-		IL_0045: ldloc.0
-		IL_0046: stelem.ref
-		IL_0047: stloc.s 6
-		IL_0049: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject::.ctor()
+		IL_0036: ldc.i4.1
+		IL_0037: newarr [System.Runtime]System.Object
+		IL_003c: dup
+		IL_003d: ldc.i4.0
+		IL_003e: ldloc.0
+		IL_003f: stelem.ref
+		IL_0040: stloc.s 5
+		IL_0042: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject::.ctor()
+		IL_0047: ldc.i4.0
+		IL_0048: conv.r8
+		IL_0049: ldstr ""
 		IL_004e: ldc.i4.0
-		IL_004f: conv.r8
-		IL_0050: ldstr ""
-		IL_0055: ldc.i4.0
-		IL_0056: ldc.i4.0
-		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_005c: stloc.s 7
-		IL_005e: ldloc.1
-		IL_005f: ldloc.s 5
-		IL_0061: ldstr "proxy-target"
-		IL_0066: ldloc.s 7
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_006d: pop
-		IL_006e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0073: stloc.s 5
-		IL_0075: ldc.i4.1
-		IL_0076: newarr [System.Runtime]System.Object
-		IL_007b: dup
+		IL_004f: ldc.i4.0
+		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0055: stloc.s 6
+		IL_0057: ldloc.0
+		IL_0058: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_005d: ldnull
+		IL_005e: ldstr "proxy-target"
+		IL_0063: ldloc.s 6
+		IL_0065: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_006a: pop
+		IL_006b: ldc.i4.1
+		IL_006c: newarr [System.Runtime]System.Object
+		IL_0071: dup
+		IL_0072: ldc.i4.0
+		IL_0073: ldloc.0
+		IL_0074: stelem.ref
+		IL_0075: stloc.s 5
+		IL_0077: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject::.ctor()
 		IL_007c: ldc.i4.0
-		IL_007d: ldloc.0
-		IL_007e: stelem.ref
-		IL_007f: stloc.s 6
-		IL_0081: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject::.ctor()
-		IL_0086: ldc.i4.0
-		IL_0087: conv.r8
-		IL_0088: ldstr ""
-		IL_008d: ldc.i4.0
-		IL_008e: ldc.i4.0
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0094: stloc.s 8
-		IL_0096: ldloc.1
-		IL_0097: ldloc.s 5
-		IL_0099: ldstr "proxy-handler"
-		IL_009e: ldloc.s 8
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00a5: pop
-		IL_00a6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00ab: stloc.s 5
-		IL_00ad: ldc.i4.1
-		IL_00ae: newarr [System.Runtime]System.Object
-		IL_00b3: dup
-		IL_00b4: ldc.i4.0
-		IL_00b5: ldloc.0
-		IL_00b6: stelem.ref
-		IL_00b7: stloc.s 6
-		IL_00b9: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject::.ctor()
-		IL_00be: ldc.i4.0
-		IL_00bf: conv.r8
-		IL_00c0: ldstr ""
-		IL_00c5: ldc.i4.0
-		IL_00c6: ldc.i4.0
-		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00cc: stloc.s 9
-		IL_00ce: ldloc.1
-		IL_00cf: ldloc.s 5
-		IL_00d1: ldstr "revocable-target"
-		IL_00d6: ldloc.s 9
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00dd: pop
-		IL_00de: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00e3: stloc.s 5
-		IL_00e5: ldc.i4.1
-		IL_00e6: newarr [System.Runtime]System.Object
-		IL_00eb: dup
-		IL_00ec: ldc.i4.0
-		IL_00ed: ldloc.0
-		IL_00ee: stelem.ref
-		IL_00ef: stloc.s 6
-		IL_00f1: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject::.ctor()
-		IL_00f6: ldc.i4.0
-		IL_00f7: conv.r8
-		IL_00f8: ldstr ""
-		IL_00fd: ldc.i4.0
-		IL_00fe: ldc.i4.0
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0104: stloc.s 10
-		IL_0106: ldloc.1
-		IL_0107: ldloc.s 5
-		IL_0109: ldstr "revocable-handler"
-		IL_010e: ldloc.s 10
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0115: pop
-		IL_0116: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_011b: stloc.s 11
-		IL_011d: ldc.i4.1
-		IL_011e: newarr [System.Runtime]System.Object
-		IL_0123: dup
-		IL_0124: ldc.i4.0
-		IL_0125: ldloc.0
-		IL_0126: stelem.ref
-		IL_0127: stloc.s 5
-		IL_0129: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject::.ctor()
-		IL_012e: ldc.i4.0
-		IL_012f: conv.r8
-		IL_0130: ldstr ""
-		IL_0135: ldc.i4.0
-		IL_0136: ldc.i4.0
-		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_013c: stloc.s 12
-		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0143: dup
-		IL_0144: ldstr "apply"
-		IL_0149: ldloc.s 12
-		IL_014b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0150: stloc.s 13
-		IL_0152: ldloc.s 11
-		IL_0154: ldloc.s 13
-		IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_015b: stloc.s 14
-		IL_015d: ldloc.0
-		IL_015e: ldloc.s 14
-		IL_0160: stfld object Modules.Proxy_Validation_EdgeCases/Scope::applyProxy
-		IL_0165: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_016a: stloc.s 5
-		IL_016c: ldc.i4.1
-		IL_016d: newarr [System.Runtime]System.Object
-		IL_0172: dup
+		IL_007d: conv.r8
+		IL_007e: ldstr ""
+		IL_0083: ldc.i4.0
+		IL_0084: ldc.i4.0
+		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_008a: stloc.s 7
+		IL_008c: ldloc.0
+		IL_008d: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0092: ldnull
+		IL_0093: ldstr "proxy-handler"
+		IL_0098: ldloc.s 7
+		IL_009a: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_009f: pop
+		IL_00a0: ldc.i4.1
+		IL_00a1: newarr [System.Runtime]System.Object
+		IL_00a6: dup
+		IL_00a7: ldc.i4.0
+		IL_00a8: ldloc.0
+		IL_00a9: stelem.ref
+		IL_00aa: stloc.s 5
+		IL_00ac: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject::.ctor()
+		IL_00b1: ldc.i4.0
+		IL_00b2: conv.r8
+		IL_00b3: ldstr ""
+		IL_00b8: ldc.i4.0
+		IL_00b9: ldc.i4.0
+		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00bf: stloc.s 8
+		IL_00c1: ldloc.0
+		IL_00c2: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_00c7: ldnull
+		IL_00c8: ldstr "revocable-target"
+		IL_00cd: ldloc.s 8
+		IL_00cf: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_00d4: pop
+		IL_00d5: ldc.i4.1
+		IL_00d6: newarr [System.Runtime]System.Object
+		IL_00db: dup
+		IL_00dc: ldc.i4.0
+		IL_00dd: ldloc.0
+		IL_00de: stelem.ref
+		IL_00df: stloc.s 5
+		IL_00e1: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject::.ctor()
+		IL_00e6: ldc.i4.0
+		IL_00e7: conv.r8
+		IL_00e8: ldstr ""
+		IL_00ed: ldc.i4.0
+		IL_00ee: ldc.i4.0
+		IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f4: stloc.s 9
+		IL_00f6: ldloc.0
+		IL_00f7: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_00fc: ldnull
+		IL_00fd: ldstr "revocable-handler"
+		IL_0102: ldloc.s 9
+		IL_0104: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_0109: pop
+		IL_010a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_010f: stloc.s 10
+		IL_0111: ldc.i4.1
+		IL_0112: newarr [System.Runtime]System.Object
+		IL_0117: dup
+		IL_0118: ldc.i4.0
+		IL_0119: ldloc.0
+		IL_011a: stelem.ref
+		IL_011b: stloc.s 5
+		IL_011d: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject::.ctor()
+		IL_0122: ldc.i4.0
+		IL_0123: conv.r8
+		IL_0124: ldstr ""
+		IL_0129: ldc.i4.0
+		IL_012a: ldc.i4.0
+		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0130: stloc.s 11
+		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0137: dup
+		IL_0138: ldstr "apply"
+		IL_013d: ldloc.s 11
+		IL_013f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0144: stloc.s 12
+		IL_0146: ldloc.s 10
+		IL_0148: ldloc.s 12
+		IL_014a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_014f: stloc.s 13
+		IL_0151: ldloc.0
+		IL_0152: ldloc.s 13
+		IL_0154: stfld object Modules.Proxy_Validation_EdgeCases/Scope::applyProxy
+		IL_0159: ldc.i4.1
+		IL_015a: newarr [System.Runtime]System.Object
+		IL_015f: dup
+		IL_0160: ldc.i4.0
+		IL_0161: ldloc.0
+		IL_0162: stelem.ref
+		IL_0163: stloc.s 5
+		IL_0165: ldloc.s 5
+		IL_0167: ldc.i4.0
+		IL_0168: ldelem.ref
+		IL_0169: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_016e: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_0173: ldc.i4.0
-		IL_0174: ldloc.0
-		IL_0175: stelem.ref
-		IL_0176: stloc.s 6
-		IL_0178: ldloc.s 6
+		IL_0174: conv.r8
+		IL_0175: ldstr ""
 		IL_017a: ldc.i4.0
-		IL_017b: ldelem.ref
-		IL_017c: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0181: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_0186: ldc.i4.0
-		IL_0187: conv.r8
-		IL_0188: ldstr ""
-		IL_018d: ldc.i4.0
-		IL_018e: ldc.i4.0
-		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0194: stloc.s 15
-		IL_0196: ldloc.1
-		IL_0197: ldloc.s 5
-		IL_0199: ldstr "apply-noncallable"
-		IL_019e: ldloc.s 15
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01a5: pop
-		IL_01a6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01ab: stloc.s 13
-		IL_01ad: ldc.i4.1
-		IL_01ae: newarr [System.Runtime]System.Object
-		IL_01b3: dup
-		IL_01b4: ldc.i4.0
-		IL_01b5: ldloc.0
-		IL_01b6: stelem.ref
-		IL_01b7: stloc.s 5
-		IL_01b9: ldloc.s 5
-		IL_01bb: ldc.i4.0
-		IL_01bc: ldelem.ref
-		IL_01bd: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_01c2: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_01c7: ldc.i4.0
-		IL_01c8: conv.r8
-		IL_01c9: ldstr ""
-		IL_01ce: ldc.i4.0
-		IL_01cf: ldc.i4.0
-		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01d5: stloc.s 16
-		IL_01d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01dc: dup
-		IL_01dd: ldstr "construct"
-		IL_01e2: ldloc.s 16
-		IL_01e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_01e9: stloc.s 11
-		IL_01eb: ldloc.s 13
-		IL_01ed: ldloc.s 11
-		IL_01ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_01f4: stloc.s 14
-		IL_01f6: ldloc.0
-		IL_01f7: ldloc.s 14
-		IL_01f9: stfld object Modules.Proxy_Validation_EdgeCases/Scope::constructProxy
-		IL_01fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0203: stloc.s 5
-		IL_0205: ldc.i4.1
-		IL_0206: newarr [System.Runtime]System.Object
-		IL_020b: dup
-		IL_020c: ldc.i4.0
-		IL_020d: ldloc.0
-		IL_020e: stelem.ref
-		IL_020f: stloc.s 6
-		IL_0211: ldloc.s 6
-		IL_0213: ldc.i4.0
-		IL_0214: ldelem.ref
-		IL_0215: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_021a: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_021f: ldc.i4.0
-		IL_0220: conv.r8
-		IL_0221: ldstr ""
-		IL_0226: ldc.i4.0
-		IL_0227: ldc.i4.0
-		IL_0228: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_022d: stloc.s 17
-		IL_022f: ldloc.1
-		IL_0230: ldloc.s 5
-		IL_0232: ldstr "construct-nonconstructible"
-		IL_0237: ldloc.s 17
-		IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_023e: pop
-		IL_023f: ldc.i4.1
-		IL_0240: newarr [System.Runtime]System.Object
-		IL_0245: dup
+		IL_017b: ldc.i4.0
+		IL_017c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0181: stloc.s 14
+		IL_0183: ldloc.0
+		IL_0184: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0189: ldnull
+		IL_018a: ldstr "apply-noncallable"
+		IL_018f: ldloc.s 14
+		IL_0191: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_0196: pop
+		IL_0197: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_019c: stloc.s 12
+		IL_019e: ldc.i4.1
+		IL_019f: newarr [System.Runtime]System.Object
+		IL_01a4: dup
+		IL_01a5: ldc.i4.0
+		IL_01a6: ldloc.0
+		IL_01a7: stelem.ref
+		IL_01a8: stloc.s 5
+		IL_01aa: ldloc.s 5
+		IL_01ac: ldc.i4.0
+		IL_01ad: ldelem.ref
+		IL_01ae: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_01b3: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_01b8: ldc.i4.0
+		IL_01b9: conv.r8
+		IL_01ba: ldstr ""
+		IL_01bf: ldc.i4.0
+		IL_01c0: ldc.i4.0
+		IL_01c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01c6: stloc.s 15
+		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01cd: dup
+		IL_01ce: ldstr "construct"
+		IL_01d3: ldloc.s 15
+		IL_01d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_01da: stloc.s 10
+		IL_01dc: ldloc.s 12
+		IL_01de: ldloc.s 10
+		IL_01e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_01e5: stloc.s 13
+		IL_01e7: ldloc.0
+		IL_01e8: ldloc.s 13
+		IL_01ea: stfld object Modules.Proxy_Validation_EdgeCases/Scope::constructProxy
+		IL_01ef: ldc.i4.1
+		IL_01f0: newarr [System.Runtime]System.Object
+		IL_01f5: dup
+		IL_01f6: ldc.i4.0
+		IL_01f7: ldloc.0
+		IL_01f8: stelem.ref
+		IL_01f9: stloc.s 5
+		IL_01fb: ldloc.s 5
+		IL_01fd: ldc.i4.0
+		IL_01fe: ldelem.ref
+		IL_01ff: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0204: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_0209: ldc.i4.0
+		IL_020a: conv.r8
+		IL_020b: ldstr ""
+		IL_0210: ldc.i4.0
+		IL_0211: ldc.i4.0
+		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0217: stloc.s 16
+		IL_0219: ldloc.0
+		IL_021a: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_021f: ldnull
+		IL_0220: ldstr "construct-nonconstructible"
+		IL_0225: ldloc.s 16
+		IL_0227: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_022c: pop
+		IL_022d: ldc.i4.1
+		IL_022e: newarr [System.Runtime]System.Object
+		IL_0233: dup
+		IL_0234: ldc.i4.0
+		IL_0235: ldloc.0
+		IL_0236: stelem.ref
+		IL_0237: stloc.s 5
+		IL_0239: newobj instance void Modules.Proxy_Validation_EdgeCases/Base/FunctionObject::.ctor()
+		IL_023e: ldc.i4.0
+		IL_023f: conv.r8
+		IL_0240: ldstr "Base"
+		IL_0245: ldc.i4.1
 		IL_0246: ldc.i4.0
-		IL_0247: ldloc.0
-		IL_0248: stelem.ref
-		IL_0249: stloc.s 5
-		IL_024b: newobj instance void Modules.Proxy_Validation_EdgeCases/Base/FunctionObject::.ctor()
-		IL_0250: ldc.i4.0
-		IL_0251: conv.r8
-		IL_0252: ldstr "Base"
-		IL_0257: ldc.i4.1
-		IL_0258: ldc.i4.0
-		IL_0259: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_025e: stloc.s 18
-		IL_0260: ldc.i4.1
-		IL_0261: newarr [System.Runtime]System.Object
-		IL_0266: dup
+		IL_0247: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_024c: stloc.s 17
+		IL_024e: ldc.i4.1
+		IL_024f: newarr [System.Runtime]System.Object
+		IL_0254: dup
+		IL_0255: ldc.i4.0
+		IL_0256: ldloc.0
+		IL_0257: stelem.ref
+		IL_0258: stloc.s 5
+		IL_025a: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject::.ctor()
+		IL_025f: ldc.i4.0
+		IL_0260: conv.r8
+		IL_0261: ldstr ""
+		IL_0266: ldc.i4.0
 		IL_0267: ldc.i4.0
-		IL_0268: ldloc.0
-		IL_0269: stelem.ref
-		IL_026a: stloc.s 5
-		IL_026c: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject::.ctor()
-		IL_0271: ldc.i4.0
-		IL_0272: conv.r8
-		IL_0273: ldstr ""
-		IL_0278: ldc.i4.0
-		IL_0279: ldc.i4.0
-		IL_027a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_027f: stloc.s 19
-		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0286: dup
-		IL_0287: ldstr "construct"
-		IL_028c: ldloc.s 19
-		IL_028e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0293: stloc.s 11
-		IL_0295: ldloc.s 18
-		IL_0297: ldloc.s 11
-		IL_0299: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_029e: stloc.s 14
-		IL_02a0: ldloc.0
-		IL_02a1: ldloc.s 14
-		IL_02a3: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badConstructResultProxy
-		IL_02a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02ad: stloc.s 5
-		IL_02af: ldc.i4.1
-		IL_02b0: newarr [System.Runtime]System.Object
-		IL_02b5: dup
-		IL_02b6: ldc.i4.0
-		IL_02b7: ldloc.0
-		IL_02b8: stelem.ref
-		IL_02b9: stloc.s 6
-		IL_02bb: ldloc.s 6
-		IL_02bd: ldc.i4.0
-		IL_02be: ldelem.ref
-		IL_02bf: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_02c4: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_02c9: ldc.i4.0
-		IL_02ca: conv.r8
-		IL_02cb: ldstr ""
-		IL_02d0: ldc.i4.0
-		IL_02d1: ldc.i4.0
-		IL_02d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02d7: stloc.s 20
-		IL_02d9: ldloc.1
-		IL_02da: ldloc.s 5
-		IL_02dc: ldstr "construct-primitive-result"
-		IL_02e1: ldloc.s 20
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_02e8: pop
-		IL_02e9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02ee: stloc.s 11
-		IL_02f0: ldc.i4.1
-		IL_02f1: newarr [System.Runtime]System.Object
-		IL_02f6: dup
-		IL_02f7: ldc.i4.0
-		IL_02f8: ldloc.0
-		IL_02f9: stelem.ref
-		IL_02fa: stloc.s 5
-		IL_02fc: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject::.ctor()
-		IL_0301: ldc.i4.0
-		IL_0302: conv.r8
-		IL_0303: ldstr ""
-		IL_0308: ldc.i4.0
-		IL_0309: ldc.i4.0
-		IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_030f: stloc.s 21
-		IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0316: dup
-		IL_0317: ldstr "getPrototypeOf"
-		IL_031c: ldloc.s 21
-		IL_031e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0323: stloc.s 13
-		IL_0325: ldloc.s 11
-		IL_0327: ldloc.s 13
-		IL_0329: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_032e: stloc.2
-		IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0334: stloc.s 22
-		IL_0336: ldloc.2
-		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_033c: stloc.s 23
-		IL_033e: ldloc.s 23
-		IL_0340: ldc.i4.0
-		IL_0341: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0346: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_034b: stloc.s 24
-		IL_034d: ldloc.s 24
-		IL_034f: box [System.Runtime]System.Boolean
-		IL_0354: stloc.s 25
-		IL_0356: ldloc.s 22
-		IL_0358: ldloc.s 25
-		IL_035a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_035f: pop
-		IL_0360: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0365: stloc.s 13
-		IL_0367: ldc.i4.1
-		IL_0368: newarr [System.Runtime]System.Object
-		IL_036d: dup
-		IL_036e: ldc.i4.0
-		IL_036f: ldloc.0
-		IL_0370: stelem.ref
-		IL_0371: stloc.s 5
-		IL_0373: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject::.ctor()
-		IL_0378: ldc.i4.0
-		IL_0379: conv.r8
-		IL_037a: ldstr ""
-		IL_037f: ldc.i4.0
-		IL_0380: ldc.i4.0
-		IL_0381: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0386: stloc.s 26
-		IL_0388: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_038d: dup
-		IL_038e: ldstr "getPrototypeOf"
-		IL_0393: ldloc.s 26
-		IL_0395: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_039a: stloc.s 11
-		IL_039c: ldloc.s 13
-		IL_039e: ldloc.s 11
-		IL_03a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_03a5: stloc.s 14
-		IL_03a7: ldloc.0
-		IL_03a8: ldloc.s 14
-		IL_03aa: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badGetPrototypeProxy
-		IL_03af: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03b4: stloc.s 5
-		IL_03b6: ldc.i4.1
-		IL_03b7: newarr [System.Runtime]System.Object
-		IL_03bc: dup
-		IL_03bd: ldc.i4.0
-		IL_03be: ldloc.0
-		IL_03bf: stelem.ref
-		IL_03c0: stloc.s 6
-		IL_03c2: ldloc.s 6
-		IL_03c4: ldc.i4.0
-		IL_03c5: ldelem.ref
-		IL_03c6: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_03cb: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_03d0: ldc.i4.0
-		IL_03d1: conv.r8
-		IL_03d2: ldstr ""
-		IL_03d7: ldc.i4.0
-		IL_03d8: ldc.i4.0
-		IL_03d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03de: stloc.s 27
-		IL_03e0: ldloc.1
-		IL_03e1: ldloc.s 5
-		IL_03e3: ldstr "getPrototypeOf-primitive"
-		IL_03e8: ldloc.s 27
-		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_03ef: pop
-		IL_03f0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03f5: stloc.s 11
-		IL_03f7: ldc.i4.1
-		IL_03f8: newarr [System.Runtime]System.Object
-		IL_03fd: dup
-		IL_03fe: ldc.i4.0
-		IL_03ff: ldloc.0
-		IL_0400: stelem.ref
-		IL_0401: stloc.s 5
-		IL_0403: ldloc.s 5
-		IL_0405: ldc.i4.0
-		IL_0406: ldelem.ref
-		IL_0407: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_040c: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_0411: ldc.i4.0
-		IL_0412: conv.r8
-		IL_0413: ldstr ""
-		IL_0418: ldc.i4.0
-		IL_0419: ldc.i4.0
-		IL_041a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_041f: stloc.s 28
-		IL_0421: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0426: dup
-		IL_0427: ldstr "ownKeys"
-		IL_042c: ldloc.s 28
-		IL_042e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0433: stloc.s 13
-		IL_0435: ldloc.s 11
-		IL_0437: ldloc.s 13
-		IL_0439: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_043e: stloc.3
-		IL_043f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0444: stloc.s 22
-		IL_0446: ldloc.3
-		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_044c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0451: volatile.
-		IL_0453: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0458: brfalse IL_0471
+		IL_0268: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_026d: stloc.s 18
+		IL_026f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0274: dup
+		IL_0275: ldstr "construct"
+		IL_027a: ldloc.s 18
+		IL_027c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0281: stloc.s 10
+		IL_0283: ldloc.s 17
+		IL_0285: ldloc.s 10
+		IL_0287: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_028c: stloc.s 13
+		IL_028e: ldloc.0
+		IL_028f: ldloc.s 13
+		IL_0291: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badConstructResultProxy
+		IL_0296: ldc.i4.1
+		IL_0297: newarr [System.Runtime]System.Object
+		IL_029c: dup
+		IL_029d: ldc.i4.0
+		IL_029e: ldloc.0
+		IL_029f: stelem.ref
+		IL_02a0: stloc.s 5
+		IL_02a2: ldloc.s 5
+		IL_02a4: ldc.i4.0
+		IL_02a5: ldelem.ref
+		IL_02a6: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_02ab: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_02b0: ldc.i4.0
+		IL_02b1: conv.r8
+		IL_02b2: ldstr ""
+		IL_02b7: ldc.i4.0
+		IL_02b8: ldc.i4.0
+		IL_02b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02be: stloc.s 19
+		IL_02c0: ldloc.0
+		IL_02c1: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_02c6: ldnull
+		IL_02c7: ldstr "construct-primitive-result"
+		IL_02cc: ldloc.s 19
+		IL_02ce: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_02d3: pop
+		IL_02d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02d9: stloc.s 10
+		IL_02db: ldc.i4.1
+		IL_02dc: newarr [System.Runtime]System.Object
+		IL_02e1: dup
+		IL_02e2: ldc.i4.0
+		IL_02e3: ldloc.0
+		IL_02e4: stelem.ref
+		IL_02e5: stloc.s 5
+		IL_02e7: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject::.ctor()
+		IL_02ec: ldc.i4.0
+		IL_02ed: conv.r8
+		IL_02ee: ldstr ""
+		IL_02f3: ldc.i4.0
+		IL_02f4: ldc.i4.0
+		IL_02f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02fa: stloc.s 20
+		IL_02fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0301: dup
+		IL_0302: ldstr "getPrototypeOf"
+		IL_0307: ldloc.s 20
+		IL_0309: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_030e: stloc.s 12
+		IL_0310: ldloc.s 10
+		IL_0312: ldloc.s 12
+		IL_0314: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0319: stloc.2
+		IL_031a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_031f: stloc.s 21
+		IL_0321: ldloc.2
+		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0327: stloc.s 22
+		IL_0329: ldloc.s 22
+		IL_032b: ldc.i4.0
+		IL_032c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0331: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0336: stloc.s 23
+		IL_0338: ldloc.s 23
+		IL_033a: box [System.Runtime]System.Boolean
+		IL_033f: stloc.s 24
+		IL_0341: ldloc.s 21
+		IL_0343: ldloc.s 24
+		IL_0345: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_034a: pop
+		IL_034b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0350: stloc.s 12
+		IL_0352: ldc.i4.1
+		IL_0353: newarr [System.Runtime]System.Object
+		IL_0358: dup
+		IL_0359: ldc.i4.0
+		IL_035a: ldloc.0
+		IL_035b: stelem.ref
+		IL_035c: stloc.s 5
+		IL_035e: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject::.ctor()
+		IL_0363: ldc.i4.0
+		IL_0364: conv.r8
+		IL_0365: ldstr ""
+		IL_036a: ldc.i4.0
+		IL_036b: ldc.i4.0
+		IL_036c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0371: stloc.s 25
+		IL_0373: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0378: dup
+		IL_0379: ldstr "getPrototypeOf"
+		IL_037e: ldloc.s 25
+		IL_0380: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0385: stloc.s 10
+		IL_0387: ldloc.s 12
+		IL_0389: ldloc.s 10
+		IL_038b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0390: stloc.s 13
+		IL_0392: ldloc.0
+		IL_0393: ldloc.s 13
+		IL_0395: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badGetPrototypeProxy
+		IL_039a: ldc.i4.1
+		IL_039b: newarr [System.Runtime]System.Object
+		IL_03a0: dup
+		IL_03a1: ldc.i4.0
+		IL_03a2: ldloc.0
+		IL_03a3: stelem.ref
+		IL_03a4: stloc.s 5
+		IL_03a6: ldloc.s 5
+		IL_03a8: ldc.i4.0
+		IL_03a9: ldelem.ref
+		IL_03aa: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_03af: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_03b4: ldc.i4.0
+		IL_03b5: conv.r8
+		IL_03b6: ldstr ""
+		IL_03bb: ldc.i4.0
+		IL_03bc: ldc.i4.0
+		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03c2: stloc.s 26
+		IL_03c4: ldloc.0
+		IL_03c5: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_03ca: ldnull
+		IL_03cb: ldstr "getPrototypeOf-primitive"
+		IL_03d0: ldloc.s 26
+		IL_03d2: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_03d7: pop
+		IL_03d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03dd: stloc.s 10
+		IL_03df: ldc.i4.1
+		IL_03e0: newarr [System.Runtime]System.Object
+		IL_03e5: dup
+		IL_03e6: ldc.i4.0
+		IL_03e7: ldloc.0
+		IL_03e8: stelem.ref
+		IL_03e9: stloc.s 5
+		IL_03eb: ldloc.s 5
+		IL_03ed: ldc.i4.0
+		IL_03ee: ldelem.ref
+		IL_03ef: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_03f4: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_03f9: ldc.i4.0
+		IL_03fa: conv.r8
+		IL_03fb: ldstr ""
+		IL_0400: ldc.i4.0
+		IL_0401: ldc.i4.0
+		IL_0402: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0407: stloc.s 27
+		IL_0409: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_040e: dup
+		IL_040f: ldstr "ownKeys"
+		IL_0414: ldloc.s 27
+		IL_0416: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_041b: stloc.s 12
+		IL_041d: ldloc.s 10
+		IL_041f: ldloc.s 12
+		IL_0421: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0426: stloc.3
+		IL_0427: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_042c: stloc.s 21
+		IL_042e: ldloc.3
+		IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0439: volatile.
+		IL_043b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0440: brfalse IL_0459
 
-		IL_045d: ldstr "join"
-		IL_0462: ldstr ","
-		IL_0467: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_046c: br IL_048a
+		IL_0445: ldstr "join"
+		IL_044a: ldstr ","
+		IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0454: br IL_0472
 
-		IL_0471: ldstr "join"
-		IL_0476: ldstr ","
-		IL_047b: ldstr "Proxy_Validation_EdgeCases:Modules.Proxy_Validation_EdgeCases:__js_module_init__:111"
-		IL_0480: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0459: ldstr "join"
+		IL_045e: ldstr ","
+		IL_0463: ldstr "Proxy_Validation_EdgeCases:Modules.Proxy_Validation_EdgeCases:__js_module_init__:111"
+		IL_0468: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_048a: stloc.s 23
-		IL_048c: ldloc.s 22
-		IL_048e: ldloc.s 23
-		IL_0490: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0495: pop
-		IL_0496: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_049b: stloc.s 13
-		IL_049d: ldc.i4.1
-		IL_049e: newarr [System.Runtime]System.Object
-		IL_04a3: dup
-		IL_04a4: ldc.i4.0
-		IL_04a5: ldloc.0
-		IL_04a6: stelem.ref
-		IL_04a7: stloc.s 5
-		IL_04a9: ldloc.s 5
-		IL_04ab: ldc.i4.0
-		IL_04ac: ldelem.ref
-		IL_04ad: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_04b2: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_04b7: ldc.i4.0
-		IL_04b8: conv.r8
-		IL_04b9: ldstr ""
-		IL_04be: ldc.i4.0
-		IL_04bf: ldc.i4.0
-		IL_04c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04c5: stloc.s 29
-		IL_04c7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04cc: dup
-		IL_04cd: ldstr "ownKeys"
-		IL_04d2: ldloc.s 29
-		IL_04d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_04d9: stloc.s 11
-		IL_04db: ldloc.s 13
-		IL_04dd: ldloc.s 11
-		IL_04df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_04e4: stloc.s 4
-		IL_04e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04eb: stloc.s 22
-		IL_04ed: ldloc.s 4
-		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04f9: volatile.
-		IL_04fb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_0500: brfalse IL_0519
+		IL_0472: stloc.s 22
+		IL_0474: ldloc.s 21
+		IL_0476: ldloc.s 22
+		IL_0478: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_047d: pop
+		IL_047e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0483: stloc.s 12
+		IL_0485: ldc.i4.1
+		IL_0486: newarr [System.Runtime]System.Object
+		IL_048b: dup
+		IL_048c: ldc.i4.0
+		IL_048d: ldloc.0
+		IL_048e: stelem.ref
+		IL_048f: stloc.s 5
+		IL_0491: ldloc.s 5
+		IL_0493: ldc.i4.0
+		IL_0494: ldelem.ref
+		IL_0495: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_049a: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_049f: ldc.i4.0
+		IL_04a0: conv.r8
+		IL_04a1: ldstr ""
+		IL_04a6: ldc.i4.0
+		IL_04a7: ldc.i4.0
+		IL_04a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04ad: stloc.s 28
+		IL_04af: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04b4: dup
+		IL_04b5: ldstr "ownKeys"
+		IL_04ba: ldloc.s 28
+		IL_04bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_04c1: stloc.s 10
+		IL_04c3: ldloc.s 12
+		IL_04c5: ldloc.s 10
+		IL_04c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_04cc: stloc.s 4
+		IL_04ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04d3: stloc.s 21
+		IL_04d5: ldloc.s 4
+		IL_04d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04e1: volatile.
+		IL_04e3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_04e8: brfalse IL_0501
 
-		IL_0505: ldstr "join"
-		IL_050a: ldstr ","
-		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0514: br IL_0532
+		IL_04ed: ldstr "join"
+		IL_04f2: ldstr ","
+		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04fc: br IL_051a
 
-		IL_0519: ldstr "join"
-		IL_051e: ldstr ","
-		IL_0523: ldstr "Proxy_Validation_EdgeCases:Modules.Proxy_Validation_EdgeCases:__js_module_init__:125"
-		IL_0528: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_0501: ldstr "join"
+		IL_0506: ldstr ","
+		IL_050b: ldstr "Proxy_Validation_EdgeCases:Modules.Proxy_Validation_EdgeCases:__js_module_init__:125"
+		IL_0510: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0532: stloc.s 23
-		IL_0534: ldloc.s 22
-		IL_0536: ldloc.s 23
-		IL_0538: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_053d: pop
-		IL_053e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0543: stloc.s 11
-		IL_0545: ldc.i4.1
-		IL_0546: newarr [System.Runtime]System.Object
-		IL_054b: dup
-		IL_054c: ldc.i4.0
-		IL_054d: ldloc.0
-		IL_054e: stelem.ref
-		IL_054f: stloc.s 5
-		IL_0551: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject::.ctor()
-		IL_0556: ldc.i4.0
-		IL_0557: conv.r8
-		IL_0558: ldstr ""
-		IL_055d: ldc.i4.0
-		IL_055e: ldc.i4.0
-		IL_055f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0564: stloc.s 30
-		IL_0566: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_056b: dup
-		IL_056c: ldstr "ownKeys"
-		IL_0571: ldloc.s 30
-		IL_0573: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0578: stloc.s 13
-		IL_057a: ldloc.s 11
-		IL_057c: ldloc.s 13
-		IL_057e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0583: stloc.s 14
-		IL_0585: ldloc.0
-		IL_0586: ldloc.s 14
-		IL_0588: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
-		IL_058d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0592: stloc.s 5
-		IL_0594: ldc.i4.1
-		IL_0595: newarr [System.Runtime]System.Object
-		IL_059a: dup
-		IL_059b: ldc.i4.0
-		IL_059c: ldloc.0
-		IL_059d: stelem.ref
-		IL_059e: stloc.s 6
-		IL_05a0: ldloc.s 6
-		IL_05a2: ldc.i4.0
-		IL_05a3: ldelem.ref
-		IL_05a4: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_05a9: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_05ae: ldc.i4.0
-		IL_05af: conv.r8
-		IL_05b0: ldstr ""
-		IL_05b5: ldc.i4.0
-		IL_05b6: ldc.i4.0
-		IL_05b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05bc: stloc.s 31
-		IL_05be: ldloc.1
-		IL_05bf: ldloc.s 5
-		IL_05c1: ldstr "ownKeys-primitive"
-		IL_05c6: ldloc.s 31
-		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_05cd: pop
-		IL_05ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_05d3: stloc.s 13
-		IL_05d5: ldc.i4.1
-		IL_05d6: newarr [System.Runtime]System.Object
-		IL_05db: dup
-		IL_05dc: ldc.i4.0
-		IL_05dd: ldloc.0
-		IL_05de: stelem.ref
-		IL_05df: stloc.s 5
-		IL_05e1: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject::.ctor()
-		IL_05e6: ldc.i4.0
-		IL_05e7: conv.r8
-		IL_05e8: ldstr ""
-		IL_05ed: ldc.i4.0
-		IL_05ee: ldc.i4.0
-		IL_05ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05f4: stloc.s 32
-		IL_05f6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_05fb: dup
-		IL_05fc: ldstr "ownKeys"
-		IL_0601: ldloc.s 32
-		IL_0603: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0608: stloc.s 11
-		IL_060a: ldloc.s 13
-		IL_060c: ldloc.s 11
-		IL_060e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0613: stloc.s 14
-		IL_0615: ldloc.0
-		IL_0616: ldloc.s 14
-		IL_0618: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
-		IL_061d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0622: stloc.s 5
-		IL_0624: ldc.i4.1
-		IL_0625: newarr [System.Runtime]System.Object
-		IL_062a: dup
-		IL_062b: ldc.i4.0
+		IL_051a: stloc.s 22
+		IL_051c: ldloc.s 21
+		IL_051e: ldloc.s 22
+		IL_0520: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0525: pop
+		IL_0526: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_052b: stloc.s 10
+		IL_052d: ldc.i4.1
+		IL_052e: newarr [System.Runtime]System.Object
+		IL_0533: dup
+		IL_0534: ldc.i4.0
+		IL_0535: ldloc.0
+		IL_0536: stelem.ref
+		IL_0537: stloc.s 5
+		IL_0539: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject::.ctor()
+		IL_053e: ldc.i4.0
+		IL_053f: conv.r8
+		IL_0540: ldstr ""
+		IL_0545: ldc.i4.0
+		IL_0546: ldc.i4.0
+		IL_0547: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_054c: stloc.s 29
+		IL_054e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0553: dup
+		IL_0554: ldstr "ownKeys"
+		IL_0559: ldloc.s 29
+		IL_055b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0560: stloc.s 12
+		IL_0562: ldloc.s 10
+		IL_0564: ldloc.s 12
+		IL_0566: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_056b: stloc.s 13
+		IL_056d: ldloc.0
+		IL_056e: ldloc.s 13
+		IL_0570: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
+		IL_0575: ldc.i4.1
+		IL_0576: newarr [System.Runtime]System.Object
+		IL_057b: dup
+		IL_057c: ldc.i4.0
+		IL_057d: ldloc.0
+		IL_057e: stelem.ref
+		IL_057f: stloc.s 5
+		IL_0581: ldloc.s 5
+		IL_0583: ldc.i4.0
+		IL_0584: ldelem.ref
+		IL_0585: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_058a: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_058f: ldc.i4.0
+		IL_0590: conv.r8
+		IL_0591: ldstr ""
+		IL_0596: ldc.i4.0
+		IL_0597: ldc.i4.0
+		IL_0598: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_059d: stloc.s 30
+		IL_059f: ldloc.0
+		IL_05a0: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_05a5: ldnull
+		IL_05a6: ldstr "ownKeys-primitive"
+		IL_05ab: ldloc.s 30
+		IL_05ad: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_05b2: pop
+		IL_05b3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_05b8: stloc.s 12
+		IL_05ba: ldc.i4.1
+		IL_05bb: newarr [System.Runtime]System.Object
+		IL_05c0: dup
+		IL_05c1: ldc.i4.0
+		IL_05c2: ldloc.0
+		IL_05c3: stelem.ref
+		IL_05c4: stloc.s 5
+		IL_05c6: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject::.ctor()
+		IL_05cb: ldc.i4.0
+		IL_05cc: conv.r8
+		IL_05cd: ldstr ""
+		IL_05d2: ldc.i4.0
+		IL_05d3: ldc.i4.0
+		IL_05d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05d9: stloc.s 31
+		IL_05db: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_05e0: dup
+		IL_05e1: ldstr "ownKeys"
+		IL_05e6: ldloc.s 31
+		IL_05e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_05ed: stloc.s 10
+		IL_05ef: ldloc.s 12
+		IL_05f1: ldloc.s 10
+		IL_05f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_05f8: stloc.s 13
+		IL_05fa: ldloc.0
+		IL_05fb: ldloc.s 13
+		IL_05fd: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
+		IL_0602: ldc.i4.1
+		IL_0603: newarr [System.Runtime]System.Object
+		IL_0608: dup
+		IL_0609: ldc.i4.0
+		IL_060a: ldloc.0
+		IL_060b: stelem.ref
+		IL_060c: stloc.s 5
+		IL_060e: ldloc.s 5
+		IL_0610: ldc.i4.0
+		IL_0611: ldelem.ref
+		IL_0612: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0617: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_061c: ldc.i4.0
+		IL_061d: conv.r8
+		IL_061e: ldstr ""
+		IL_0623: ldc.i4.0
+		IL_0624: ldc.i4.0
+		IL_0625: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_062a: stloc.s 32
 		IL_062c: ldloc.0
-		IL_062d: stelem.ref
-		IL_062e: stloc.s 6
-		IL_0630: ldloc.s 6
-		IL_0632: ldc.i4.0
-		IL_0633: ldelem.ref
-		IL_0634: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0639: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
-		IL_063e: ldc.i4.0
-		IL_063f: conv.r8
-		IL_0640: ldstr ""
-		IL_0645: ldc.i4.0
-		IL_0646: ldc.i4.0
-		IL_0647: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_064c: stloc.s 33
-		IL_064e: ldloc.1
-		IL_064f: ldloc.s 5
-		IL_0651: ldstr "ownKeys-entry"
-		IL_0656: ldloc.s 33
-		IL_0658: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_065d: pop
-		IL_065e: ret
+		IL_062d: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0632: ldnull
+		IL_0633: ldstr "ownKeys-entry"
+		IL_0638: ldloc.s 32
+		IL_063a: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+		IL_063f: pop
+		IL_0640: ret
 	} // end of method Proxy_Validation_EdgeCases::__js_module_init__
 
 } // end of class Modules.Proxy_Validation_EdgeCases

--- a/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_MixedNumeric_BoxedArithmetic.verified.txt
+++ b/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_MixedNumeric_BoxedArithmetic.verified.txt
@@ -252,7 +252,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 274 (0x112)
+		// Code size: 246 (0xf6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/Scope,
@@ -285,94 +285,86 @@
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
-		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002d: stloc.s 4
-		IL_002f: ldloc.1
-		IL_0030: ldloc.s 4
-		IL_0032: ldc.r8 3
-		IL_003b: box [System.Runtime]System.Double
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0045: stloc.s 5
-		IL_0047: ldloc.s 5
-		IL_0049: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_004e: stloc.2
-		IL_004f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0054: stloc.s 4
-		IL_0056: ldloc.1
-		IL_0057: ldloc.s 4
-		IL_0059: ldc.r8 4
-		IL_0062: box [System.Runtime]System.Double
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_006c: stloc.s 5
-		IL_006e: ldloc.s 5
-		IL_0070: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0075: stloc.3
-		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007b: stloc.s 6
-		IL_007d: ldloc.2
-		IL_007e: ldloc.3
-		IL_007f: add
-		IL_0080: stloc.s 7
-		IL_0082: ldloc.s 7
-		IL_0084: box [System.Runtime]System.Double
-		IL_0089: stloc.s 8
-		IL_008b: ldloc.s 6
-		IL_008d: ldloc.s 8
-		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0094: pop
-		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009a: stloc.s 6
-		IL_009c: ldloc.2
-		IL_009d: ldloc.3
-		IL_009e: sub
-		IL_009f: stloc.s 7
-		IL_00a1: ldloc.s 7
-		IL_00a3: box [System.Runtime]System.Double
-		IL_00a8: stloc.s 8
-		IL_00aa: ldloc.s 6
-		IL_00ac: ldloc.s 8
-		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b3: pop
-		IL_00b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b9: stloc.s 6
-		IL_00bb: ldloc.2
-		IL_00bc: ldloc.3
-		IL_00bd: mul
-		IL_00be: stloc.s 7
-		IL_00c0: ldloc.s 7
-		IL_00c2: box [System.Runtime]System.Double
-		IL_00c7: stloc.s 8
-		IL_00c9: ldloc.s 6
-		IL_00cb: ldloc.s 8
-		IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d2: pop
-		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d8: stloc.s 6
-		IL_00da: ldloc.2
-		IL_00db: ldloc.3
-		IL_00dc: div
-		IL_00dd: stloc.s 7
-		IL_00df: ldloc.s 7
-		IL_00e1: box [System.Runtime]System.Double
-		IL_00e6: stloc.s 8
-		IL_00e8: ldloc.s 6
-		IL_00ea: ldloc.s 8
-		IL_00ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f1: pop
-		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f7: stloc.s 6
-		IL_00f9: ldloc.2
-		IL_00fa: ldloc.3
-		IL_00fb: rem
-		IL_00fc: stloc.s 7
-		IL_00fe: ldloc.s 7
-		IL_0100: box [System.Runtime]System.Double
-		IL_0105: stloc.s 8
-		IL_0107: ldloc.s 6
-		IL_0109: ldloc.s 8
-		IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0110: pop
-		IL_0111: ret
+		IL_0028: ldnull
+		IL_0029: ldc.r8 3
+		IL_0032: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
+		IL_0037: stloc.s 5
+		IL_0039: ldloc.s 5
+		IL_003b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0040: stloc.2
+		IL_0041: ldnull
+		IL_0042: ldc.r8 4
+		IL_004b: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
+		IL_0050: stloc.s 5
+		IL_0052: ldloc.s 5
+		IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0059: stloc.3
+		IL_005a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_005f: stloc.s 6
+		IL_0061: ldloc.2
+		IL_0062: ldloc.3
+		IL_0063: add
+		IL_0064: stloc.s 7
+		IL_0066: ldloc.s 7
+		IL_0068: box [System.Runtime]System.Double
+		IL_006d: stloc.s 8
+		IL_006f: ldloc.s 6
+		IL_0071: ldloc.s 8
+		IL_0073: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0078: pop
+		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007e: stloc.s 6
+		IL_0080: ldloc.2
+		IL_0081: ldloc.3
+		IL_0082: sub
+		IL_0083: stloc.s 7
+		IL_0085: ldloc.s 7
+		IL_0087: box [System.Runtime]System.Double
+		IL_008c: stloc.s 8
+		IL_008e: ldloc.s 6
+		IL_0090: ldloc.s 8
+		IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0097: pop
+		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009d: stloc.s 6
+		IL_009f: ldloc.2
+		IL_00a0: ldloc.3
+		IL_00a1: mul
+		IL_00a2: stloc.s 7
+		IL_00a4: ldloc.s 7
+		IL_00a6: box [System.Runtime]System.Double
+		IL_00ab: stloc.s 8
+		IL_00ad: ldloc.s 6
+		IL_00af: ldloc.s 8
+		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b6: pop
+		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bc: stloc.s 6
+		IL_00be: ldloc.2
+		IL_00bf: ldloc.3
+		IL_00c0: div
+		IL_00c1: stloc.s 7
+		IL_00c3: ldloc.s 7
+		IL_00c5: box [System.Runtime]System.Double
+		IL_00ca: stloc.s 8
+		IL_00cc: ldloc.s 6
+		IL_00ce: ldloc.s 8
+		IL_00d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d5: pop
+		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00db: stloc.s 6
+		IL_00dd: ldloc.2
+		IL_00de: ldloc.3
+		IL_00df: rem
+		IL_00e0: stloc.s 7
+		IL_00e2: ldloc.s 7
+		IL_00e4: box [System.Runtime]System.Double
+		IL_00e9: stloc.s 8
+		IL_00eb: ldloc.s 6
+		IL_00ed: ldloc.s 8
+		IL_00ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f4: pop
+		IL_00f5: ret
 	} // end of method ShapeCoverage_MixedNumeric_BoxedArithmetic::__js_module_init__
 
 } // end of class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_IntrinsicGuard_HoistedLoop.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_IntrinsicGuard_HoistedLoop.verified.txt
@@ -898,7 +898,7 @@
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
 			// Header size: 12
-			// Code size: 245 (0xf5)
+			// Code size: 226 (0xe2)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -923,7 +923,7 @@
 				IL_0010: ldloc.3
 				IL_0011: ldc.r8 3
 				IL_001a: clt
-				IL_001c: brfalse IL_00e5
+				IL_001c: brfalse IL_00d2
 
 				IL_0021: ldarg.2
 				IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
@@ -955,61 +955,52 @@
 				IL_0066: ldloc.3
 				IL_0067: ldc.r8 0.0
 				IL_0070: ceq
-				IL_0072: brfalse IL_0091
+				IL_0072: brfalse IL_007e
 
-				IL_0077: ldarg.0
-				IL_0078: ldfld object Modules.String_IntrinsicGuard_HoistedLoop/Scope::mutateStringPrototype
-				IL_007d: stloc.s 6
-				IL_007f: ldloc.s 6
-				IL_0081: ldc.i4.1
-				IL_0082: newarr [System.Runtime]System.Object
-				IL_0087: dup
-				IL_0088: ldc.i4.0
-				IL_0089: ldarg.0
-				IL_008a: stelem.ref
-				IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0090: pop
+				IL_0077: ldnull
+				IL_0078: call object Modules.String_IntrinsicGuard_HoistedLoop/mutateStringPrototype::__js_call__(object)
+				IL_007d: pop
 
-				IL_0091: ldarg.2
-				IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-				IL_0097: stloc.s 4
-				IL_0099: ldloc.2
-				IL_009a: box [System.Runtime]System.Double
-				IL_009f: stloc.s 5
-				IL_00a1: ldc.i4.0
-				IL_00a2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_00a7: brfalse IL_00c1
+				IL_007e: ldarg.2
+				IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+				IL_0084: stloc.s 4
+				IL_0086: ldloc.2
+				IL_0087: box [System.Runtime]System.Double
+				IL_008c: stloc.s 5
+				IL_008e: ldc.i4.0
+				IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0094: brfalse IL_00ae
 
-				IL_00ac: ldloc.s 4
-				IL_00ae: ldloc.s 5
-				IL_00b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-				IL_00b5: box [System.Runtime]System.Double
-				IL_00ba: stloc.s 6
-				IL_00bc: br IL_00d1
+				IL_0099: ldloc.s 4
+				IL_009b: ldloc.s 5
+				IL_009d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_00a2: box [System.Runtime]System.Double
+				IL_00a7: stloc.s 6
+				IL_00a9: br IL_00be
 
-				IL_00c1: ldloc.s 4
-				IL_00c3: ldstr "charCodeAt"
-				IL_00c8: ldloc.s 5
-				IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00cf: stloc.s 6
+				IL_00ae: ldloc.s 4
+				IL_00b0: ldstr "charCodeAt"
+				IL_00b5: ldloc.s 5
+				IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00bc: stloc.s 6
 
-				IL_00d1: ldloc.s 6
-				IL_00d3: stloc.1
-				IL_00d4: ldloc.2
-				IL_00d5: ldc.r8 1
-				IL_00de: add
-				IL_00df: stloc.2
-				IL_00e0: br IL_000e
+				IL_00be: ldloc.s 6
+				IL_00c0: stloc.1
+				IL_00c1: ldloc.2
+				IL_00c2: ldc.r8 1
+				IL_00cb: add
+				IL_00cc: stloc.2
+				IL_00cd: br IL_000e
 			// end loop
 
-			IL_00e5: ldloc.0
-			IL_00e6: stloc.s 6
-			IL_00e8: ldloc.s 6
-			IL_00ea: ldloc.1
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00f0: stloc.s 7
-			IL_00f2: ldloc.s 7
-			IL_00f4: ret
+			IL_00d2: ldloc.0
+			IL_00d3: stloc.s 6
+			IL_00d5: ldloc.s 6
+			IL_00d7: ldloc.1
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00dd: stloc.s 7
+			IL_00df: ldloc.s 7
+			IL_00e1: ret
 		} // end of method sumWithUnknownMutation::__js_call__
 
 	} // end of class sumWithUnknownMutation
@@ -1430,7 +1421,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 971 (0x3cb)
+		// Code size: 963 (0x3c3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_IntrinsicGuard_HoistedLoop/Scope,
@@ -1512,267 +1503,265 @@
 		IL_0087: nop
 		IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_008d: stloc.s 8
-		IL_008f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0094: stloc.s 6
-		IL_0096: ldloc.1
-		IL_0097: ldloc.s 6
-		IL_0099: ldstr "abc"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00a3: stloc.s 9
-		IL_00a5: ldloc.s 8
-		IL_00a7: ldloc.s 9
-		IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ae: pop
-		IL_00af: ldstr "String"
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b9: volatile.
-		IL_00bb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_00c0: brfalse IL_00d4
+		IL_008f: ldloc.0
+		IL_0090: castclass Modules.String_IntrinsicGuard_HoistedLoop/Scope
+		IL_0095: ldnull
+		IL_0096: ldstr "abc"
+		IL_009b: call object Modules.String_IntrinsicGuard_HoistedLoop/lastCodes::__js_call__(class Modules.String_IntrinsicGuard_HoistedLoop/Scope, object, object)
+		IL_00a0: stloc.s 9
+		IL_00a2: ldloc.s 8
+		IL_00a4: ldloc.s 9
+		IL_00a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ab: pop
+		IL_00ac: ldstr "String"
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b6: volatile.
+		IL_00b8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00bd: brfalse IL_00d1
 
-		IL_00c5: ldstr "prototype"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00cf: br IL_00e8
+		IL_00c2: ldstr "prototype"
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00cc: br IL_00e5
 
-		IL_00d4: ldstr "prototype"
-		IL_00d9: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:23"
-		IL_00de: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00d1: ldstr "prototype"
+		IL_00d6: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:23"
+		IL_00db: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00e8: stloc.s 9
-		IL_00ea: volatile.
-		IL_00ec: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_00f1: brfalse IL_0107
+		IL_00e5: stloc.s 9
+		IL_00e7: volatile.
+		IL_00e9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00ee: brfalse IL_0104
 
-		IL_00f6: ldloc.s 9
-		IL_00f8: ldstr "charCodeAt"
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0102: br IL_011d
+		IL_00f3: ldloc.s 9
+		IL_00f5: ldstr "charCodeAt"
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ff: br IL_011a
 
-		IL_0107: ldloc.s 9
-		IL_0109: ldstr "charCodeAt"
-		IL_010e: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:25"
-		IL_0113: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0104: ldloc.s 9
+		IL_0106: ldstr "charCodeAt"
+		IL_010b: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:25"
+		IL_0110: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_011d: stloc.3
-		IL_011e: ldstr "String"
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0128: volatile.
-		IL_012a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_012f: brfalse IL_0143
+		IL_011a: stloc.3
+		IL_011b: ldstr "String"
+		IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0125: volatile.
+		IL_0127: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_012c: brfalse IL_0140
 
-		IL_0134: ldstr "prototype"
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013e: br IL_0157
+		IL_0131: ldstr "prototype"
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013b: br IL_0154
 
-		IL_0143: ldstr "prototype"
-		IL_0148: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:31"
-		IL_014d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0140: ldstr "prototype"
+		IL_0145: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:31"
+		IL_014a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0157: stloc.s 9
-		IL_0159: ldloc.s 9
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0160: stloc.s 4
-		IL_0162: nop
-		IL_0163: nop
-		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0169: stloc.s 8
-		IL_016b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0170: stloc.s 6
-		IL_0172: ldloc.2
-		IL_0173: ldloc.s 6
-		IL_0175: ldstr "abc"
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_017f: stloc.s 9
-		IL_0181: ldloc.s 8
-		IL_0183: ldloc.s 9
-		IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018a: pop
-		IL_018b: ldstr "String"
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0195: volatile.
-		IL_0197: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_019c: brfalse IL_01b0
+		IL_0154: stloc.s 9
+		IL_0156: ldloc.s 9
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_015d: stloc.s 4
+		IL_015f: nop
+		IL_0160: nop
+		IL_0161: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0166: stloc.s 8
+		IL_0168: ldloc.0
+		IL_0169: castclass Modules.String_IntrinsicGuard_HoistedLoop/Scope
+		IL_016e: ldnull
+		IL_016f: ldstr "abc"
+		IL_0174: call object Modules.String_IntrinsicGuard_HoistedLoop/sumWithUnknownMutation::__js_call__(class Modules.String_IntrinsicGuard_HoistedLoop/Scope, object, string)
+		IL_0179: stloc.s 9
+		IL_017b: ldloc.s 8
+		IL_017d: ldloc.s 9
+		IL_017f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0184: pop
+		IL_0185: ldstr "String"
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_018f: volatile.
+		IL_0191: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0196: brfalse IL_01aa
 
-		IL_01a1: ldstr "prototype"
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ab: br IL_01c4
+		IL_019b: ldstr "prototype"
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a5: br IL_01be
 
-		IL_01b0: ldstr "prototype"
-		IL_01b5: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:46"
-		IL_01ba: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01aa: ldstr "prototype"
+		IL_01af: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:46"
+		IL_01b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_01c4: stloc.s 9
-		IL_01c6: ldloc.s 9
-		IL_01c8: ldstr "charCodeAt"
-		IL_01cd: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_01d2: stloc.s 10
-		IL_01d4: ldstr "String"
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01de: volatile.
-		IL_01e0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_01e5: brfalse IL_01f9
+		IL_01be: stloc.s 9
+		IL_01c0: ldloc.s 9
+		IL_01c2: ldstr "charCodeAt"
+		IL_01c7: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_01cc: stloc.s 10
+		IL_01ce: ldstr "String"
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01d8: volatile.
+		IL_01da: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_01df: brfalse IL_01f3
 
-		IL_01ea: ldstr "prototype"
-		IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f4: br IL_020d
+		IL_01e4: ldstr "prototype"
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ee: br IL_0207
 
-		IL_01f9: ldstr "prototype"
-		IL_01fe: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:54"
-		IL_0203: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_01f3: ldstr "prototype"
+		IL_01f8: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:54"
+		IL_01fd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_020d: stloc.s 9
-		IL_020f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0214: stloc.s 11
-		IL_0216: ldc.i4.1
-		IL_0217: newarr [System.Runtime]System.Object
-		IL_021c: dup
-		IL_021d: ldc.i4.0
-		IL_021e: ldloc.0
-		IL_021f: stelem.ref
-		IL_0220: stloc.s 6
-		IL_0222: newobj instance void Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L41C14/FunctionObject::.ctor()
-		IL_0227: ldc.i4.1
-		IL_0228: conv.r8
-		IL_0229: ldstr ""
-		IL_022e: ldc.i4.0
-		IL_022f: ldc.i4.0
-		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L41C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L41C14/FunctionObject>(!!0)
-		IL_023a: stloc.s 12
-		IL_023c: ldloc.s 11
-		IL_023e: ldstr "charCodeAt"
-		IL_0243: ldloc.s 12
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_024a: pop
-		IL_024b: ldloc.s 9
-		IL_024d: ldloc.s 11
-		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_0254: pop
-		IL_0255: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_025a: stloc.s 8
-		IL_025c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0261: stloc.s 6
-		IL_0263: ldloc.1
-		IL_0264: ldloc.s 6
-		IL_0266: ldstr "abc"
-		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0270: stloc.s 9
-		IL_0272: ldloc.s 8
-		IL_0274: ldloc.s 9
-		IL_0276: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_027b: pop
-		IL_027c: ldstr "String"
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0286: volatile.
-		IL_0288: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_028d: brfalse IL_02a1
+		IL_0207: stloc.s 9
+		IL_0209: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_020e: stloc.s 11
+		IL_0210: ldc.i4.1
+		IL_0211: newarr [System.Runtime]System.Object
+		IL_0216: dup
+		IL_0217: ldc.i4.0
+		IL_0218: ldloc.0
+		IL_0219: stelem.ref
+		IL_021a: stloc.s 6
+		IL_021c: newobj instance void Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L41C14/FunctionObject::.ctor()
+		IL_0221: ldc.i4.1
+		IL_0222: conv.r8
+		IL_0223: ldstr ""
+		IL_0228: ldc.i4.0
+		IL_0229: ldc.i4.0
+		IL_022a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L41C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_022f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L41C14/FunctionObject>(!!0)
+		IL_0234: stloc.s 12
+		IL_0236: ldloc.s 11
+		IL_0238: ldstr "charCodeAt"
+		IL_023d: ldloc.s 12
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0244: pop
+		IL_0245: ldloc.s 9
+		IL_0247: ldloc.s 11
+		IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_024e: pop
+		IL_024f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0254: stloc.s 8
+		IL_0256: ldloc.0
+		IL_0257: castclass Modules.String_IntrinsicGuard_HoistedLoop/Scope
+		IL_025c: ldnull
+		IL_025d: ldstr "abc"
+		IL_0262: call object Modules.String_IntrinsicGuard_HoistedLoop/lastCodes::__js_call__(class Modules.String_IntrinsicGuard_HoistedLoop/Scope, object, object)
+		IL_0267: stloc.s 9
+		IL_0269: ldloc.s 8
+		IL_026b: ldloc.s 9
+		IL_026d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0272: pop
+		IL_0273: ldstr "String"
+		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_027d: volatile.
+		IL_027f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_0284: brfalse IL_0298
 
-		IL_0292: ldstr "prototype"
-		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_029c: br IL_02b5
+		IL_0289: ldstr "prototype"
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0293: br IL_02ac
 
-		IL_02a1: ldstr "prototype"
-		IL_02a6: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:71"
-		IL_02ab: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0298: ldstr "prototype"
+		IL_029d: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:71"
+		IL_02a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02b5: stloc.s 9
-		IL_02b7: ldloc.s 9
-		IL_02b9: ldloc.s 4
-		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_02c0: pop
-		IL_02c1: ldstr "String"
-		IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02cb: volatile.
-		IL_02cd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_02d2: brfalse IL_02e6
+		IL_02ac: stloc.s 9
+		IL_02ae: ldloc.s 9
+		IL_02b0: ldloc.s 4
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_02b7: pop
+		IL_02b8: ldstr "String"
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c2: volatile.
+		IL_02c4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_02c9: brfalse IL_02dd
 
-		IL_02d7: ldstr "prototype"
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e1: br IL_02fa
+		IL_02ce: ldstr "prototype"
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02d8: br IL_02f1
 
-		IL_02e6: ldstr "prototype"
-		IL_02eb: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:77"
-		IL_02f0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_02dd: ldstr "prototype"
+		IL_02e2: ldstr "String_IntrinsicGuard_HoistedLoop:Modules.String_IntrinsicGuard_HoistedLoop:__js_module_init__:77"
+		IL_02e7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_02fa: stloc.s 9
-		IL_02fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0301: dup
-		IL_0302: ldstr "configurable"
-		IL_0307: ldc.i4.1
-		IL_0308: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_030d: dup
-		IL_030e: ldstr "writable"
-		IL_0313: ldc.i4.1
-		IL_0314: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0319: dup
-		IL_031a: ldstr "value"
-		IL_031f: ldloc.3
-		IL_0320: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0325: stloc.s 11
-		IL_0327: ldloc.s 9
-		IL_0329: ldstr "charCodeAt"
-		IL_032e: ldloc.s 11
-		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0335: pop
-		IL_0336: ldstr "String"
-		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0340: stloc.s 9
-		IL_0342: ldloc.s 9
-		IL_0344: dup
-		IL_0345: ldstr "abc"
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_034f: stloc.s 5
-		IL_0351: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0356: stloc.s 11
-		IL_0358: ldloc.s 11
-		IL_035a: ldstr "configurable"
-		IL_035f: ldc.i4.1
-		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
-		IL_0365: pop
-		IL_0366: ldc.i4.1
-		IL_0367: newarr [System.Runtime]System.Object
-		IL_036c: dup
-		IL_036d: ldc.i4.0
-		IL_036e: ldloc.0
-		IL_036f: stelem.ref
-		IL_0370: stloc.s 6
-		IL_0372: newobj instance void Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L57C7/FunctionObject::.ctor()
-		IL_0377: ldc.i4.0
-		IL_0378: conv.r8
-		IL_0379: ldstr ""
-		IL_037e: ldc.i4.0
-		IL_037f: ldc.i4.0
-		IL_0380: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L57C7/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0385: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L57C7/FunctionObject>(!!0)
-		IL_038a: stloc.s 13
-		IL_038c: ldloc.s 11
-		IL_038e: ldstr "get"
-		IL_0393: ldloc.s 13
-		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_039a: pop
-		IL_039b: ldloc.s 5
-		IL_039d: ldstr "charCodeAt"
-		IL_03a2: ldloc.s 11
-		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_03a9: pop
-		IL_03aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03af: stloc.s 8
-		IL_03b1: ldloc.1
-		IL_03b2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03b7: ldloc.s 5
-		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03be: stloc.s 9
-		IL_03c0: ldloc.s 8
-		IL_03c2: ldloc.s 9
-		IL_03c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03c9: pop
-		IL_03ca: ret
+		IL_02f1: stloc.s 9
+		IL_02f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02f8: dup
+		IL_02f9: ldstr "configurable"
+		IL_02fe: ldc.i4.1
+		IL_02ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0304: dup
+		IL_0305: ldstr "writable"
+		IL_030a: ldc.i4.1
+		IL_030b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0310: dup
+		IL_0311: ldstr "value"
+		IL_0316: ldloc.3
+		IL_0317: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_031c: stloc.s 11
+		IL_031e: ldloc.s 9
+		IL_0320: ldstr "charCodeAt"
+		IL_0325: ldloc.s 11
+		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_032c: pop
+		IL_032d: ldstr "String"
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0337: stloc.s 9
+		IL_0339: ldloc.s 9
+		IL_033b: dup
+		IL_033c: ldstr "abc"
+		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0346: stloc.s 5
+		IL_0348: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_034d: stloc.s 11
+		IL_034f: ldloc.s 11
+		IL_0351: ldstr "configurable"
+		IL_0356: ldc.i4.1
+		IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+		IL_035c: pop
+		IL_035d: ldc.i4.1
+		IL_035e: newarr [System.Runtime]System.Object
+		IL_0363: dup
+		IL_0364: ldc.i4.0
+		IL_0365: ldloc.0
+		IL_0366: stelem.ref
+		IL_0367: stloc.s 6
+		IL_0369: newobj instance void Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L57C7/FunctionObject::.ctor()
+		IL_036e: ldc.i4.0
+		IL_036f: conv.r8
+		IL_0370: ldstr ""
+		IL_0375: ldc.i4.0
+		IL_0376: ldc.i4.0
+		IL_0377: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L57C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_037c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.String_IntrinsicGuard_HoistedLoop/FunctionExpression_L57C7/FunctionObject>(!!0)
+		IL_0381: stloc.s 13
+		IL_0383: ldloc.s 11
+		IL_0385: ldstr "get"
+		IL_038a: ldloc.s 13
+		IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0391: pop
+		IL_0392: ldloc.s 5
+		IL_0394: ldstr "charCodeAt"
+		IL_0399: ldloc.s 11
+		IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_03a0: pop
+		IL_03a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a6: stloc.s 8
+		IL_03a8: ldloc.0
+		IL_03a9: castclass Modules.String_IntrinsicGuard_HoistedLoop/Scope
+		IL_03ae: ldnull
+		IL_03af: ldloc.s 5
+		IL_03b1: call object Modules.String_IntrinsicGuard_HoistedLoop/lastCodes::__js_call__(class Modules.String_IntrinsicGuard_HoistedLoop/Scope, object, object)
+		IL_03b6: stloc.s 9
+		IL_03b8: ldloc.s 8
+		IL_03ba: ldloc.s 9
+		IL_03bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03c1: pop
+		IL_03c2: ret
 	} // end of method String_IntrinsicGuard_HoistedLoop::__js_module_init__
 
 } // end of class Modules.String_IntrinsicGuard_HoistedLoop

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
@@ -623,7 +623,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 479 (0x1df)
+		// Code size: 472 (0x1d8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_FastPath_CommonMethods/Scope,
@@ -652,154 +652,151 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "abcdef"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003f: stloc.3
-		IL_0040: ldc.i4.0
-		IL_0041: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0046: brfalse IL_005c
+		IL_0027: ldnull
+		IL_0028: ldstr "abcdef"
+		IL_002d: call object Modules.String_MemberCall_FastPath_CommonMethods/runCommon::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0038: stloc.3
+		IL_0039: ldc.i4.0
+		IL_003a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_003f: brfalse IL_0055
 
-		IL_004b: ldstr "  x  "
-		IL_0050: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-		IL_0055: stloc.s 4
-		IL_0057: br IL_006d
+		IL_0044: ldstr "  x  "
+		IL_0049: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_004e: stloc.s 4
+		IL_0050: br IL_0066
 
-		IL_005c: ldstr "  x  "
-		IL_0061: ldstr "trim"
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_006b: stloc.s 4
+		IL_0055: ldstr "  x  "
+		IL_005a: ldstr "trim"
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0064: stloc.s 4
 
-		IL_006d: ldloc.3
-		IL_006e: ldloc.s 4
-		IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0075: pop
-		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007b: stloc.3
-		IL_007c: ldc.i4.0
-		IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0082: brfalse IL_0098
+		IL_0066: ldloc.3
+		IL_0067: ldloc.s 4
+		IL_0069: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006e: pop
+		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0074: stloc.3
+		IL_0075: ldc.i4.0
+		IL_0076: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_007b: brfalse IL_0091
 
-		IL_0087: ldstr "  x  "
-		IL_008c: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
-		IL_0091: stloc.s 4
-		IL_0093: br IL_00a9
+		IL_0080: ldstr "  x  "
+		IL_0085: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
+		IL_008a: stloc.s 4
+		IL_008c: br IL_00a2
 
-		IL_0098: ldstr "  x  "
-		IL_009d: ldstr "trimStart"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00a7: stloc.s 4
+		IL_0091: ldstr "  x  "
+		IL_0096: ldstr "trimStart"
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00a0: stloc.s 4
 
-		IL_00a9: ldloc.3
-		IL_00aa: ldloc.s 4
-		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b1: pop
-		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b7: stloc.3
-		IL_00b8: ldc.i4.0
-		IL_00b9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_00be: brfalse IL_00d4
+		IL_00a2: ldloc.3
+		IL_00a3: ldloc.s 4
+		IL_00a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00aa: pop
+		IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b0: stloc.3
+		IL_00b1: ldc.i4.0
+		IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00b7: brfalse IL_00cd
 
-		IL_00c3: ldstr "x  "
-		IL_00c8: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
-		IL_00cd: stloc.s 4
-		IL_00cf: br IL_00e5
+		IL_00bc: ldstr "x  "
+		IL_00c1: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
+		IL_00c6: stloc.s 4
+		IL_00c8: br IL_00de
 
-		IL_00d4: ldstr "x  "
-		IL_00d9: ldstr "trimEnd"
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00e3: stloc.s 4
+		IL_00cd: ldstr "x  "
+		IL_00d2: ldstr "trimEnd"
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00dc: stloc.s 4
 
-		IL_00e5: ldloc.3
-		IL_00e6: ldloc.s 4
-		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ed: pop
-		IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f3: stloc.3
-		IL_00f4: ldc.i4.0
-		IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_00fa: brfalse IL_0110
+		IL_00de: ldloc.3
+		IL_00df: ldloc.s 4
+		IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e6: pop
+		IL_00e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ec: stloc.3
+		IL_00ed: ldc.i4.0
+		IL_00ee: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00f3: brfalse IL_0109
 
-		IL_00ff: ldstr "  x  "
-		IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
-		IL_0109: stloc.s 4
-		IL_010b: br IL_0121
+		IL_00f8: ldstr "  x  "
+		IL_00fd: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
+		IL_0102: stloc.s 4
+		IL_0104: br IL_011a
 
-		IL_0110: ldstr "  x  "
-		IL_0115: ldstr "trimLeft"
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_011f: stloc.s 4
+		IL_0109: ldstr "  x  "
+		IL_010e: ldstr "trimLeft"
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0118: stloc.s 4
 
-		IL_0121: ldloc.3
-		IL_0122: ldloc.s 4
-		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0129: pop
-		IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012f: stloc.3
-		IL_0130: ldc.i4.0
-		IL_0131: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0136: brfalse IL_014c
+		IL_011a: ldloc.3
+		IL_011b: ldloc.s 4
+		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0122: pop
+		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0128: stloc.3
+		IL_0129: ldc.i4.0
+		IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_012f: brfalse IL_0145
 
-		IL_013b: ldstr "x  "
-		IL_0140: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
-		IL_0145: stloc.s 4
-		IL_0147: br IL_015d
+		IL_0134: ldstr "x  "
+		IL_0139: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
+		IL_013e: stloc.s 4
+		IL_0140: br IL_0156
 
-		IL_014c: ldstr "x  "
-		IL_0151: ldstr "trimRight"
-		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_015b: stloc.s 4
+		IL_0145: ldstr "x  "
+		IL_014a: ldstr "trimRight"
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0154: stloc.s 4
 
-		IL_015d: ldloc.3
-		IL_015e: ldloc.s 4
-		IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0165: pop
-		IL_0166: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016b: stloc.3
-		IL_016c: ldc.i4.0
-		IL_016d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0172: brfalse IL_0188
+		IL_0156: ldloc.3
+		IL_0157: ldloc.s 4
+		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015e: pop
+		IL_015f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0164: stloc.3
+		IL_0165: ldc.i4.0
+		IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_016b: brfalse IL_0181
 
-		IL_0177: ldstr "A"
-		IL_017c: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
-		IL_0181: stloc.s 4
-		IL_0183: br IL_0199
+		IL_0170: ldstr "A"
+		IL_0175: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+		IL_017a: stloc.s 4
+		IL_017c: br IL_0192
 
-		IL_0188: ldstr "A"
-		IL_018d: ldstr "toLowerCase"
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0197: stloc.s 4
+		IL_0181: ldstr "A"
+		IL_0186: ldstr "toLowerCase"
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0190: stloc.s 4
 
-		IL_0199: ldloc.3
-		IL_019a: ldloc.s 4
-		IL_019c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a1: pop
-		IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a7: stloc.3
-		IL_01a8: ldc.i4.0
-		IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01ae: brfalse IL_01c4
+		IL_0192: ldloc.3
+		IL_0193: ldloc.s 4
+		IL_0195: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019a: pop
+		IL_019b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a0: stloc.3
+		IL_01a1: ldc.i4.0
+		IL_01a2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01a7: brfalse IL_01bd
 
-		IL_01b3: ldstr "a"
-		IL_01b8: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-		IL_01bd: stloc.s 4
-		IL_01bf: br IL_01d5
+		IL_01ac: ldstr "a"
+		IL_01b1: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_01b6: stloc.s 4
+		IL_01b8: br IL_01ce
 
-		IL_01c4: ldstr "a"
-		IL_01c9: ldstr "toUpperCase"
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01d3: stloc.s 4
+		IL_01bd: ldstr "a"
+		IL_01c2: ldstr "toUpperCase"
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01cc: stloc.s 4
 
-		IL_01d5: ldloc.3
-		IL_01d6: ldloc.s 4
-		IL_01d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01dd: pop
-		IL_01de: ret
+		IL_01ce: ldloc.3
+		IL_01cf: ldloc.s 4
+		IL_01d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d6: pop
+		IL_01d7: ret
 	} // end of method String_MemberCall_FastPath_CommonMethods::__js_module_init__
 
 } // end of class Modules.String_MemberCall_FastPath_CommonMethods

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_PrototypeMethodOverrides.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_PrototypeMethodOverrides.verified.txt
@@ -1732,7 +1732,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3732 (0xe94)
+		// Code size: 3714 (0xe82)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_PrototypeMethodOverrides/Scope,
@@ -1762,17 +1762,16 @@
 			[24] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L19C11/FunctionObject,
 			[25] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[26] class Modules.String_PrototypeMethodOverrides/FunctionExpression_customPrototype/FunctionObject,
-			[27] object[],
-			[28] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10/FunctionObject,
-			[29] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26/FunctionObject,
-			[30] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionObject,
-			[31] bool,
-			[32] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31/FunctionObject,
-			[33] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30/FunctionObject,
-			[34] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[35] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30/FunctionObject,
-			[36] object,
-			[37] float64
+			[27] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10/FunctionObject,
+			[28] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26/FunctionObject,
+			[29] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionObject,
+			[30] bool,
+			[31] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31/FunctionObject,
+			[32] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30/FunctionObject,
+			[33] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[34] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30/FunctionObject,
+			[35] object,
+			[36] float64
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -2054,925 +2053,919 @@
 		IL_02e0: pop
 		IL_02e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_02e6: stloc.s 21
-		IL_02e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02ed: stloc.s 19
-		IL_02ef: ldloc.1
-		IL_02f0: ldloc.s 19
-		IL_02f2: ldstr "  uncertain  "
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02fc: stloc.s 20
-		IL_02fe: ldloc.s 21
-		IL_0300: ldloc.s 20
-		IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0307: pop
-		IL_0308: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_030d: stloc.s 21
-		IL_030f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0314: stloc.s 19
-		IL_0316: ldc.i4.1
-		IL_0317: newarr [System.Runtime]System.Object
-		IL_031c: dup
-		IL_031d: ldc.i4.0
-		IL_031e: ldloc.0
-		IL_031f: stelem.ref
-		IL_0320: stloc.s 27
-		IL_0322: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10/FunctionObject::.ctor()
-		IL_0327: ldc.i4.0
-		IL_0328: conv.r8
-		IL_0329: ldstr ""
-		IL_032e: ldc.i4.0
-		IL_032f: ldc.i4.0
-		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0335: stloc.s 28
-		IL_0337: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_033c: dup
-		IL_033d: ldstr "trim"
-		IL_0342: ldloc.s 28
-		IL_0344: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0349: stloc.s 25
-		IL_034b: ldloc.1
-		IL_034c: ldloc.s 19
-		IL_034e: ldloc.s 25
-		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0355: stloc.s 20
-		IL_0357: ldloc.s 21
-		IL_0359: ldloc.s 20
-		IL_035b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0360: pop
-		IL_0361: ldstr "String"
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_036b: volatile.
-		IL_036d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0372: brfalse IL_0386
+		IL_02e8: ldnull
+		IL_02e9: ldstr "  uncertain  "
+		IL_02ee: call object Modules.String_PrototypeMethodOverrides/callTrim::__js_call__(object, object)
+		IL_02f3: stloc.s 20
+		IL_02f5: ldloc.s 21
+		IL_02f7: ldloc.s 20
+		IL_02f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02fe: pop
+		IL_02ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0304: stloc.s 21
+		IL_0306: ldc.i4.1
+		IL_0307: newarr [System.Runtime]System.Object
+		IL_030c: dup
+		IL_030d: ldc.i4.0
+		IL_030e: ldloc.0
+		IL_030f: stelem.ref
+		IL_0310: stloc.s 19
+		IL_0312: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10/FunctionObject::.ctor()
+		IL_0317: ldc.i4.0
+		IL_0318: conv.r8
+		IL_0319: ldstr ""
+		IL_031e: ldc.i4.0
+		IL_031f: ldc.i4.0
+		IL_0320: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0325: stloc.s 27
+		IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_032c: dup
+		IL_032d: ldstr "trim"
+		IL_0332: ldloc.s 27
+		IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0339: stloc.s 25
+		IL_033b: ldnull
+		IL_033c: ldloc.s 25
+		IL_033e: call object Modules.String_PrototypeMethodOverrides/callTrim::__js_call__(object, object)
+		IL_0343: stloc.s 20
+		IL_0345: ldloc.s 21
+		IL_0347: ldloc.s 20
+		IL_0349: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_034e: pop
+		IL_034f: ldstr "String"
+		IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0359: volatile.
+		IL_035b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0360: brfalse IL_0374
 
-		IL_0377: ldstr "prototype"
-		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0381: br IL_039a
+		IL_0365: ldstr "prototype"
+		IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_036f: br IL_0388
 
-		IL_0386: ldstr "prototype"
-		IL_038b: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:91"
-		IL_0390: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
-		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0374: ldstr "prototype"
+		IL_0379: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:91"
+		IL_037e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_2
+		IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_039a: stloc.s 20
-		IL_039c: volatile.
-		IL_039e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_03a3: brfalse IL_03b9
+		IL_0388: stloc.s 20
+		IL_038a: volatile.
+		IL_038c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0391: brfalse IL_03a7
 
-		IL_03a8: ldloc.s 20
-		IL_03aa: ldstr "charAt"
-		IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03b4: br IL_03cf
+		IL_0396: ldloc.s 20
+		IL_0398: ldstr "charAt"
+		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03a2: br IL_03bd
 
-		IL_03b9: ldloc.s 20
-		IL_03bb: ldstr "charAt"
-		IL_03c0: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:93"
-		IL_03c5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
-		IL_03ca: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03a7: ldloc.s 20
+		IL_03a9: ldstr "charAt"
+		IL_03ae: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:93"
+		IL_03b3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_03cf: stloc.s 7
-		IL_03d1: ldstr "String"
-		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03db: volatile.
-		IL_03dd: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_03e2: brfalse IL_03f6
+		IL_03bd: stloc.s 7
+		IL_03bf: ldstr "String"
+		IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c9: volatile.
+		IL_03cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_03d0: brfalse IL_03e4
 
-		IL_03e7: ldstr "prototype"
-		IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03f1: br IL_040a
+		IL_03d5: ldstr "prototype"
+		IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03df: br IL_03f8
 
-		IL_03f6: ldstr "prototype"
-		IL_03fb: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:99"
-		IL_0400: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
-		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_03e4: ldstr "prototype"
+		IL_03e9: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:99"
+		IL_03ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_03f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_040a: stloc.s 20
-		IL_040c: ldc.i4.1
-		IL_040d: newarr [System.Runtime]System.Object
-		IL_0412: dup
+		IL_03f8: stloc.s 20
+		IL_03fa: ldc.i4.1
+		IL_03fb: newarr [System.Runtime]System.Object
+		IL_0400: dup
+		IL_0401: ldc.i4.0
+		IL_0402: ldloc.0
+		IL_0403: stelem.ref
+		IL_0404: stloc.s 19
+		IL_0406: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26/FunctionObject::.ctor()
+		IL_040b: ldc.i4.1
+		IL_040c: conv.r8
+		IL_040d: ldstr ""
+		IL_0412: ldc.i4.0
 		IL_0413: ldc.i4.0
-		IL_0414: ldloc.0
-		IL_0415: stelem.ref
-		IL_0416: stloc.s 19
-		IL_0418: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26/FunctionObject::.ctor()
-		IL_041d: ldc.i4.1
-		IL_041e: conv.r8
-		IL_041f: ldstr ""
-		IL_0424: ldc.i4.0
-		IL_0425: ldc.i4.0
-		IL_0426: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_042b: stloc.s 29
-		IL_042d: ldloc.s 20
-		IL_042f: ldstr "charAt"
-		IL_0434: ldloc.s 29
-		IL_0436: ldc.i4.1
-		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_043c: pop
-		IL_043d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0442: stloc.s 21
-		IL_0444: ldc.i4.0
-		IL_0445: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_044a: brfalse IL_046e
+		IL_0414: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0419: stloc.s 28
+		IL_041b: ldloc.s 20
+		IL_041d: ldstr "charAt"
+		IL_0422: ldloc.s 28
+		IL_0424: ldc.i4.1
+		IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_042a: pop
+		IL_042b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0430: stloc.s 21
+		IL_0432: ldc.i4.0
+		IL_0433: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0438: brfalse IL_045c
 
-		IL_044f: ldstr "abc"
-		IL_0454: ldc.r8 1
-		IL_045d: box [System.Runtime]System.Double
-		IL_0462: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_0467: stloc.s 20
-		IL_0469: br IL_048d
+		IL_043d: ldstr "abc"
+		IL_0442: ldc.r8 1
+		IL_044b: box [System.Runtime]System.Double
+		IL_0450: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_0455: stloc.s 20
+		IL_0457: br IL_047b
 
-		IL_046e: ldstr "abc"
-		IL_0473: ldstr "charAt"
-		IL_0478: ldc.r8 1
-		IL_0481: box [System.Runtime]System.Double
-		IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_048b: stloc.s 20
+		IL_045c: ldstr "abc"
+		IL_0461: ldstr "charAt"
+		IL_0466: ldc.r8 1
+		IL_046f: box [System.Runtime]System.Double
+		IL_0474: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0479: stloc.s 20
 
-		IL_048d: ldloc.s 21
-		IL_048f: ldloc.s 20
-		IL_0491: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0496: pop
-		IL_0497: ldstr "String"
-		IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04a1: volatile.
-		IL_04a3: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_04a8: brfalse IL_04bc
+		IL_047b: ldloc.s 21
+		IL_047d: ldloc.s 20
+		IL_047f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0484: pop
+		IL_0485: ldstr "String"
+		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_048f: volatile.
+		IL_0491: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0496: brfalse IL_04aa
 
-		IL_04ad: ldstr "prototype"
-		IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04b7: br IL_04d0
+		IL_049b: ldstr "prototype"
+		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04a5: br IL_04be
 
-		IL_04bc: ldstr "prototype"
-		IL_04c1: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:115"
-		IL_04c6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04aa: ldstr "prototype"
+		IL_04af: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:115"
+		IL_04b4: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_04d0: stloc.s 20
-		IL_04d2: ldloc.s 20
-		IL_04d4: ldstr "charAt"
-		IL_04d9: ldloc.s 7
-		IL_04db: ldc.i4.1
-		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_04e1: pop
-		IL_04e2: ldstr "String"
-		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04ec: volatile.
-		IL_04ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_04f3: brfalse IL_0507
+		IL_04be: stloc.s 20
+		IL_04c0: ldloc.s 20
+		IL_04c2: ldstr "charAt"
+		IL_04c7: ldloc.s 7
+		IL_04c9: ldc.i4.1
+		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_04cf: pop
+		IL_04d0: ldstr "String"
+		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04da: volatile.
+		IL_04dc: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_04e1: brfalse IL_04f5
 
-		IL_04f8: ldstr "prototype"
-		IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0502: br IL_051b
+		IL_04e6: ldstr "prototype"
+		IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04f0: br IL_0509
 
-		IL_0507: ldstr "prototype"
-		IL_050c: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:122"
-		IL_0511: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_04f5: ldstr "prototype"
+		IL_04fa: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:122"
+		IL_04ff: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_051b: stloc.s 20
-		IL_051d: ldloc.s 20
-		IL_051f: ldstr "trim"
-		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_0529: stloc.s 8
-		IL_052b: ldstr "String"
-		IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0535: volatile.
-		IL_0537: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_053c: brfalse IL_0550
+		IL_0509: stloc.s 20
+		IL_050b: ldloc.s 20
+		IL_050d: ldstr "trim"
+		IL_0512: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_0517: stloc.s 8
+		IL_0519: ldstr "String"
+		IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0523: volatile.
+		IL_0525: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_052a: brfalse IL_053e
 
-		IL_0541: ldstr "prototype"
-		IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_054b: br IL_0564
+		IL_052f: ldstr "prototype"
+		IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0539: br IL_0552
 
-		IL_0550: ldstr "prototype"
-		IL_0555: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:130"
-		IL_055a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_053e: ldstr "prototype"
+		IL_0543: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:130"
+		IL_0548: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_054d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0564: stloc.s 20
-		IL_0566: ldc.i4.1
-		IL_0567: newarr [System.Runtime]System.Object
-		IL_056c: dup
+		IL_0552: stloc.s 20
+		IL_0554: ldc.i4.1
+		IL_0555: newarr [System.Runtime]System.Object
+		IL_055a: dup
+		IL_055b: ldc.i4.0
+		IL_055c: ldloc.0
+		IL_055d: stelem.ref
+		IL_055e: stloc.s 19
+		IL_0560: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionObject::.ctor()
+		IL_0565: ldc.i4.0
+		IL_0566: conv.r8
+		IL_0567: ldstr ""
+		IL_056c: ldc.i4.0
 		IL_056d: ldc.i4.0
-		IL_056e: ldloc.0
-		IL_056f: stelem.ref
-		IL_0570: stloc.s 19
-		IL_0572: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionObject::.ctor()
-		IL_0577: ldc.i4.0
-		IL_0578: conv.r8
-		IL_0579: ldstr ""
-		IL_057e: ldc.i4.0
-		IL_057f: ldc.i4.0
-		IL_0580: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0585: stloc.s 30
-		IL_0587: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_058c: dup
-		IL_058d: ldstr "configurable"
-		IL_0592: ldc.i4.1
-		IL_0593: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0598: dup
-		IL_0599: ldstr "get"
-		IL_059e: ldloc.s 30
-		IL_05a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_05a5: stloc.s 25
-		IL_05a7: ldloc.s 20
-		IL_05a9: ldstr "trim"
-		IL_05ae: ldloc.s 25
-		IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_05b5: pop
-		IL_05b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05bb: stloc.s 21
-		IL_05bd: ldc.i4.0
-		IL_05be: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_05c3: brfalse IL_05d9
+		IL_056e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0573: stloc.s 29
+		IL_0575: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_057a: dup
+		IL_057b: ldstr "configurable"
+		IL_0580: ldc.i4.1
+		IL_0581: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0586: dup
+		IL_0587: ldstr "get"
+		IL_058c: ldloc.s 29
+		IL_058e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0593: stloc.s 25
+		IL_0595: ldloc.s 20
+		IL_0597: ldstr "trim"
+		IL_059c: ldloc.s 25
+		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_05a3: pop
+		IL_05a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05a9: stloc.s 21
+		IL_05ab: ldc.i4.0
+		IL_05ac: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_05b1: brfalse IL_05c7
 
-		IL_05c8: ldstr " abc "
-		IL_05cd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-		IL_05d2: stloc.s 20
-		IL_05d4: br IL_05ea
+		IL_05b6: ldstr " abc "
+		IL_05bb: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_05c0: stloc.s 20
+		IL_05c2: br IL_05d8
 
-		IL_05d9: ldstr " abc "
-		IL_05de: ldstr "trim"
-		IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_05e8: stloc.s 20
+		IL_05c7: ldstr " abc "
+		IL_05cc: ldstr "trim"
+		IL_05d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_05d6: stloc.s 20
 
-		IL_05ea: ldloc.s 21
-		IL_05ec: ldloc.s 20
-		IL_05ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05f3: pop
-		IL_05f4: ldstr "String"
-		IL_05f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05fe: volatile.
-		IL_0600: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0605: brfalse IL_0619
+		IL_05d8: ldloc.s 21
+		IL_05da: ldloc.s 20
+		IL_05dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05e1: pop
+		IL_05e2: ldstr "String"
+		IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05ec: volatile.
+		IL_05ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_05f3: brfalse IL_0607
 
-		IL_060a: ldstr "prototype"
-		IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0614: br IL_062d
+		IL_05f8: ldstr "prototype"
+		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0602: br IL_061b
 
-		IL_0619: ldstr "prototype"
-		IL_061e: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:146"
-		IL_0623: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-		IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0607: ldstr "prototype"
+		IL_060c: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:146"
+		IL_0611: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_0616: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_062d: stloc.s 20
-		IL_062f: ldloc.s 20
-		IL_0631: ldstr "trim"
-		IL_0636: ldloc.s 8
-		IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_063d: pop
-		IL_063e: ldstr "String"
-		IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0648: volatile.
-		IL_064a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_064f: brfalse IL_0663
+		IL_061b: stloc.s 20
+		IL_061d: ldloc.s 20
+		IL_061f: ldstr "trim"
+		IL_0624: ldloc.s 8
+		IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_062b: pop
+		IL_062c: ldstr "String"
+		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0636: volatile.
+		IL_0638: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_063d: brfalse IL_0651
 
-		IL_0654: ldstr "prototype"
-		IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_065e: br IL_0677
+		IL_0642: ldstr "prototype"
+		IL_0647: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_064c: br IL_0665
 
-		IL_0663: ldstr "prototype"
-		IL_0668: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:153"
-		IL_066d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
-		IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0651: ldstr "prototype"
+		IL_0656: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:153"
+		IL_065b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_0660: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0677: stloc.s 20
-		IL_0679: volatile.
-		IL_067b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_0680: brfalse IL_0696
+		IL_0665: stloc.s 20
+		IL_0667: volatile.
+		IL_0669: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_066e: brfalse IL_0684
 
-		IL_0685: ldloc.s 20
-		IL_0687: ldstr "toUpperCase"
-		IL_068c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0691: br IL_06ac
+		IL_0673: ldloc.s 20
+		IL_0675: ldstr "toUpperCase"
+		IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_067f: br IL_069a
 
-		IL_0696: ldloc.s 20
-		IL_0698: ldstr "toUpperCase"
-		IL_069d: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:155"
-		IL_06a2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
-		IL_06a7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0684: ldloc.s 20
+		IL_0686: ldstr "toUpperCase"
+		IL_068b: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:155"
+		IL_0690: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06ac: stloc.s 9
-		IL_06ae: ldstr "Object"
-		IL_06b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_06b8: volatile.
-		IL_06ba: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_06bf: brfalse IL_06d3
+		IL_069a: stloc.s 9
+		IL_069c: ldstr "Object"
+		IL_06a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06a6: volatile.
+		IL_06a8: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_06ad: brfalse IL_06c1
 
-		IL_06c4: ldstr "prototype"
-		IL_06c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06ce: br IL_06e7
+		IL_06b2: ldstr "prototype"
+		IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06bc: br IL_06d5
 
-		IL_06d3: ldstr "prototype"
-		IL_06d8: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:161"
-		IL_06dd: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
-		IL_06e2: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06c1: ldstr "prototype"
+		IL_06c6: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:161"
+		IL_06cb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_11
+		IL_06d0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_06e7: stloc.s 20
-		IL_06e9: volatile.
-		IL_06eb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_06f0: brfalse IL_0706
+		IL_06d5: stloc.s 20
+		IL_06d7: volatile.
+		IL_06d9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_06de: brfalse IL_06f4
 
-		IL_06f5: ldloc.s 20
-		IL_06f7: ldstr "toUpperCase"
-		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0701: br IL_071c
+		IL_06e3: ldloc.s 20
+		IL_06e5: ldstr "toUpperCase"
+		IL_06ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06ef: br IL_070a
 
-		IL_0706: ldloc.s 20
-		IL_0708: ldstr "toUpperCase"
-		IL_070d: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:163"
-		IL_0712: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
-		IL_0717: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_06f4: ldloc.s 20
+		IL_06f6: ldstr "toUpperCase"
+		IL_06fb: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:163"
+		IL_0700: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_12
+		IL_0705: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_071c: stloc.s 10
-		IL_071e: ldstr "String"
-		IL_0723: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0728: volatile.
-		IL_072a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_072f: brfalse IL_0743
+		IL_070a: stloc.s 10
+		IL_070c: ldstr "String"
+		IL_0711: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0716: volatile.
+		IL_0718: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_071d: brfalse IL_0731
 
-		IL_0734: ldstr "prototype"
-		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_073e: br IL_0757
+		IL_0722: ldstr "prototype"
+		IL_0727: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_072c: br IL_0745
 
-		IL_0743: ldstr "prototype"
-		IL_0748: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:169"
-		IL_074d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
-		IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0731: ldstr "prototype"
+		IL_0736: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:169"
+		IL_073b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_13
+		IL_0740: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0757: stloc.s 20
-		IL_0759: ldloc.s 20
-		IL_075b: ldstr "toUpperCase"
-		IL_0760: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_0765: stloc.s 31
-		IL_0767: ldstr "Object"
-		IL_076c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0771: volatile.
-		IL_0773: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_0778: brfalse IL_078c
+		IL_0745: stloc.s 20
+		IL_0747: ldloc.s 20
+		IL_0749: ldstr "toUpperCase"
+		IL_074e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_0753: stloc.s 30
+		IL_0755: ldstr "Object"
+		IL_075a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_075f: volatile.
+		IL_0761: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0766: brfalse IL_077a
 
-		IL_077d: ldstr "prototype"
-		IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0787: br IL_07a0
+		IL_076b: ldstr "prototype"
+		IL_0770: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0775: br IL_078e
 
-		IL_078c: ldstr "prototype"
-		IL_0791: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:177"
-		IL_0796: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
-		IL_079b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_077a: ldstr "prototype"
+		IL_077f: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:177"
+		IL_0784: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_14
+		IL_0789: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_07a0: stloc.s 20
-		IL_07a2: ldc.i4.1
-		IL_07a3: newarr [System.Runtime]System.Object
-		IL_07a8: dup
+		IL_078e: stloc.s 20
+		IL_0790: ldc.i4.1
+		IL_0791: newarr [System.Runtime]System.Object
+		IL_0796: dup
+		IL_0797: ldc.i4.0
+		IL_0798: ldloc.0
+		IL_0799: stelem.ref
+		IL_079a: stloc.s 19
+		IL_079c: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31/FunctionObject::.ctor()
+		IL_07a1: ldc.i4.0
+		IL_07a2: conv.r8
+		IL_07a3: ldstr ""
+		IL_07a8: ldc.i4.0
 		IL_07a9: ldc.i4.0
-		IL_07aa: ldloc.0
-		IL_07ab: stelem.ref
-		IL_07ac: stloc.s 19
-		IL_07ae: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31/FunctionObject::.ctor()
-		IL_07b3: ldc.i4.0
-		IL_07b4: conv.r8
-		IL_07b5: ldstr ""
-		IL_07ba: ldc.i4.0
-		IL_07bb: ldc.i4.0
-		IL_07bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07c1: stloc.s 32
-		IL_07c3: ldloc.s 20
-		IL_07c5: ldstr "toUpperCase"
-		IL_07ca: ldloc.s 32
-		IL_07cc: ldc.i4.1
-		IL_07cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_07d2: pop
-		IL_07d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07d8: stloc.s 21
-		IL_07da: ldc.i4.0
-		IL_07db: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_07e0: brfalse IL_07f6
+		IL_07aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07af: stloc.s 31
+		IL_07b1: ldloc.s 20
+		IL_07b3: ldstr "toUpperCase"
+		IL_07b8: ldloc.s 31
+		IL_07ba: ldc.i4.1
+		IL_07bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_07c0: pop
+		IL_07c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07c6: stloc.s 21
+		IL_07c8: ldc.i4.0
+		IL_07c9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_07ce: brfalse IL_07e4
 
-		IL_07e5: ldstr "abc"
-		IL_07ea: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-		IL_07ef: stloc.s 20
-		IL_07f1: br IL_0807
+		IL_07d3: ldstr "abc"
+		IL_07d8: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_07dd: stloc.s 20
+		IL_07df: br IL_07f5
 
-		IL_07f6: ldstr "abc"
-		IL_07fb: ldstr "toUpperCase"
-		IL_0800: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0805: stloc.s 20
+		IL_07e4: ldstr "abc"
+		IL_07e9: ldstr "toUpperCase"
+		IL_07ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_07f3: stloc.s 20
 
-		IL_0807: ldloc.s 21
-		IL_0809: ldloc.s 20
-		IL_080b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0810: pop
-		IL_0811: ldstr "String"
-		IL_0816: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_081b: volatile.
-		IL_081d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0822: brfalse IL_0836
+		IL_07f5: ldloc.s 21
+		IL_07f7: ldloc.s 20
+		IL_07f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07fe: pop
+		IL_07ff: ldstr "String"
+		IL_0804: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0809: volatile.
+		IL_080b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0810: brfalse IL_0824
 
-		IL_0827: ldstr "prototype"
-		IL_082c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0831: br IL_084a
+		IL_0815: ldstr "prototype"
+		IL_081a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_081f: br IL_0838
 
-		IL_0836: ldstr "prototype"
-		IL_083b: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:191"
-		IL_0840: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
-		IL_0845: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0824: ldstr "prototype"
+		IL_0829: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:191"
+		IL_082e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_15
+		IL_0833: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_084a: stloc.s 20
-		IL_084c: ldloc.s 20
-		IL_084e: ldstr "toUpperCase"
-		IL_0853: ldloc.s 9
-		IL_0855: ldc.i4.1
-		IL_0856: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_085b: pop
-		IL_085c: ldloc.s 10
-		IL_085e: stloc.s 20
-		IL_0860: ldloc.s 20
-		IL_0862: ldnull
-		IL_0863: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0868: stloc.s 31
-		IL_086a: ldloc.s 31
-		IL_086c: brfalse IL_08bf
+		IL_0838: stloc.s 20
+		IL_083a: ldloc.s 20
+		IL_083c: ldstr "toUpperCase"
+		IL_0841: ldloc.s 9
+		IL_0843: ldc.i4.1
+		IL_0844: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0849: pop
+		IL_084a: ldloc.s 10
+		IL_084c: stloc.s 20
+		IL_084e: ldloc.s 20
+		IL_0850: ldnull
+		IL_0851: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0856: stloc.s 30
+		IL_0858: ldloc.s 30
+		IL_085a: brfalse IL_08ad
 
-		IL_0871: ldstr "Object"
-		IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_087b: volatile.
-		IL_087d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_0882: brfalse IL_0896
+		IL_085f: ldstr "Object"
+		IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0869: volatile.
+		IL_086b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0870: brfalse IL_0884
 
-		IL_0887: ldstr "prototype"
-		IL_088c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0891: br IL_08aa
+		IL_0875: ldstr "prototype"
+		IL_087a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_087f: br IL_0898
 
-		IL_0896: ldstr "prototype"
-		IL_089b: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:203"
-		IL_08a0: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
-		IL_08a5: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0884: ldstr "prototype"
+		IL_0889: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:203"
+		IL_088e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_16
+		IL_0893: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_08aa: stloc.s 20
-		IL_08ac: ldloc.s 20
-		IL_08ae: ldstr "toUpperCase"
-		IL_08b3: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_08b8: stloc.s 31
-		IL_08ba: br IL_090a
+		IL_0898: stloc.s 20
+		IL_089a: ldloc.s 20
+		IL_089c: ldstr "toUpperCase"
+		IL_08a1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_08a6: stloc.s 30
+		IL_08a8: br IL_08f8
 
-		IL_08bf: ldstr "Object"
-		IL_08c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08c9: volatile.
-		IL_08cb: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_08d0: brfalse IL_08e4
+		IL_08ad: ldstr "Object"
+		IL_08b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08b7: volatile.
+		IL_08b9: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_08be: brfalse IL_08d2
 
-		IL_08d5: ldstr "prototype"
-		IL_08da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08df: br IL_08f8
+		IL_08c3: ldstr "prototype"
+		IL_08c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08cd: br IL_08e6
 
-		IL_08e4: ldstr "prototype"
-		IL_08e9: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:213"
-		IL_08ee: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
-		IL_08f3: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_08d2: ldstr "prototype"
+		IL_08d7: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:213"
+		IL_08dc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_17
+		IL_08e1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_08f8: stloc.s 20
-		IL_08fa: ldloc.s 20
-		IL_08fc: ldstr "toUpperCase"
-		IL_0901: ldloc.s 10
-		IL_0903: ldc.i4.1
-		IL_0904: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0909: pop
+		IL_08e6: stloc.s 20
+		IL_08e8: ldloc.s 20
+		IL_08ea: ldstr "toUpperCase"
+		IL_08ef: ldloc.s 10
+		IL_08f1: ldc.i4.1
+		IL_08f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_08f7: pop
 
-		IL_090a: ldstr "String"
-		IL_090f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0914: volatile.
-		IL_0916: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_091b: brfalse IL_092f
+		IL_08f8: ldstr "String"
+		IL_08fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0902: volatile.
+		IL_0904: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_0909: brfalse IL_091d
 
-		IL_0920: ldstr "prototype"
-		IL_0925: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_092a: br IL_0943
+		IL_090e: ldstr "prototype"
+		IL_0913: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0918: br IL_0931
 
-		IL_092f: ldstr "prototype"
-		IL_0934: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:221"
-		IL_0939: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
-		IL_093e: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_091d: ldstr "prototype"
+		IL_0922: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:221"
+		IL_0927: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_18
+		IL_092c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0943: stloc.s 20
-		IL_0945: volatile.
-		IL_0947: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_094c: brfalse IL_0962
+		IL_0931: stloc.s 20
+		IL_0933: volatile.
+		IL_0935: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_093a: brfalse IL_0950
 
-		IL_0951: ldloc.s 20
-		IL_0953: ldstr "includes"
-		IL_0958: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_095d: br IL_0978
+		IL_093f: ldloc.s 20
+		IL_0941: ldstr "includes"
+		IL_0946: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_094b: br IL_0966
 
-		IL_0962: ldloc.s 20
-		IL_0964: ldstr "includes"
-		IL_0969: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:223"
-		IL_096e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
-		IL_0973: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0950: ldloc.s 20
+		IL_0952: ldstr "includes"
+		IL_0957: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:223"
+		IL_095c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_19
+		IL_0961: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0978: stloc.s 11
-		IL_097a: ldstr "String"
-		IL_097f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0984: volatile.
-		IL_0986: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_098b: brfalse IL_099f
+		IL_0966: stloc.s 11
+		IL_0968: ldstr "String"
+		IL_096d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0972: volatile.
+		IL_0974: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_0979: brfalse IL_098d
 
-		IL_0990: ldstr "prototype"
-		IL_0995: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_099a: br IL_09b3
+		IL_097e: ldstr "prototype"
+		IL_0983: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0988: br IL_09a1
 
-		IL_099f: ldstr "prototype"
-		IL_09a4: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:229"
-		IL_09a9: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
-		IL_09ae: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_098d: ldstr "prototype"
+		IL_0992: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:229"
+		IL_0997: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_20
+		IL_099c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_09b3: stloc.s 20
-		IL_09b5: ldloc.s 20
-		IL_09b7: ldstr "includes"
-		IL_09bc: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_09c1: stloc.s 31
+		IL_09a1: stloc.s 20
+		IL_09a3: ldloc.s 20
+		IL_09a5: ldstr "includes"
+		IL_09aa: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_09af: stloc.s 30
 		.try
 		{
-			IL_09c3: nop
-			IL_09c4: ldc.i4.0
-			IL_09c5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_09ca: brfalse IL_09e4
+			IL_09b1: nop
+			IL_09b2: ldc.i4.0
+			IL_09b3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_09b8: brfalse IL_09d2
 
-			IL_09cf: ldstr "abc"
-			IL_09d4: ldstr "a"
-			IL_09d9: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_09de: pop
-			IL_09df: br IL_09f9
+			IL_09bd: ldstr "abc"
+			IL_09c2: ldstr "a"
+			IL_09c7: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_09cc: pop
+			IL_09cd: br IL_09e7
 
-			IL_09e4: ldstr "abc"
-			IL_09e9: ldstr "includes"
-			IL_09ee: ldstr "a"
-			IL_09f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_09f8: pop
+			IL_09d2: ldstr "abc"
+			IL_09d7: ldstr "includes"
+			IL_09dc: ldstr "a"
+			IL_09e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_09e6: pop
 
-			IL_09f9: leave IL_0a7b
+			IL_09e7: leave IL_0a69
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_09fe: stloc.s 12
-			IL_0a00: ldloc.s 12
-			IL_0a02: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0a07: dup
-			IL_0a08: brtrue IL_0a1e
+			IL_09ec: stloc.s 12
+			IL_09ee: ldloc.s 12
+			IL_09f0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_09f5: dup
+			IL_09f6: brtrue IL_0a0c
 
-			IL_0a0d: pop
-			IL_0a0e: ldloc.s 12
-			IL_0a10: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0a15: dup
-			IL_0a16: brtrue IL_0a2a
+			IL_09fb: pop
+			IL_09fc: ldloc.s 12
+			IL_09fe: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0a03: dup
+			IL_0a04: brtrue IL_0a18
 
-			IL_0a1b: pop
-			IL_0a1c: rethrow
+			IL_0a09: pop
+			IL_0a0a: rethrow
 
-			IL_0a1e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0a23: stloc.s 13
-			IL_0a25: br IL_0a2c
+			IL_0a0c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0a11: stloc.s 13
+			IL_0a13: br IL_0a1a
 
-			IL_0a2a: stloc.s 13
+			IL_0a18: stloc.s 13
 
-			IL_0a2c: ldloc.s 13
-			IL_0a2e: stloc.s 14
-			IL_0a30: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a35: stloc.s 21
-			IL_0a37: volatile.
-			IL_0a39: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_0a3e: brfalse IL_0a54
+			IL_0a1a: ldloc.s 13
+			IL_0a1c: stloc.s 14
+			IL_0a1e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a23: stloc.s 21
+			IL_0a25: volatile.
+			IL_0a27: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0a2c: brfalse IL_0a42
 
-			IL_0a43: ldloc.s 14
-			IL_0a45: ldstr "name"
-			IL_0a4a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a4f: br IL_0a6a
+			IL_0a31: ldloc.s 14
+			IL_0a33: ldstr "name"
+			IL_0a38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a3d: br IL_0a58
 
-			IL_0a54: ldloc.s 14
-			IL_0a56: ldstr "name"
-			IL_0a5b: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:250"
-			IL_0a60: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
-			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0a42: ldloc.s 14
+			IL_0a44: ldstr "name"
+			IL_0a49: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:250"
+			IL_0a4e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_21
+			IL_0a53: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_0a6a: stloc.s 20
-			IL_0a6c: ldloc.s 21
-			IL_0a6e: ldloc.s 20
-			IL_0a70: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a75: pop
-			IL_0a76: leave IL_0a7b
+			IL_0a58: stloc.s 20
+			IL_0a5a: ldloc.s 21
+			IL_0a5c: ldloc.s 20
+			IL_0a5e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a63: pop
+			IL_0a64: leave IL_0a69
 		} // end handler
 
-		IL_0a7b: ldstr "String"
-		IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0a85: volatile.
-		IL_0a87: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0a8c: brfalse IL_0aa0
+		IL_0a69: ldstr "String"
+		IL_0a6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a73: volatile.
+		IL_0a75: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0a7a: brfalse IL_0a8e
 
-		IL_0a91: ldstr "prototype"
-		IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0a9b: br IL_0ab4
+		IL_0a7f: ldstr "prototype"
+		IL_0a84: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a89: br IL_0aa2
 
-		IL_0aa0: ldstr "prototype"
-		IL_0aa5: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:260"
-		IL_0aaa: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
-		IL_0aaf: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0a8e: ldstr "prototype"
+		IL_0a93: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:260"
+		IL_0a98: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_22
+		IL_0a9d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0ab4: stloc.s 20
-		IL_0ab6: ldloc.s 20
-		IL_0ab8: ldstr "includes"
-		IL_0abd: ldloc.s 11
-		IL_0abf: ldc.i4.1
-		IL_0ac0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0ac5: pop
-		IL_0ac6: ldstr "String"
-		IL_0acb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0ad0: volatile.
-		IL_0ad2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0ad7: brfalse IL_0aeb
+		IL_0aa2: stloc.s 20
+		IL_0aa4: ldloc.s 20
+		IL_0aa6: ldstr "includes"
+		IL_0aab: ldloc.s 11
+		IL_0aad: ldc.i4.1
+		IL_0aae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0ab3: pop
+		IL_0ab4: ldstr "String"
+		IL_0ab9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0abe: volatile.
+		IL_0ac0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0ac5: brfalse IL_0ad9
 
-		IL_0adc: ldstr "prototype"
-		IL_0ae1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ae6: br IL_0aff
+		IL_0aca: ldstr "prototype"
+		IL_0acf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ad4: br IL_0aed
 
-		IL_0aeb: ldstr "prototype"
-		IL_0af0: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:267"
-		IL_0af5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
-		IL_0afa: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ad9: ldstr "prototype"
+		IL_0ade: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:267"
+		IL_0ae3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_23
+		IL_0ae8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0aff: stloc.s 20
-		IL_0b01: volatile.
-		IL_0b03: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0b08: brfalse IL_0b1e
+		IL_0aed: stloc.s 20
+		IL_0aef: volatile.
+		IL_0af1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0af6: brfalse IL_0b0c
 
-		IL_0b0d: ldloc.s 20
-		IL_0b0f: ldstr "startsWith"
-		IL_0b14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b19: br IL_0b34
+		IL_0afb: ldloc.s 20
+		IL_0afd: ldstr "startsWith"
+		IL_0b02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b07: br IL_0b22
 
-		IL_0b1e: ldloc.s 20
-		IL_0b20: ldstr "startsWith"
-		IL_0b25: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:269"
-		IL_0b2a: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
-		IL_0b2f: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0b0c: ldloc.s 20
+		IL_0b0e: ldstr "startsWith"
+		IL_0b13: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:269"
+		IL_0b18: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_24
+		IL_0b1d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0b34: stloc.s 15
-		IL_0b36: ldstr "String"
-		IL_0b3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0b40: volatile.
-		IL_0b42: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0b47: brfalse IL_0b5b
+		IL_0b22: stloc.s 15
+		IL_0b24: ldstr "String"
+		IL_0b29: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0b2e: volatile.
+		IL_0b30: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0b35: brfalse IL_0b49
 
-		IL_0b4c: ldstr "prototype"
-		IL_0b51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0b56: br IL_0b6f
+		IL_0b3a: ldstr "prototype"
+		IL_0b3f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0b44: br IL_0b5d
 
-		IL_0b5b: ldstr "prototype"
-		IL_0b60: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:275"
-		IL_0b65: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
-		IL_0b6a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0b49: ldstr "prototype"
+		IL_0b4e: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:275"
+		IL_0b53: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_25
+		IL_0b58: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0b6f: stloc.s 20
-		IL_0b71: ldc.i4.1
-		IL_0b72: newarr [System.Runtime]System.Object
-		IL_0b77: dup
+		IL_0b5d: stloc.s 20
+		IL_0b5f: ldc.i4.1
+		IL_0b60: newarr [System.Runtime]System.Object
+		IL_0b65: dup
+		IL_0b66: ldc.i4.0
+		IL_0b67: ldloc.0
+		IL_0b68: stelem.ref
+		IL_0b69: stloc.s 19
+		IL_0b6b: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30/FunctionObject::.ctor()
+		IL_0b70: ldc.i4.1
+		IL_0b71: conv.r8
+		IL_0b72: ldstr ""
+		IL_0b77: ldc.i4.0
 		IL_0b78: ldc.i4.0
-		IL_0b79: ldloc.0
-		IL_0b7a: stelem.ref
-		IL_0b7b: stloc.s 19
-		IL_0b7d: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30/FunctionObject::.ctor()
-		IL_0b82: ldc.i4.1
-		IL_0b83: conv.r8
-		IL_0b84: ldstr ""
-		IL_0b89: ldc.i4.0
-		IL_0b8a: ldc.i4.0
-		IL_0b8b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b90: stloc.s 33
-		IL_0b92: ldloc.s 20
-		IL_0b94: ldstr "startsWith"
-		IL_0b99: ldloc.s 33
-		IL_0b9b: ldc.i4.1
-		IL_0b9c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0ba1: pop
-		IL_0ba2: volatile.
-		IL_0ba4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0ba9: brfalse IL_0bc2
+		IL_0b79: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b7e: stloc.s 32
+		IL_0b80: ldloc.s 20
+		IL_0b82: ldstr "startsWith"
+		IL_0b87: ldloc.s 32
+		IL_0b89: ldc.i4.1
+		IL_0b8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0b8f: pop
+		IL_0b90: volatile.
+		IL_0b92: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0b97: brfalse IL_0bb0
 
-		IL_0bae: ldstr "abc"
-		IL_0bb3: ldstr "startsWith"
-		IL_0bb8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0bbd: br IL_0bdb
+		IL_0b9c: ldstr "abc"
+		IL_0ba1: ldstr "startsWith"
+		IL_0ba6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0bab: br IL_0bc9
 
-		IL_0bc2: ldstr "abc"
-		IL_0bc7: ldstr "startsWith"
-		IL_0bcc: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:283"
-		IL_0bd1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
-		IL_0bd6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0bb0: ldstr "abc"
+		IL_0bb5: ldstr "startsWith"
+		IL_0bba: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:283"
+		IL_0bbf: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_26
+		IL_0bc4: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0bdb: stloc.s 16
-		IL_0bdd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0be2: stloc.s 21
-		IL_0be4: ldloc.s 16
-		IL_0be6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0beb: ldstr "call"
-		IL_0bf0: ldstr "abc"
-		IL_0bf5: ldstr "a"
-		IL_0bfa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0bff: stloc.s 20
-		IL_0c01: ldloc.s 21
-		IL_0c03: ldloc.s 20
-		IL_0c05: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0c0a: pop
-		IL_0c0b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0c10: stloc.s 21
-		IL_0c12: ldloc.s 16
-		IL_0c14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0c19: ldc.i4.1
-		IL_0c1a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0c1f: dup
-		IL_0c20: ldstr "b"
-		IL_0c25: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0c2a: stloc.s 34
-		IL_0c2c: ldstr "apply"
-		IL_0c31: ldstr "abc"
-		IL_0c36: ldloc.s 34
-		IL_0c38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0c3d: stloc.s 20
-		IL_0c3f: ldloc.s 21
-		IL_0c41: ldloc.s 20
-		IL_0c43: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0c48: pop
-		IL_0c49: ldstr "String"
-		IL_0c4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0c53: volatile.
-		IL_0c55: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0c5a: brfalse IL_0c6e
+		IL_0bc9: stloc.s 16
+		IL_0bcb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0bd0: stloc.s 21
+		IL_0bd2: ldloc.s 16
+		IL_0bd4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0bd9: ldstr "call"
+		IL_0bde: ldstr "abc"
+		IL_0be3: ldstr "a"
+		IL_0be8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0bed: stloc.s 20
+		IL_0bef: ldloc.s 21
+		IL_0bf1: ldloc.s 20
+		IL_0bf3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0bf8: pop
+		IL_0bf9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0bfe: stloc.s 21
+		IL_0c00: ldloc.s 16
+		IL_0c02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0c07: ldc.i4.1
+		IL_0c08: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0c0d: dup
+		IL_0c0e: ldstr "b"
+		IL_0c13: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0c18: stloc.s 33
+		IL_0c1a: ldstr "apply"
+		IL_0c1f: ldstr "abc"
+		IL_0c24: ldloc.s 33
+		IL_0c26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0c2b: stloc.s 20
+		IL_0c2d: ldloc.s 21
+		IL_0c2f: ldloc.s 20
+		IL_0c31: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0c36: pop
+		IL_0c37: ldstr "String"
+		IL_0c3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0c41: volatile.
+		IL_0c43: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0c48: brfalse IL_0c5c
 
-		IL_0c5f: ldstr "prototype"
-		IL_0c64: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0c69: br IL_0c82
+		IL_0c4d: ldstr "prototype"
+		IL_0c52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0c57: br IL_0c70
 
-		IL_0c6e: ldstr "prototype"
-		IL_0c73: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:304"
-		IL_0c78: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
-		IL_0c7d: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0c5c: ldstr "prototype"
+		IL_0c61: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:304"
+		IL_0c66: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_27
+		IL_0c6b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0c82: stloc.s 20
-		IL_0c84: ldloc.s 20
-		IL_0c86: ldstr "startsWith"
-		IL_0c8b: ldloc.s 15
-		IL_0c8d: ldc.i4.1
-		IL_0c8e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0c93: pop
-		IL_0c94: ldstr "String"
-		IL_0c99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0c9e: volatile.
-		IL_0ca0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0ca5: brfalse IL_0cb9
+		IL_0c70: stloc.s 20
+		IL_0c72: ldloc.s 20
+		IL_0c74: ldstr "startsWith"
+		IL_0c79: ldloc.s 15
+		IL_0c7b: ldc.i4.1
+		IL_0c7c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0c81: pop
+		IL_0c82: ldstr "String"
+		IL_0c87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0c8c: volatile.
+		IL_0c8e: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0c93: brfalse IL_0ca7
 
-		IL_0caa: ldstr "prototype"
-		IL_0caf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0cb4: br IL_0ccd
+		IL_0c98: ldstr "prototype"
+		IL_0c9d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0ca2: br IL_0cbb
 
-		IL_0cb9: ldstr "prototype"
-		IL_0cbe: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:311"
-		IL_0cc3: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
-		IL_0cc8: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0ca7: ldstr "prototype"
+		IL_0cac: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:311"
+		IL_0cb1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_28
+		IL_0cb6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0ccd: stloc.s 20
-		IL_0ccf: volatile.
-		IL_0cd1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0cd6: brfalse IL_0cec
+		IL_0cbb: stloc.s 20
+		IL_0cbd: volatile.
+		IL_0cbf: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0cc4: brfalse IL_0cda
 
-		IL_0cdb: ldloc.s 20
-		IL_0cdd: ldstr "charCodeAt"
-		IL_0ce2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0ce7: br IL_0d02
+		IL_0cc9: ldloc.s 20
+		IL_0ccb: ldstr "charCodeAt"
+		IL_0cd0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0cd5: br IL_0cf0
 
-		IL_0cec: ldloc.s 20
-		IL_0cee: ldstr "charCodeAt"
-		IL_0cf3: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:313"
-		IL_0cf8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
-		IL_0cfd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0cda: ldloc.s 20
+		IL_0cdc: ldstr "charCodeAt"
+		IL_0ce1: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:313"
+		IL_0ce6: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_29
+		IL_0ceb: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0d02: stloc.s 17
-		IL_0d04: ldstr "String"
-		IL_0d09: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0d0e: volatile.
-		IL_0d10: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0d15: brfalse IL_0d29
+		IL_0cf0: stloc.s 17
+		IL_0cf2: ldstr "String"
+		IL_0cf7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0cfc: volatile.
+		IL_0cfe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0d03: brfalse IL_0d17
 
-		IL_0d1a: ldstr "prototype"
-		IL_0d1f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0d24: br IL_0d3d
+		IL_0d08: ldstr "prototype"
+		IL_0d0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0d12: br IL_0d2b
 
-		IL_0d29: ldstr "prototype"
-		IL_0d2e: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:319"
-		IL_0d33: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
-		IL_0d38: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0d17: ldstr "prototype"
+		IL_0d1c: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:319"
+		IL_0d21: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_30
+		IL_0d26: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0d3d: stloc.s 20
-		IL_0d3f: ldc.i4.1
-		IL_0d40: newarr [System.Runtime]System.Object
-		IL_0d45: dup
+		IL_0d2b: stloc.s 20
+		IL_0d2d: ldc.i4.1
+		IL_0d2e: newarr [System.Runtime]System.Object
+		IL_0d33: dup
+		IL_0d34: ldc.i4.0
+		IL_0d35: ldloc.0
+		IL_0d36: stelem.ref
+		IL_0d37: stloc.s 19
+		IL_0d39: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30/FunctionObject::.ctor()
+		IL_0d3e: ldc.i4.0
+		IL_0d3f: conv.r8
+		IL_0d40: ldstr ""
+		IL_0d45: ldc.i4.0
 		IL_0d46: ldc.i4.0
-		IL_0d47: ldloc.0
-		IL_0d48: stelem.ref
-		IL_0d49: stloc.s 19
-		IL_0d4b: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30/FunctionObject::.ctor()
-		IL_0d50: ldc.i4.0
-		IL_0d51: conv.r8
-		IL_0d52: ldstr ""
-		IL_0d57: ldc.i4.0
-		IL_0d58: ldc.i4.0
-		IL_0d59: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0d5e: stloc.s 35
-		IL_0d60: ldloc.s 20
-		IL_0d62: ldstr "charCodeAt"
-		IL_0d67: ldloc.s 35
-		IL_0d69: ldc.i4.1
-		IL_0d6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0d6f: pop
-		IL_0d70: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0d75: stloc.s 21
-		IL_0d77: ldc.i4.0
-		IL_0d78: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0d7d: brfalse IL_0da6
+		IL_0d47: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d4c: stloc.s 34
+		IL_0d4e: ldloc.s 20
+		IL_0d50: ldstr "charCodeAt"
+		IL_0d55: ldloc.s 34
+		IL_0d57: ldc.i4.1
+		IL_0d58: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0d5d: pop
+		IL_0d5e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0d63: stloc.s 21
+		IL_0d65: ldc.i4.0
+		IL_0d66: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0d6b: brfalse IL_0d94
 
-		IL_0d82: ldstr "A"
-		IL_0d87: ldc.r8 0.0
-		IL_0d90: box [System.Runtime]System.Double
-		IL_0d95: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_0d9a: box [System.Runtime]System.Double
-		IL_0d9f: stloc.s 20
-		IL_0da1: br IL_0dc5
+		IL_0d70: ldstr "A"
+		IL_0d75: ldc.r8 0.0
+		IL_0d7e: box [System.Runtime]System.Double
+		IL_0d83: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0d88: box [System.Runtime]System.Double
+		IL_0d8d: stloc.s 20
+		IL_0d8f: br IL_0db3
 
-		IL_0da6: ldstr "A"
-		IL_0dab: ldstr "charCodeAt"
-		IL_0db0: ldc.r8 0.0
-		IL_0db9: box [System.Runtime]System.Double
-		IL_0dbe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0dc3: stloc.s 20
+		IL_0d94: ldstr "A"
+		IL_0d99: ldstr "charCodeAt"
+		IL_0d9e: ldc.r8 0.0
+		IL_0da7: box [System.Runtime]System.Double
+		IL_0dac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0db1: stloc.s 20
 
-		IL_0dc5: ldloc.s 20
-		IL_0dc7: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-		IL_0dcc: box [System.Runtime]System.Double
-		IL_0dd1: stloc.s 36
-		IL_0dd3: ldloc.s 21
-		IL_0dd5: ldloc.s 36
-		IL_0dd7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0ddc: pop
-		IL_0ddd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0de2: stloc.s 21
-		IL_0de4: ldc.i4.0
-		IL_0de5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0dea: brfalse IL_0e0e
+		IL_0db3: ldloc.s 20
+		IL_0db5: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+		IL_0dba: box [System.Runtime]System.Double
+		IL_0dbf: stloc.s 35
+		IL_0dc1: ldloc.s 21
+		IL_0dc3: ldloc.s 35
+		IL_0dc5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0dca: pop
+		IL_0dcb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0dd0: stloc.s 21
+		IL_0dd2: ldc.i4.0
+		IL_0dd3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0dd8: brfalse IL_0dfc
 
-		IL_0def: ldstr "A"
-		IL_0df4: ldc.r8 0.0
-		IL_0dfd: box [System.Runtime]System.Double
-		IL_0e02: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_0e07: stloc.s 37
-		IL_0e09: br IL_0e32
+		IL_0ddd: ldstr "A"
+		IL_0de2: ldc.r8 0.0
+		IL_0deb: box [System.Runtime]System.Double
+		IL_0df0: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0df5: stloc.s 36
+		IL_0df7: br IL_0e20
 
-		IL_0e0e: ldstr "A"
-		IL_0e13: ldstr "charCodeAt"
-		IL_0e18: ldc.r8 0.0
-		IL_0e21: box [System.Runtime]System.Double
-		IL_0e26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0e2b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0e30: stloc.s 37
+		IL_0dfc: ldstr "A"
+		IL_0e01: ldstr "charCodeAt"
+		IL_0e06: ldc.r8 0.0
+		IL_0e0f: box [System.Runtime]System.Double
+		IL_0e14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0e19: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0e1e: stloc.s 36
 
-		IL_0e32: ldloc.s 37
-		IL_0e34: box [System.Runtime]System.Double
-		IL_0e39: stloc.s 36
-		IL_0e3b: ldloc.s 21
-		IL_0e3d: ldloc.s 36
-		IL_0e3f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0e44: pop
-		IL_0e45: ldstr "String"
-		IL_0e4a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0e4f: volatile.
-		IL_0e51: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0e56: brfalse IL_0e6a
+		IL_0e20: ldloc.s 36
+		IL_0e22: box [System.Runtime]System.Double
+		IL_0e27: stloc.s 35
+		IL_0e29: ldloc.s 21
+		IL_0e2b: ldloc.s 35
+		IL_0e2d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0e32: pop
+		IL_0e33: ldstr "String"
+		IL_0e38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0e3d: volatile.
+		IL_0e3f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0e44: brfalse IL_0e58
 
-		IL_0e5b: ldstr "prototype"
-		IL_0e60: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0e65: br IL_0e7e
+		IL_0e49: ldstr "prototype"
+		IL_0e4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0e53: br IL_0e6c
 
-		IL_0e6a: ldstr "prototype"
-		IL_0e6f: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:345"
-		IL_0e74: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
-		IL_0e79: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0e58: ldstr "prototype"
+		IL_0e5d: ldstr "String_PrototypeMethodOverrides:Modules.String_PrototypeMethodOverrides:__js_module_init__:345"
+		IL_0e62: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_31
+		IL_0e67: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0e7e: stloc.s 20
-		IL_0e80: ldloc.s 20
-		IL_0e82: ldstr "charCodeAt"
-		IL_0e87: ldloc.s 17
-		IL_0e89: ldc.i4.1
-		IL_0e8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0e8f: pop
-		IL_0e90: ldnull
-		IL_0e91: stloc.s 18
-		IL_0e93: ret
+		IL_0e6c: stloc.s 20
+		IL_0e6e: ldloc.s 20
+		IL_0e70: ldstr "charCodeAt"
+		IL_0e75: ldloc.s 17
+		IL_0e77: ldc.i4.1
+		IL_0e78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0e7d: pop
+		IL_0e7e: ldnull
+		IL_0e7f: stloc.s 18
+		IL_0e81: ret
 	} // end of method String_PrototypeMethodOverrides::__js_module_init__
 
 } // end of class Modules.String_PrototypeMethodOverrides

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
@@ -464,7 +464,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 253 (0xfd)
+		// Code size: 247 (0xf7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Repeat_Basic/Scope,
@@ -497,66 +497,60 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.2
-		IL_0035: ldloc.1
-		IL_0036: ldloc.2
-		IL_0037: ldstr "ab"
-		IL_003c: ldc.r8 3
-		IL_0045: box [System.Runtime]System.Double
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_004f: pop
-		IL_0050: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0055: stloc.2
-		IL_0056: ldloc.1
-		IL_0057: ldloc.2
-		IL_0058: ldstr "x"
-		IL_005d: ldc.r8 0.0
-		IL_0066: box [System.Runtime]System.Double
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0070: pop
-		IL_0071: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0076: stloc.2
-		IL_0077: ldloc.1
-		IL_0078: ldloc.2
-		IL_0079: ldstr "x"
-		IL_007e: ldc.r8 1
-		IL_0087: box [System.Runtime]System.Double
-		IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0091: pop
-		IL_0092: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0097: stloc.2
-		IL_0098: ldloc.1
-		IL_0099: ldloc.2
-		IL_009a: ldstr "x"
-		IL_009f: ldc.r8 2.9
-		IL_00a8: box [System.Runtime]System.Double
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00b2: pop
-		IL_00b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00b8: stloc.2
-		IL_00b9: ldc.r8 1
-		IL_00c2: neg
-		IL_00c3: stloc.3
-		IL_00c4: ldloc.3
-		IL_00c5: box [System.Runtime]System.Double
-		IL_00ca: stloc.s 4
-		IL_00cc: ldloc.1
-		IL_00cd: ldloc.2
-		IL_00ce: ldstr "x"
-		IL_00d3: ldloc.s 4
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00da: pop
-		IL_00db: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00e0: stloc.2
-		IL_00e1: ldloc.1
-		IL_00e2: ldloc.2
-		IL_00e3: ldstr "x"
-		IL_00e8: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_00f1: box [System.Runtime]System.Double
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00fb: pop
-		IL_00fc: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.String_Repeat_Basic/Scope
+		IL_0035: ldnull
+		IL_0036: ldstr "ab"
+		IL_003b: ldc.r8 3
+		IL_0044: box [System.Runtime]System.Double
+		IL_0049: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
+		IL_004e: pop
+		IL_004f: ldloc.0
+		IL_0050: castclass Modules.String_Repeat_Basic/Scope
+		IL_0055: ldnull
+		IL_0056: ldstr "x"
+		IL_005b: ldc.r8 0.0
+		IL_0064: box [System.Runtime]System.Double
+		IL_0069: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
+		IL_006e: pop
+		IL_006f: ldloc.0
+		IL_0070: castclass Modules.String_Repeat_Basic/Scope
+		IL_0075: ldnull
+		IL_0076: ldstr "x"
+		IL_007b: ldc.r8 1
+		IL_0084: box [System.Runtime]System.Double
+		IL_0089: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
+		IL_008e: pop
+		IL_008f: ldloc.0
+		IL_0090: castclass Modules.String_Repeat_Basic/Scope
+		IL_0095: ldnull
+		IL_0096: ldstr "x"
+		IL_009b: ldc.r8 2.9
+		IL_00a4: box [System.Runtime]System.Double
+		IL_00a9: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
+		IL_00ae: pop
+		IL_00af: ldc.r8 1
+		IL_00b8: neg
+		IL_00b9: stloc.3
+		IL_00ba: ldloc.3
+		IL_00bb: box [System.Runtime]System.Double
+		IL_00c0: stloc.s 4
+		IL_00c2: ldloc.0
+		IL_00c3: castclass Modules.String_Repeat_Basic/Scope
+		IL_00c8: ldnull
+		IL_00c9: ldstr "x"
+		IL_00ce: ldloc.s 4
+		IL_00d0: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
+		IL_00d5: pop
+		IL_00d6: ldloc.0
+		IL_00d7: castclass Modules.String_Repeat_Basic/Scope
+		IL_00dc: ldnull
+		IL_00dd: ldstr "x"
+		IL_00e2: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_00eb: box [System.Runtime]System.Double
+		IL_00f0: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
+		IL_00f5: pop
+		IL_00f6: ret
 	} // end of method String_Repeat_Basic::__js_module_init__
 
 } // end of class Modules.String_Repeat_Basic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -524,7 +524,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 83 (0x53)
+		// Code size: 82 (0x52)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_StartsWith_NestedParam/Scope,
@@ -559,18 +559,17 @@
 		IL_002e: nop
 		IL_002f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0034: stloc.3
-		IL_0035: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003a: stloc.2
-		IL_003b: ldloc.1
-		IL_003c: ldloc.2
-		IL_003d: ldstr "abc"
-		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0047: stloc.s 4
-		IL_0049: ldloc.3
-		IL_004a: ldloc.s 4
-		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0051: pop
-		IL_0052: ret
+		IL_0035: ldloc.0
+		IL_0036: castclass Modules.String_StartsWith_NestedParam/Scope
+		IL_003b: ldnull
+		IL_003c: ldstr "abc"
+		IL_0041: call object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
+		IL_0046: stloc.s 4
+		IL_0048: ldloc.3
+		IL_0049: ldloc.s 4
+		IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0050: pop
+		IL_0051: ret
 	} // end of method String_StartsWith_NestedParam::__js_module_init__
 
 } // end of class Modules.String_StartsWith_NestedParam

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
@@ -492,7 +492,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 280 (0x118)
+		// Code size: 282 (0x11a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_EvaluationOrder/Scope,
@@ -586,49 +586,51 @@
 		IL_00ad: ldloc.s 5
 		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateTemplateObject(object, object, object)
 		IL_00b4: stloc.s 6
-		IL_00b6: ldloc.2
-		IL_00b7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00c1: stloc.s 7
-		IL_00c3: ldloc.s 7
-		IL_00c5: stloc.s 8
-		IL_00c7: ldloc.2
-		IL_00c8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00d2: stloc.s 7
-		IL_00d4: ldloc.s 7
-		IL_00d6: stloc.s 9
-		IL_00d8: ldc.i4.3
-		IL_00d9: newarr [System.Runtime]System.Object
-		IL_00de: dup
-		IL_00df: ldc.i4.0
-		IL_00e0: ldloc.s 6
-		IL_00e2: stelem.ref
-		IL_00e3: dup
-		IL_00e4: ldc.i4.1
-		IL_00e5: ldloc.s 8
-		IL_00e7: stelem.ref
-		IL_00e8: dup
-		IL_00e9: ldc.i4.2
-		IL_00ea: ldloc.s 9
-		IL_00ec: stelem.ref
-		IL_00ed: stloc.s 5
-		IL_00ef: ldc.i4.0
-		IL_00f0: newarr [System.Runtime]System.Object
-		IL_00f5: stloc.s 4
-		IL_00f7: ldloc.1
-		IL_00f8: ldloc.s 4
-		IL_00fa: ldloc.s 5
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0101: stloc.3
-		IL_0102: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0107: stloc.s 10
-		IL_0109: ldloc.s 10
-		IL_010b: ldstr "final result:"
-		IL_0110: ldloc.3
-		IL_0111: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0116: pop
-		IL_0117: ret
+		IL_00b6: ldloc.0
+		IL_00b7: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
+		IL_00bc: ldnull
+		IL_00bd: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
+		IL_00c2: stloc.s 7
+		IL_00c4: ldloc.s 7
+		IL_00c6: stloc.s 8
+		IL_00c8: ldloc.0
+		IL_00c9: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
+		IL_00ce: ldnull
+		IL_00cf: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
+		IL_00d4: stloc.s 7
+		IL_00d6: ldloc.s 7
+		IL_00d8: stloc.s 9
+		IL_00da: ldc.i4.3
+		IL_00db: newarr [System.Runtime]System.Object
+		IL_00e0: dup
+		IL_00e1: ldc.i4.0
+		IL_00e2: ldloc.s 6
+		IL_00e4: stelem.ref
+		IL_00e5: dup
+		IL_00e6: ldc.i4.1
+		IL_00e7: ldloc.s 8
+		IL_00e9: stelem.ref
+		IL_00ea: dup
+		IL_00eb: ldc.i4.2
+		IL_00ec: ldloc.s 9
+		IL_00ee: stelem.ref
+		IL_00ef: stloc.s 5
+		IL_00f1: ldc.i4.0
+		IL_00f2: newarr [System.Runtime]System.Object
+		IL_00f7: stloc.s 4
+		IL_00f9: ldloc.1
+		IL_00fa: ldloc.s 4
+		IL_00fc: ldloc.s 5
+		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0103: stloc.3
+		IL_0104: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0109: stloc.s 10
+		IL_010b: ldloc.s 10
+		IL_010d: ldstr "final result:"
+		IL_0112: ldloc.3
+		IL_0113: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0118: pop
+		IL_0119: ret
 	} // end of method String_TaggedTemplate_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.String_TaggedTemplate_EvaluationOrder

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_Return.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_Return.verified.txt
@@ -314,7 +314,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 52 (0x34)
+		// Code size: 47 (0x2f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryFinally_Return/Scope,
@@ -341,11 +341,10 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldloc.1
-		IL_0028: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0032: pop
-		IL_0033: ret
+		IL_0027: ldnull
+		IL_0028: call object Modules.TryFinally_Return/f::__js_call__(object)
+		IL_002d: pop
+		IL_002e: ret
 	} // end of method TryFinally_Return::__js_module_init__
 
 } // end of class Modules.TryFinally_Return

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -398,7 +398,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 122 (0x7a)
+			// Code size: 99 (0x63)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -406,9 +406,8 @@
 				[2] float64,
 				[3] object,
 				[4] object,
-				[5] object[],
-				[6] object,
-				[7] object
+				[5] object,
+				[6] object
 			)
 
 			IL_0000: ldarg.0
@@ -437,32 +436,21 @@
 			IL_0035: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
 			IL_003a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_003f: stloc.2
-			IL_0040: ldarg.0
-			IL_0041: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
-			IL_0046: stloc.s 4
-			IL_0048: ldc.i4.1
-			IL_0049: newarr [System.Runtime]System.Object
-			IL_004e: dup
-			IL_004f: ldc.i4.0
-			IL_0050: ldarg.0
-			IL_0051: stelem.ref
-			IL_0052: stloc.s 5
-			IL_0054: ldloc.0
-			IL_0055: box [System.Runtime]System.Double
-			IL_005a: stloc.s 6
-			IL_005c: ldloc.2
-			IL_005d: box [System.Runtime]System.Double
-			IL_0062: stloc.s 7
-			IL_0064: ldloc.s 4
-			IL_0066: ldloc.s 5
-			IL_0068: ldstr "captured-double"
-			IL_006d: ldloc.s 6
-			IL_006f: ldloc.1
-			IL_0070: ldloc.s 7
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0077: pop
-			IL_0078: ldnull
-			IL_0079: ret
+			IL_0040: ldloc.0
+			IL_0041: box [System.Runtime]System.Double
+			IL_0046: stloc.s 5
+			IL_0048: ldloc.2
+			IL_0049: box [System.Runtime]System.Double
+			IL_004e: stloc.s 6
+			IL_0050: ldnull
+			IL_0051: ldstr "captured-double"
+			IL_0056: ldloc.s 5
+			IL_0058: ldloc.1
+			IL_0059: ldloc.s 6
+			IL_005b: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
+			IL_0060: pop
+			IL_0061: ldnull
+			IL_0062: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -614,7 +602,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 61 (0x3d)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -622,9 +610,7 @@
 				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object[],
-				[6] object,
-				[7] object
+				[5] object
 			)
 
 			IL_0000: ldarg.2
@@ -640,32 +626,21 @@
 			IL_0017: stloc.1
 			IL_0018: ldarg.2
 			IL_0019: stloc.2
-			IL_001a: ldarg.0
-			IL_001b: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+			IL_001a: ldloc.0
+			IL_001b: box [System.Runtime]System.Double
 			IL_0020: stloc.s 4
-			IL_0022: ldc.i4.1
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: dup
-			IL_0029: ldc.i4.0
-			IL_002a: ldarg.0
-			IL_002b: stelem.ref
-			IL_002c: stloc.s 5
-			IL_002e: ldloc.0
-			IL_002f: box [System.Runtime]System.Double
-			IL_0034: stloc.s 6
-			IL_0036: ldloc.2
-			IL_0037: box [System.Runtime]System.Double
-			IL_003c: stloc.s 7
-			IL_003e: ldloc.s 4
-			IL_0040: ldloc.s 5
-			IL_0042: ldstr "arg-double"
-			IL_0047: ldloc.s 6
-			IL_0049: ldloc.1
-			IL_004a: ldloc.s 7
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0051: pop
-			IL_0052: ldnull
-			IL_0053: ret
+			IL_0022: ldloc.2
+			IL_0023: box [System.Runtime]System.Double
+			IL_0028: stloc.s 5
+			IL_002a: ldnull
+			IL_002b: ldstr "arg-double"
+			IL_0030: ldloc.s 4
+			IL_0032: ldloc.1
+			IL_0033: ldloc.s 5
+			IL_0035: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
+			IL_003a: pop
+			IL_003b: ldnull
+			IL_003c: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -808,15 +783,14 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 94 (0x5e)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] object,
-				[5] object[]
+				[4] object
 			)
 
 			IL_0000: ldarg.0
@@ -843,26 +817,15 @@
 			IL_002f: ldarg.0
 			IL_0030: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
 			IL_0035: stloc.2
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
-			IL_003c: stloc.s 4
-			IL_003e: ldc.i4.1
-			IL_003f: newarr [System.Runtime]System.Object
-			IL_0044: dup
-			IL_0045: ldc.i4.0
-			IL_0046: ldarg.0
-			IL_0047: stelem.ref
-			IL_0048: stloc.s 5
-			IL_004a: ldloc.s 4
-			IL_004c: ldloc.s 5
-			IL_004e: ldstr "captured-string"
-			IL_0053: ldloc.0
-			IL_0054: ldloc.1
-			IL_0055: ldloc.2
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_005b: pop
-			IL_005c: ldnull
-			IL_005d: ret
+			IL_0036: ldnull
+			IL_0037: ldstr "captured-string"
+			IL_003c: ldloc.0
+			IL_003d: ldloc.1
+			IL_003e: ldloc.2
+			IL_003f: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -1012,15 +975,14 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 73 (0x49)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] object,
-				[5] object[]
+				[4] object
 			)
 
 			IL_0000: ldarg.2
@@ -1041,26 +1003,15 @@
 			IL_001e: stloc.1
 			IL_001f: ldarg.2
 			IL_0020: stloc.2
-			IL_0021: ldarg.0
-			IL_0022: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
-			IL_0027: stloc.s 4
-			IL_0029: ldc.i4.1
-			IL_002a: newarr [System.Runtime]System.Object
-			IL_002f: dup
-			IL_0030: ldc.i4.0
-			IL_0031: ldarg.0
-			IL_0032: stelem.ref
-			IL_0033: stloc.s 5
-			IL_0035: ldloc.s 4
-			IL_0037: ldloc.s 5
-			IL_0039: ldstr "arg-string"
-			IL_003e: ldloc.0
-			IL_003f: ldloc.1
-			IL_0040: ldloc.2
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0046: pop
-			IL_0047: ldnull
-			IL_0048: ret
+			IL_0021: ldnull
+			IL_0022: ldstr "arg-string"
+			IL_0027: ldloc.0
+			IL_0028: ldloc.1
+			IL_0029: ldloc.2
+			IL_002a: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
+			IL_002f: pop
+			IL_0030: ldnull
+			IL_0031: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -1122,7 +1073,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 509 (0x1fd)
+		// Code size: 463 (0x1cf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix/Scope,
@@ -1138,8 +1089,8 @@
 			[10] object[],
 			[11] class Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject,
 			[12] object,
-			[13] object,
-			[14] string,
+			[13] string,
+			[14] object,
 			[15] object
 		)
 
@@ -1258,89 +1209,76 @@
 		IL_0105: ldloc.s 5
 		IL_0107: box [System.Runtime]System.Double
 		IL_010c: stloc.s 8
-		IL_010e: ldloc.0
-		IL_010f: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
-		IL_0114: stloc.s 13
-		IL_0116: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_011b: stloc.s 10
-		IL_011d: ldloc.s 13
-		IL_011f: ldloc.s 10
-		IL_0121: ldstr "global-double"
-		IL_0126: ldloc.s 6
-		IL_0128: ldloc.s 7
-		IL_012a: ldloc.s 8
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_0131: pop
-		IL_0132: ldloc.0
-		IL_0133: ldc.r8 3
-		IL_013c: box [System.Runtime]System.Double
-		IL_0141: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
-		IL_0146: nop
-		IL_0147: ldloc.1
-		IL_0148: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0152: pop
-		IL_0153: nop
-		IL_0154: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0159: stloc.s 10
-		IL_015b: ldloc.2
-		IL_015c: ldloc.s 10
-		IL_015e: ldc.r8 3
-		IL_0167: box [System.Runtime]System.Double
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0171: pop
-		IL_0172: ldstr "3"
-		IL_0177: stloc.s 9
-		IL_0179: ldloc.s 9
-		IL_017b: stloc.s 14
-		IL_017d: ldloc.s 14
-		IL_017f: stloc.s 6
-		IL_0181: ldloc.s 9
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
-		IL_0188: stloc.s 13
-		IL_018a: ldloc.s 13
-		IL_018c: ldc.i4.0
-		IL_018d: box [System.Runtime]System.Boolean
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
-		IL_0197: stloc.s 15
-		IL_0199: ldloc.s 15
-		IL_019b: stloc.s 9
-		IL_019d: ldloc.s 13
-		IL_019f: stloc.s 7
-		IL_01a1: ldloc.s 9
-		IL_01a3: stloc.s 13
-		IL_01a5: ldloc.s 13
-		IL_01a7: stloc.s 8
-		IL_01a9: ldloc.0
-		IL_01aa: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
-		IL_01af: stloc.s 13
-		IL_01b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b6: stloc.s 10
-		IL_01b8: ldloc.s 13
-		IL_01ba: ldloc.s 10
-		IL_01bc: ldstr "global-string"
-		IL_01c1: ldloc.s 6
-		IL_01c3: ldloc.s 7
-		IL_01c5: ldloc.s 8
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_01cc: pop
-		IL_01cd: ldloc.0
-		IL_01ce: ldstr "3"
-		IL_01d3: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
-		IL_01d8: nop
-		IL_01d9: ldloc.3
-		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_01e4: pop
-		IL_01e5: nop
-		IL_01e6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01eb: stloc.s 10
-		IL_01ed: ldloc.s 4
-		IL_01ef: ldloc.s 10
-		IL_01f1: ldstr "3"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01fb: pop
-		IL_01fc: ret
+		IL_010e: ldnull
+		IL_010f: ldstr "global-double"
+		IL_0114: ldloc.s 6
+		IL_0116: ldloc.s 7
+		IL_0118: ldloc.s 8
+		IL_011a: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
+		IL_011f: pop
+		IL_0120: ldloc.0
+		IL_0121: ldc.r8 3
+		IL_012a: box [System.Runtime]System.Double
+		IL_012f: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
+		IL_0134: nop
+		IL_0135: ldloc.0
+		IL_0136: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
+		IL_013b: ldnull
+		IL_013c: call object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
+		IL_0141: pop
+		IL_0142: nop
+		IL_0143: ldloc.0
+		IL_0144: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
+		IL_0149: ldnull
+		IL_014a: ldc.r8 3
+		IL_0153: call object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, float64)
+		IL_0158: pop
+		IL_0159: ldstr "3"
+		IL_015e: stloc.s 9
+		IL_0160: ldloc.s 9
+		IL_0162: stloc.s 13
+		IL_0164: ldloc.s 13
+		IL_0166: stloc.s 6
+		IL_0168: ldloc.s 9
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
+		IL_016f: stloc.s 14
+		IL_0171: ldloc.s 14
+		IL_0173: ldc.i4.0
+		IL_0174: box [System.Runtime]System.Boolean
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
+		IL_017e: stloc.s 15
+		IL_0180: ldloc.s 15
+		IL_0182: stloc.s 9
+		IL_0184: ldloc.s 14
+		IL_0186: stloc.s 7
+		IL_0188: ldloc.s 9
+		IL_018a: stloc.s 14
+		IL_018c: ldloc.s 14
+		IL_018e: stloc.s 8
+		IL_0190: ldnull
+		IL_0191: ldstr "global-string"
+		IL_0196: ldloc.s 6
+		IL_0198: ldloc.s 7
+		IL_019a: ldloc.s 8
+		IL_019c: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
+		IL_01a1: pop
+		IL_01a2: ldloc.0
+		IL_01a3: ldstr "3"
+		IL_01a8: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
+		IL_01ad: nop
+		IL_01ae: ldloc.0
+		IL_01af: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
+		IL_01b4: ldnull
+		IL_01b5: call object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
+		IL_01ba: pop
+		IL_01bb: nop
+		IL_01bc: ldloc.0
+		IL_01bd: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
+		IL_01c2: ldnull
+		IL_01c3: ldstr "3"
+		IL_01c8: call object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
+		IL_01cd: pop
+		IL_01ce: ret
 	} // end of method UnaryOperator_MinusMinusPostfix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
@@ -376,7 +376,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/Scope,
@@ -403,28 +403,19 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "major"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003f: stloc.2
-		IL_0040: ldloc.1
-		IL_0041: ldloc.2
-		IL_0042: ldstr "minor"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004c: pop
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldloc.2
-		IL_0055: ldstr "patch"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0027: ldnull
+		IL_0028: ldstr "major"
+		IL_002d: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: ldnull
+		IL_0034: ldstr "minor"
+		IL_0039: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_003e: pop
+		IL_003f: ldnull
+		IL_0040: ldstr "patch"
+		IL_0045: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -383,7 +383,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/Scope,
@@ -410,28 +410,19 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "major"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003f: stloc.2
-		IL_0040: ldloc.1
-		IL_0041: ldloc.2
-		IL_0042: ldstr "minor"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004c: pop
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldloc.2
-		IL_0055: ldstr "patch"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0027: ldnull
+		IL_0028: ldstr "major"
+		IL_002d: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: ldnull
+		IL_0034: ldstr "minor"
+		IL_0039: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_003e: pop
+		IL_003f: ldnull
+		IL_0040: ldstr "patch"
+		IL_0045: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -398,16 +398,15 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 95 (0x5f)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] object,
 				[2] float64,
 				[3] object,
-				[4] object[],
-				[5] object,
-				[6] object
+				[4] object,
+				[5] object
 			)
 
 			IL_0000: ldarg.0
@@ -434,32 +433,21 @@
 			IL_0031: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
 			IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_003b: stloc.2
-			IL_003c: ldarg.0
-			IL_003d: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
-			IL_0042: stloc.3
-			IL_0043: ldc.i4.1
-			IL_0044: newarr [System.Runtime]System.Object
-			IL_0049: dup
-			IL_004a: ldc.i4.0
-			IL_004b: ldarg.0
-			IL_004c: stelem.ref
-			IL_004d: stloc.s 4
-			IL_004f: ldloc.0
-			IL_0050: box [System.Runtime]System.Double
-			IL_0055: stloc.s 5
-			IL_0057: ldloc.2
-			IL_0058: box [System.Runtime]System.Double
-			IL_005d: stloc.s 6
-			IL_005f: ldloc.3
-			IL_0060: ldloc.s 4
-			IL_0062: ldstr "captured-double"
-			IL_0067: ldloc.s 5
-			IL_0069: ldloc.1
-			IL_006a: ldloc.s 6
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0071: pop
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_003c: ldloc.0
+			IL_003d: box [System.Runtime]System.Double
+			IL_0042: stloc.s 4
+			IL_0044: ldloc.2
+			IL_0045: box [System.Runtime]System.Double
+			IL_004a: stloc.s 5
+			IL_004c: ldnull
+			IL_004d: ldstr "captured-double"
+			IL_0052: ldloc.s 4
+			IL_0054: ldloc.1
+			IL_0055: ldloc.s 5
+			IL_0057: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
+			IL_005c: pop
+			IL_005d: ldnull
+			IL_005e: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -611,7 +599,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 61 (0x3d)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -619,9 +607,7 @@
 				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object[],
-				[6] object,
-				[7] object
+				[5] object
 			)
 
 			IL_0000: ldarg.2
@@ -637,32 +623,21 @@
 			IL_0017: stloc.1
 			IL_0018: ldarg.2
 			IL_0019: stloc.2
-			IL_001a: ldarg.0
-			IL_001b: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+			IL_001a: ldloc.0
+			IL_001b: box [System.Runtime]System.Double
 			IL_0020: stloc.s 4
-			IL_0022: ldc.i4.1
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: dup
-			IL_0029: ldc.i4.0
-			IL_002a: ldarg.0
-			IL_002b: stelem.ref
-			IL_002c: stloc.s 5
-			IL_002e: ldloc.0
-			IL_002f: box [System.Runtime]System.Double
-			IL_0034: stloc.s 6
-			IL_0036: ldloc.2
-			IL_0037: box [System.Runtime]System.Double
-			IL_003c: stloc.s 7
-			IL_003e: ldloc.s 4
-			IL_0040: ldloc.s 5
-			IL_0042: ldstr "arg-double"
-			IL_0047: ldloc.s 6
-			IL_0049: ldloc.1
-			IL_004a: ldloc.s 7
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0051: pop
-			IL_0052: ldnull
-			IL_0053: ret
+			IL_0022: ldloc.2
+			IL_0023: box [System.Runtime]System.Double
+			IL_0028: stloc.s 5
+			IL_002a: ldnull
+			IL_002b: ldstr "arg-double"
+			IL_0030: ldloc.s 4
+			IL_0032: ldloc.1
+			IL_0033: ldloc.s 5
+			IL_0035: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
+			IL_003a: pop
+			IL_003b: ldnull
+			IL_003c: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -805,14 +780,13 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 88 (0x58)
+			// Code size: 67 (0x43)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] object[]
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -837,26 +811,15 @@
 			IL_002b: ldarg.0
 			IL_002c: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
 			IL_0031: stloc.2
-			IL_0032: ldarg.0
-			IL_0033: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
-			IL_0038: stloc.3
-			IL_0039: ldc.i4.1
-			IL_003a: newarr [System.Runtime]System.Object
-			IL_003f: dup
-			IL_0040: ldc.i4.0
-			IL_0041: ldarg.0
-			IL_0042: stelem.ref
-			IL_0043: stloc.s 4
-			IL_0045: ldloc.3
-			IL_0046: ldloc.s 4
-			IL_0048: ldstr "captured-string"
-			IL_004d: ldloc.0
-			IL_004e: ldloc.1
-			IL_004f: ldloc.2
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0055: pop
-			IL_0056: ldnull
-			IL_0057: ret
+			IL_0032: ldnull
+			IL_0033: ldstr "captured-string"
+			IL_0038: ldloc.0
+			IL_0039: ldloc.1
+			IL_003a: ldloc.2
+			IL_003b: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
+			IL_0040: pop
+			IL_0041: ldnull
+			IL_0042: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -1006,14 +969,13 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 46 (0x2e)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] object[]
+				[3] object
 			)
 
 			IL_0000: ldarg.2
@@ -1032,26 +994,15 @@
 			IL_001a: stloc.1
 			IL_001b: ldarg.2
 			IL_001c: stloc.2
-			IL_001d: ldarg.0
-			IL_001e: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
-			IL_0023: stloc.3
-			IL_0024: ldc.i4.1
-			IL_0025: newarr [System.Runtime]System.Object
-			IL_002a: dup
-			IL_002b: ldc.i4.0
-			IL_002c: ldarg.0
-			IL_002d: stelem.ref
-			IL_002e: stloc.s 4
-			IL_0030: ldloc.3
-			IL_0031: ldloc.s 4
-			IL_0033: ldstr "arg-string"
-			IL_0038: ldloc.0
-			IL_0039: ldloc.1
-			IL_003a: ldloc.2
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0040: pop
-			IL_0041: ldnull
-			IL_0042: ret
+			IL_001d: ldnull
+			IL_001e: ldstr "arg-string"
+			IL_0023: ldloc.0
+			IL_0024: ldloc.1
+			IL_0025: ldloc.2
+			IL_0026: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
+			IL_002b: pop
+			IL_002c: ldnull
+			IL_002d: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -1113,7 +1064,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 509 (0x1fd)
+		// Code size: 463 (0x1cf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix/Scope,
@@ -1128,8 +1079,8 @@
 			[9] string,
 			[10] object[],
 			[11] class Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject,
-			[12] object,
-			[13] string
+			[12] string,
+			[13] object
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/Scope::.ctor()
@@ -1245,91 +1196,78 @@
 		IL_0101: ldloc.s 5
 		IL_0103: box [System.Runtime]System.Double
 		IL_0108: stloc.s 8
-		IL_010a: ldloc.0
-		IL_010b: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
-		IL_0110: stloc.s 12
-		IL_0112: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0117: stloc.s 10
-		IL_0119: ldloc.s 12
-		IL_011b: ldloc.s 10
-		IL_011d: ldstr "global-double"
-		IL_0122: ldloc.s 6
-		IL_0124: ldloc.s 7
-		IL_0126: ldloc.s 8
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_012d: pop
-		IL_012e: ldloc.0
-		IL_012f: ldc.r8 3
-		IL_0138: box [System.Runtime]System.Double
-		IL_013d: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
-		IL_0142: nop
-		IL_0143: ldloc.1
-		IL_0144: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_014e: pop
-		IL_014f: nop
-		IL_0150: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0155: stloc.s 10
-		IL_0157: ldloc.2
-		IL_0158: ldloc.s 10
-		IL_015a: ldc.r8 3
-		IL_0163: box [System.Runtime]System.Double
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_016d: pop
-		IL_016e: ldstr "3"
-		IL_0173: stloc.s 9
-		IL_0175: ldloc.s 9
-		IL_0177: stloc.s 13
-		IL_0179: ldloc.s 13
-		IL_017b: stloc.s 6
-		IL_017d: ldloc.s 9
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
-		IL_0184: stloc.s 12
-		IL_0186: ldloc.s 12
-		IL_0188: ldc.i4.0
-		IL_0189: box [System.Runtime]System.Boolean
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
-		IL_0193: stloc.s 12
-		IL_0195: ldloc.s 12
-		IL_0197: stloc.s 9
-		IL_0199: ldloc.s 9
-		IL_019b: stloc.s 12
-		IL_019d: ldloc.s 12
-		IL_019f: stloc.s 7
-		IL_01a1: ldloc.s 9
-		IL_01a3: stloc.s 12
-		IL_01a5: ldloc.s 12
-		IL_01a7: stloc.s 8
-		IL_01a9: ldloc.0
-		IL_01aa: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
-		IL_01af: stloc.s 12
-		IL_01b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b6: stloc.s 10
-		IL_01b8: ldloc.s 12
-		IL_01ba: ldloc.s 10
-		IL_01bc: ldstr "global-string"
-		IL_01c1: ldloc.s 6
-		IL_01c3: ldloc.s 7
-		IL_01c5: ldloc.s 8
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_01cc: pop
-		IL_01cd: ldloc.0
-		IL_01ce: ldstr "3"
-		IL_01d3: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
-		IL_01d8: nop
-		IL_01d9: ldloc.3
-		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_01e4: pop
-		IL_01e5: nop
-		IL_01e6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01eb: stloc.s 10
-		IL_01ed: ldloc.s 4
-		IL_01ef: ldloc.s 10
-		IL_01f1: ldstr "3"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01fb: pop
-		IL_01fc: ret
+		IL_010a: ldnull
+		IL_010b: ldstr "global-double"
+		IL_0110: ldloc.s 6
+		IL_0112: ldloc.s 7
+		IL_0114: ldloc.s 8
+		IL_0116: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
+		IL_011b: pop
+		IL_011c: ldloc.0
+		IL_011d: ldc.r8 3
+		IL_0126: box [System.Runtime]System.Double
+		IL_012b: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
+		IL_0130: nop
+		IL_0131: ldloc.0
+		IL_0132: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
+		IL_0137: ldnull
+		IL_0138: call object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
+		IL_013d: pop
+		IL_013e: nop
+		IL_013f: ldloc.0
+		IL_0140: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
+		IL_0145: ldnull
+		IL_0146: ldc.r8 3
+		IL_014f: call object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, float64)
+		IL_0154: pop
+		IL_0155: ldstr "3"
+		IL_015a: stloc.s 9
+		IL_015c: ldloc.s 9
+		IL_015e: stloc.s 12
+		IL_0160: ldloc.s 12
+		IL_0162: stloc.s 6
+		IL_0164: ldloc.s 9
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
+		IL_016b: stloc.s 13
+		IL_016d: ldloc.s 13
+		IL_016f: ldc.i4.0
+		IL_0170: box [System.Runtime]System.Boolean
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
+		IL_017a: stloc.s 13
+		IL_017c: ldloc.s 13
+		IL_017e: stloc.s 9
+		IL_0180: ldloc.s 9
+		IL_0182: stloc.s 13
+		IL_0184: ldloc.s 13
+		IL_0186: stloc.s 7
+		IL_0188: ldloc.s 9
+		IL_018a: stloc.s 13
+		IL_018c: ldloc.s 13
+		IL_018e: stloc.s 8
+		IL_0190: ldnull
+		IL_0191: ldstr "global-string"
+		IL_0196: ldloc.s 6
+		IL_0198: ldloc.s 7
+		IL_019a: ldloc.s 8
+		IL_019c: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
+		IL_01a1: pop
+		IL_01a2: ldloc.0
+		IL_01a3: ldstr "3"
+		IL_01a8: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
+		IL_01ad: nop
+		IL_01ae: ldloc.0
+		IL_01af: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
+		IL_01b4: ldnull
+		IL_01b5: call object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
+		IL_01ba: pop
+		IL_01bb: nop
+		IL_01bc: ldloc.0
+		IL_01bd: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
+		IL_01c2: ldnull
+		IL_01c3: ldstr "3"
+		IL_01c8: call object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
+		IL_01cd: pop
+		IL_01ce: ret
 	} // end of method UnaryOperator_MinusMinusPrefix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
@@ -376,7 +376,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/Scope,
@@ -403,28 +403,19 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "major"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003f: stloc.2
-		IL_0040: ldloc.1
-		IL_0041: ldloc.2
-		IL_0042: ldstr "minor"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004c: pop
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldloc.2
-		IL_0055: ldstr "patch"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0027: ldnull
+		IL_0028: ldstr "major"
+		IL_002d: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: ldnull
+		IL_0034: ldstr "minor"
+		IL_0039: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_003e: pop
+		IL_003f: ldnull
+		IL_0040: ldstr "patch"
+		IL_0045: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -383,7 +383,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/Scope,
@@ -410,28 +410,19 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "major"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003f: stloc.2
-		IL_0040: ldloc.1
-		IL_0041: ldloc.2
-		IL_0042: ldstr "minor"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004c: pop
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldloc.2
-		IL_0055: ldstr "patch"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0027: ldnull
+		IL_0028: ldstr "major"
+		IL_002d: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: ldnull
+		IL_0034: ldstr "minor"
+		IL_0039: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_003e: pop
+		IL_003f: ldnull
+		IL_0040: ldstr "patch"
+		IL_0045: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
@@ -481,7 +481,7 @@
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
 			// Header size: 12
-			// Code size: 113 (0x71)
+			// Code size: 119 (0x77)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope,
@@ -522,26 +522,32 @@
 			IL_003c: box [System.Runtime]System.Double
 			IL_0041: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
 			IL_0046: nop
-			IL_0047: ldloc.1
-			IL_0048: ldc.i4.1
-			IL_0049: newarr [System.Runtime]System.Object
-			IL_004e: dup
-			IL_004f: ldc.i4.0
-			IL_0050: ldarg.0
-			IL_0051: stelem.ref
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0057: pop
-			IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_005d: stloc.3
-			IL_005e: ldloc.0
-			IL_005f: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-			IL_0064: stloc.s 4
-			IL_0066: ldloc.3
-			IL_0067: ldloc.s 4
-			IL_0069: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_006e: pop
-			IL_006f: ldnull
-			IL_0070: ret
+			IL_0047: ldc.i4.2
+			IL_0048: newarr [System.Runtime]System.Object
+			IL_004d: dup
+			IL_004e: ldc.i4.0
+			IL_004f: ldarg.0
+			IL_0050: stelem.ref
+			IL_0051: dup
+			IL_0052: ldc.i4.1
+			IL_0053: ldloc.0
+			IL_0054: stelem.ref
+			IL_0055: stloc.2
+			IL_0056: ldloc.2
+			IL_0057: ldnull
+			IL_0058: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner::__js_call__(object[], object)
+			IL_005d: pop
+			IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0063: stloc.3
+			IL_0064: ldloc.0
+			IL_0065: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
+			IL_006a: stloc.s 4
+			IL_006c: ldloc.3
+			IL_006d: ldloc.s 4
+			IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0074: pop
+			IL_0075: ldnull
+			IL_0076: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -584,7 +590,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 60 (0x3c)
+		// Code size: 61 (0x3d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope,
@@ -615,11 +621,12 @@
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
-		IL_002f: ldloc.1
-		IL_0030: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003a: pop
-		IL_003b: ret
+		IL_002f: ldloc.0
+		IL_0030: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope
+		IL_0035: ldnull
+		IL_0036: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
+		IL_003b: pop
+		IL_003c: ret
 	} // end of method UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -398,7 +398,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 122 (0x7a)
+			// Code size: 99 (0x63)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -406,9 +406,8 @@
 				[2] float64,
 				[3] object,
 				[4] object,
-				[5] object[],
-				[6] object,
-				[7] object
+				[5] object,
+				[6] object
 			)
 
 			IL_0000: ldarg.0
@@ -437,32 +436,21 @@
 			IL_0035: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
 			IL_003a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_003f: stloc.2
-			IL_0040: ldarg.0
-			IL_0041: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
-			IL_0046: stloc.s 4
-			IL_0048: ldc.i4.1
-			IL_0049: newarr [System.Runtime]System.Object
-			IL_004e: dup
-			IL_004f: ldc.i4.0
-			IL_0050: ldarg.0
-			IL_0051: stelem.ref
-			IL_0052: stloc.s 5
-			IL_0054: ldloc.0
-			IL_0055: box [System.Runtime]System.Double
-			IL_005a: stloc.s 6
-			IL_005c: ldloc.2
-			IL_005d: box [System.Runtime]System.Double
-			IL_0062: stloc.s 7
-			IL_0064: ldloc.s 4
-			IL_0066: ldloc.s 5
-			IL_0068: ldstr "captured-double"
-			IL_006d: ldloc.s 6
-			IL_006f: ldloc.1
-			IL_0070: ldloc.s 7
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0077: pop
-			IL_0078: ldnull
-			IL_0079: ret
+			IL_0040: ldloc.0
+			IL_0041: box [System.Runtime]System.Double
+			IL_0046: stloc.s 5
+			IL_0048: ldloc.2
+			IL_0049: box [System.Runtime]System.Double
+			IL_004e: stloc.s 6
+			IL_0050: ldnull
+			IL_0051: ldstr "captured-double"
+			IL_0056: ldloc.s 5
+			IL_0058: ldloc.1
+			IL_0059: ldloc.s 6
+			IL_005b: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
+			IL_0060: pop
+			IL_0061: ldnull
+			IL_0062: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -614,7 +602,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 61 (0x3d)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -622,9 +610,7 @@
 				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object[],
-				[6] object,
-				[7] object
+				[5] object
 			)
 
 			IL_0000: ldarg.2
@@ -640,32 +626,21 @@
 			IL_0017: stloc.1
 			IL_0018: ldarg.2
 			IL_0019: stloc.2
-			IL_001a: ldarg.0
-			IL_001b: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+			IL_001a: ldloc.0
+			IL_001b: box [System.Runtime]System.Double
 			IL_0020: stloc.s 4
-			IL_0022: ldc.i4.1
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: dup
-			IL_0029: ldc.i4.0
-			IL_002a: ldarg.0
-			IL_002b: stelem.ref
-			IL_002c: stloc.s 5
-			IL_002e: ldloc.0
-			IL_002f: box [System.Runtime]System.Double
-			IL_0034: stloc.s 6
-			IL_0036: ldloc.2
-			IL_0037: box [System.Runtime]System.Double
-			IL_003c: stloc.s 7
-			IL_003e: ldloc.s 4
-			IL_0040: ldloc.s 5
-			IL_0042: ldstr "arg-double"
-			IL_0047: ldloc.s 6
-			IL_0049: ldloc.1
-			IL_004a: ldloc.s 7
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0051: pop
-			IL_0052: ldnull
-			IL_0053: ret
+			IL_0022: ldloc.2
+			IL_0023: box [System.Runtime]System.Double
+			IL_0028: stloc.s 5
+			IL_002a: ldnull
+			IL_002b: ldstr "arg-double"
+			IL_0030: ldloc.s 4
+			IL_0032: ldloc.1
+			IL_0033: ldloc.s 5
+			IL_0035: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
+			IL_003a: pop
+			IL_003b: ldnull
+			IL_003c: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -808,15 +783,14 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 94 (0x5e)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] object,
-				[5] object[]
+				[4] object
 			)
 
 			IL_0000: ldarg.0
@@ -843,26 +817,15 @@
 			IL_002f: ldarg.0
 			IL_0030: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
 			IL_0035: stloc.2
-			IL_0036: ldarg.0
-			IL_0037: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
-			IL_003c: stloc.s 4
-			IL_003e: ldc.i4.1
-			IL_003f: newarr [System.Runtime]System.Object
-			IL_0044: dup
-			IL_0045: ldc.i4.0
-			IL_0046: ldarg.0
-			IL_0047: stelem.ref
-			IL_0048: stloc.s 5
-			IL_004a: ldloc.s 4
-			IL_004c: ldloc.s 5
-			IL_004e: ldstr "captured-string"
-			IL_0053: ldloc.0
-			IL_0054: ldloc.1
-			IL_0055: ldloc.2
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_005b: pop
-			IL_005c: ldnull
-			IL_005d: ret
+			IL_0036: ldnull
+			IL_0037: ldstr "captured-string"
+			IL_003c: ldloc.0
+			IL_003d: ldloc.1
+			IL_003e: ldloc.2
+			IL_003f: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -1012,15 +975,14 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 73 (0x49)
+			// Code size: 50 (0x32)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] object,
-				[4] object,
-				[5] object[]
+				[4] object
 			)
 
 			IL_0000: ldarg.2
@@ -1041,26 +1003,15 @@
 			IL_001e: stloc.1
 			IL_001f: ldarg.2
 			IL_0020: stloc.2
-			IL_0021: ldarg.0
-			IL_0022: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
-			IL_0027: stloc.s 4
-			IL_0029: ldc.i4.1
-			IL_002a: newarr [System.Runtime]System.Object
-			IL_002f: dup
-			IL_0030: ldc.i4.0
-			IL_0031: ldarg.0
-			IL_0032: stelem.ref
-			IL_0033: stloc.s 5
-			IL_0035: ldloc.s 4
-			IL_0037: ldloc.s 5
-			IL_0039: ldstr "arg-string"
-			IL_003e: ldloc.0
-			IL_003f: ldloc.1
-			IL_0040: ldloc.2
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0046: pop
-			IL_0047: ldnull
-			IL_0048: ret
+			IL_0021: ldnull
+			IL_0022: ldstr "arg-string"
+			IL_0027: ldloc.0
+			IL_0028: ldloc.1
+			IL_0029: ldloc.2
+			IL_002a: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
+			IL_002f: pop
+			IL_0030: ldnull
+			IL_0031: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -1122,7 +1073,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 509 (0x1fd)
+		// Code size: 463 (0x1cf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix/Scope,
@@ -1138,8 +1089,8 @@
 			[10] object[],
 			[11] class Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject,
 			[12] object,
-			[13] object,
-			[14] string,
+			[13] string,
+			[14] object,
 			[15] object
 		)
 
@@ -1258,89 +1209,76 @@
 		IL_0105: ldloc.s 5
 		IL_0107: box [System.Runtime]System.Double
 		IL_010c: stloc.s 8
-		IL_010e: ldloc.0
-		IL_010f: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
-		IL_0114: stloc.s 13
-		IL_0116: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_011b: stloc.s 10
-		IL_011d: ldloc.s 13
-		IL_011f: ldloc.s 10
-		IL_0121: ldstr "global-double"
-		IL_0126: ldloc.s 6
-		IL_0128: ldloc.s 7
-		IL_012a: ldloc.s 8
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_0131: pop
-		IL_0132: ldloc.0
-		IL_0133: ldc.r8 3
-		IL_013c: box [System.Runtime]System.Double
-		IL_0141: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
-		IL_0146: nop
-		IL_0147: ldloc.1
-		IL_0148: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0152: pop
-		IL_0153: nop
-		IL_0154: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0159: stloc.s 10
-		IL_015b: ldloc.2
-		IL_015c: ldloc.s 10
-		IL_015e: ldc.r8 3
-		IL_0167: box [System.Runtime]System.Double
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0171: pop
-		IL_0172: ldstr "3"
-		IL_0177: stloc.s 9
-		IL_0179: ldloc.s 9
-		IL_017b: stloc.s 14
-		IL_017d: ldloc.s 14
-		IL_017f: stloc.s 6
-		IL_0181: ldloc.s 9
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
-		IL_0188: stloc.s 13
-		IL_018a: ldloc.s 13
-		IL_018c: ldc.i4.1
-		IL_018d: box [System.Runtime]System.Boolean
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
-		IL_0197: stloc.s 15
-		IL_0199: ldloc.s 15
-		IL_019b: stloc.s 9
-		IL_019d: ldloc.s 13
-		IL_019f: stloc.s 7
-		IL_01a1: ldloc.s 9
-		IL_01a3: stloc.s 13
-		IL_01a5: ldloc.s 13
-		IL_01a7: stloc.s 8
-		IL_01a9: ldloc.0
-		IL_01aa: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
-		IL_01af: stloc.s 13
-		IL_01b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b6: stloc.s 10
-		IL_01b8: ldloc.s 13
-		IL_01ba: ldloc.s 10
-		IL_01bc: ldstr "global-string"
-		IL_01c1: ldloc.s 6
-		IL_01c3: ldloc.s 7
-		IL_01c5: ldloc.s 8
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_01cc: pop
-		IL_01cd: ldloc.0
-		IL_01ce: ldstr "3"
-		IL_01d3: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
-		IL_01d8: nop
-		IL_01d9: ldloc.3
-		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_01e4: pop
-		IL_01e5: nop
-		IL_01e6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01eb: stloc.s 10
-		IL_01ed: ldloc.s 4
-		IL_01ef: ldloc.s 10
-		IL_01f1: ldstr "3"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01fb: pop
-		IL_01fc: ret
+		IL_010e: ldnull
+		IL_010f: ldstr "global-double"
+		IL_0114: ldloc.s 6
+		IL_0116: ldloc.s 7
+		IL_0118: ldloc.s 8
+		IL_011a: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
+		IL_011f: pop
+		IL_0120: ldloc.0
+		IL_0121: ldc.r8 3
+		IL_012a: box [System.Runtime]System.Double
+		IL_012f: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
+		IL_0134: nop
+		IL_0135: ldloc.0
+		IL_0136: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
+		IL_013b: ldnull
+		IL_013c: call object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
+		IL_0141: pop
+		IL_0142: nop
+		IL_0143: ldloc.0
+		IL_0144: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
+		IL_0149: ldnull
+		IL_014a: ldc.r8 3
+		IL_0153: call object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, float64)
+		IL_0158: pop
+		IL_0159: ldstr "3"
+		IL_015e: stloc.s 9
+		IL_0160: ldloc.s 9
+		IL_0162: stloc.s 13
+		IL_0164: ldloc.s 13
+		IL_0166: stloc.s 6
+		IL_0168: ldloc.s 9
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
+		IL_016f: stloc.s 14
+		IL_0171: ldloc.s 14
+		IL_0173: ldc.i4.1
+		IL_0174: box [System.Runtime]System.Boolean
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
+		IL_017e: stloc.s 15
+		IL_0180: ldloc.s 15
+		IL_0182: stloc.s 9
+		IL_0184: ldloc.s 14
+		IL_0186: stloc.s 7
+		IL_0188: ldloc.s 9
+		IL_018a: stloc.s 14
+		IL_018c: ldloc.s 14
+		IL_018e: stloc.s 8
+		IL_0190: ldnull
+		IL_0191: ldstr "global-string"
+		IL_0196: ldloc.s 6
+		IL_0198: ldloc.s 7
+		IL_019a: ldloc.s 8
+		IL_019c: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
+		IL_01a1: pop
+		IL_01a2: ldloc.0
+		IL_01a3: ldstr "3"
+		IL_01a8: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
+		IL_01ad: nop
+		IL_01ae: ldloc.0
+		IL_01af: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
+		IL_01b4: ldnull
+		IL_01b5: call object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
+		IL_01ba: pop
+		IL_01bb: nop
+		IL_01bc: ldloc.0
+		IL_01bd: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
+		IL_01c2: ldnull
+		IL_01c3: ldstr "3"
+		IL_01c8: call object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
+		IL_01cd: pop
+		IL_01ce: ret
 	} // end of method UnaryOperator_PlusPlusPostfix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
@@ -376,7 +376,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/Scope,
@@ -403,28 +403,19 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "major"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003f: stloc.2
-		IL_0040: ldloc.1
-		IL_0041: ldloc.2
-		IL_0042: ldstr "minor"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004c: pop
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldloc.2
-		IL_0055: ldstr "patch"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0027: ldnull
+		IL_0028: ldstr "major"
+		IL_002d: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: ldnull
+		IL_0034: ldstr "minor"
+		IL_0039: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_003e: pop
+		IL_003f: ldnull
+		IL_0040: ldstr "patch"
+		IL_0045: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -383,7 +383,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/Scope,
@@ -410,28 +410,19 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "major"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003f: stloc.2
-		IL_0040: ldloc.1
-		IL_0041: ldloc.2
-		IL_0042: ldstr "minor"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004c: pop
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldloc.2
-		IL_0055: ldstr "patch"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0027: ldnull
+		IL_0028: ldstr "major"
+		IL_002d: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: ldnull
+		IL_0034: ldstr "minor"
+		IL_0039: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_003e: pop
+		IL_003f: ldnull
+		IL_0040: ldstr "patch"
+		IL_0045: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -398,16 +398,15 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 116 (0x74)
+			// Code size: 95 (0x5f)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] object,
 				[2] float64,
 				[3] object,
-				[4] object[],
-				[5] object,
-				[6] object
+				[4] object,
+				[5] object
 			)
 
 			IL_0000: ldarg.0
@@ -434,32 +433,21 @@
 			IL_0031: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
 			IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_003b: stloc.2
-			IL_003c: ldarg.0
-			IL_003d: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
-			IL_0042: stloc.3
-			IL_0043: ldc.i4.1
-			IL_0044: newarr [System.Runtime]System.Object
-			IL_0049: dup
-			IL_004a: ldc.i4.0
-			IL_004b: ldarg.0
-			IL_004c: stelem.ref
-			IL_004d: stloc.s 4
-			IL_004f: ldloc.0
-			IL_0050: box [System.Runtime]System.Double
-			IL_0055: stloc.s 5
-			IL_0057: ldloc.2
-			IL_0058: box [System.Runtime]System.Double
-			IL_005d: stloc.s 6
-			IL_005f: ldloc.3
-			IL_0060: ldloc.s 4
-			IL_0062: ldstr "captured-double"
-			IL_0067: ldloc.s 5
-			IL_0069: ldloc.1
-			IL_006a: ldloc.s 6
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0071: pop
-			IL_0072: ldnull
-			IL_0073: ret
+			IL_003c: ldloc.0
+			IL_003d: box [System.Runtime]System.Double
+			IL_0042: stloc.s 4
+			IL_0044: ldloc.2
+			IL_0045: box [System.Runtime]System.Double
+			IL_004a: stloc.s 5
+			IL_004c: ldnull
+			IL_004d: ldstr "captured-double"
+			IL_0052: ldloc.s 4
+			IL_0054: ldloc.1
+			IL_0055: ldloc.s 5
+			IL_0057: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
+			IL_005c: pop
+			IL_005d: ldnull
+			IL_005e: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -611,7 +599,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 84 (0x54)
+			// Code size: 61 (0x3d)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -619,9 +607,7 @@
 				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object[],
-				[6] object,
-				[7] object
+				[5] object
 			)
 
 			IL_0000: ldarg.2
@@ -637,32 +623,21 @@
 			IL_0017: stloc.1
 			IL_0018: ldarg.2
 			IL_0019: stloc.2
-			IL_001a: ldarg.0
-			IL_001b: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+			IL_001a: ldloc.0
+			IL_001b: box [System.Runtime]System.Double
 			IL_0020: stloc.s 4
-			IL_0022: ldc.i4.1
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: dup
-			IL_0029: ldc.i4.0
-			IL_002a: ldarg.0
-			IL_002b: stelem.ref
-			IL_002c: stloc.s 5
-			IL_002e: ldloc.0
-			IL_002f: box [System.Runtime]System.Double
-			IL_0034: stloc.s 6
-			IL_0036: ldloc.2
-			IL_0037: box [System.Runtime]System.Double
-			IL_003c: stloc.s 7
-			IL_003e: ldloc.s 4
-			IL_0040: ldloc.s 5
-			IL_0042: ldstr "arg-double"
-			IL_0047: ldloc.s 6
-			IL_0049: ldloc.1
-			IL_004a: ldloc.s 7
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0051: pop
-			IL_0052: ldnull
-			IL_0053: ret
+			IL_0022: ldloc.2
+			IL_0023: box [System.Runtime]System.Double
+			IL_0028: stloc.s 5
+			IL_002a: ldnull
+			IL_002b: ldstr "arg-double"
+			IL_0030: ldloc.s 4
+			IL_0032: ldloc.1
+			IL_0033: ldloc.s 5
+			IL_0035: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
+			IL_003a: pop
+			IL_003b: ldnull
+			IL_003c: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -805,14 +780,13 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 88 (0x58)
+			// Code size: 67 (0x43)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] object[]
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -837,26 +811,15 @@
 			IL_002b: ldarg.0
 			IL_002c: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
 			IL_0031: stloc.2
-			IL_0032: ldarg.0
-			IL_0033: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
-			IL_0038: stloc.3
-			IL_0039: ldc.i4.1
-			IL_003a: newarr [System.Runtime]System.Object
-			IL_003f: dup
-			IL_0040: ldc.i4.0
-			IL_0041: ldarg.0
-			IL_0042: stelem.ref
-			IL_0043: stloc.s 4
-			IL_0045: ldloc.3
-			IL_0046: ldloc.s 4
-			IL_0048: ldstr "captured-string"
-			IL_004d: ldloc.0
-			IL_004e: ldloc.1
-			IL_004f: ldloc.2
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0055: pop
-			IL_0056: ldnull
-			IL_0057: ret
+			IL_0032: ldnull
+			IL_0033: ldstr "captured-string"
+			IL_0038: ldloc.0
+			IL_0039: ldloc.1
+			IL_003a: ldloc.2
+			IL_003b: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
+			IL_0040: pop
+			IL_0041: ldnull
+			IL_0042: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -1006,14 +969,13 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 46 (0x2e)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object,
-				[4] object[]
+				[3] object
 			)
 
 			IL_0000: ldarg.2
@@ -1032,26 +994,15 @@
 			IL_001a: stloc.1
 			IL_001b: ldarg.2
 			IL_001c: stloc.2
-			IL_001d: ldarg.0
-			IL_001e: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
-			IL_0023: stloc.3
-			IL_0024: ldc.i4.1
-			IL_0025: newarr [System.Runtime]System.Object
-			IL_002a: dup
-			IL_002b: ldc.i4.0
-			IL_002c: ldarg.0
-			IL_002d: stelem.ref
-			IL_002e: stloc.s 4
-			IL_0030: ldloc.3
-			IL_0031: ldloc.s 4
-			IL_0033: ldstr "arg-string"
-			IL_0038: ldloc.0
-			IL_0039: ldloc.1
-			IL_003a: ldloc.2
-			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-			IL_0040: pop
-			IL_0041: ldnull
-			IL_0042: ret
+			IL_001d: ldnull
+			IL_001e: ldstr "arg-string"
+			IL_0023: ldloc.0
+			IL_0024: ldloc.1
+			IL_0025: ldloc.2
+			IL_0026: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
+			IL_002b: pop
+			IL_002c: ldnull
+			IL_002d: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -1113,7 +1064,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 509 (0x1fd)
+		// Code size: 463 (0x1cf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix/Scope,
@@ -1128,8 +1079,8 @@
 			[9] string,
 			[10] object[],
 			[11] class Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject,
-			[12] object,
-			[13] string
+			[12] string,
+			[13] object
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/Scope::.ctor()
@@ -1245,91 +1196,78 @@
 		IL_0101: ldloc.s 5
 		IL_0103: box [System.Runtime]System.Double
 		IL_0108: stloc.s 8
-		IL_010a: ldloc.0
-		IL_010b: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
-		IL_0110: stloc.s 12
-		IL_0112: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0117: stloc.s 10
-		IL_0119: ldloc.s 12
-		IL_011b: ldloc.s 10
-		IL_011d: ldstr "global-double"
-		IL_0122: ldloc.s 6
-		IL_0124: ldloc.s 7
-		IL_0126: ldloc.s 8
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_012d: pop
-		IL_012e: ldloc.0
-		IL_012f: ldc.r8 3
-		IL_0138: box [System.Runtime]System.Double
-		IL_013d: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
-		IL_0142: nop
-		IL_0143: ldloc.1
-		IL_0144: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_014e: pop
-		IL_014f: nop
-		IL_0150: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0155: stloc.s 10
-		IL_0157: ldloc.2
-		IL_0158: ldloc.s 10
-		IL_015a: ldc.r8 3
-		IL_0163: box [System.Runtime]System.Double
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_016d: pop
-		IL_016e: ldstr "3"
-		IL_0173: stloc.s 9
-		IL_0175: ldloc.s 9
-		IL_0177: stloc.s 13
-		IL_0179: ldloc.s 13
-		IL_017b: stloc.s 6
-		IL_017d: ldloc.s 9
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
-		IL_0184: stloc.s 12
-		IL_0186: ldloc.s 12
-		IL_0188: ldc.i4.1
-		IL_0189: box [System.Runtime]System.Boolean
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
-		IL_0193: stloc.s 12
-		IL_0195: ldloc.s 12
-		IL_0197: stloc.s 9
-		IL_0199: ldloc.s 9
-		IL_019b: stloc.s 12
-		IL_019d: ldloc.s 12
-		IL_019f: stloc.s 7
-		IL_01a1: ldloc.s 9
-		IL_01a3: stloc.s 12
-		IL_01a5: ldloc.s 12
-		IL_01a7: stloc.s 8
-		IL_01a9: ldloc.0
-		IL_01aa: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
-		IL_01af: stloc.s 12
-		IL_01b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b6: stloc.s 10
-		IL_01b8: ldloc.s 12
-		IL_01ba: ldloc.s 10
-		IL_01bc: ldstr "global-string"
-		IL_01c1: ldloc.s 6
-		IL_01c3: ldloc.s 7
-		IL_01c5: ldloc.s 8
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-		IL_01cc: pop
-		IL_01cd: ldloc.0
-		IL_01ce: ldstr "3"
-		IL_01d3: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
-		IL_01d8: nop
-		IL_01d9: ldloc.3
-		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_01e4: pop
-		IL_01e5: nop
-		IL_01e6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01eb: stloc.s 10
-		IL_01ed: ldloc.s 4
-		IL_01ef: ldloc.s 10
-		IL_01f1: ldstr "3"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01fb: pop
-		IL_01fc: ret
+		IL_010a: ldnull
+		IL_010b: ldstr "global-double"
+		IL_0110: ldloc.s 6
+		IL_0112: ldloc.s 7
+		IL_0114: ldloc.s 8
+		IL_0116: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
+		IL_011b: pop
+		IL_011c: ldloc.0
+		IL_011d: ldc.r8 3
+		IL_0126: box [System.Runtime]System.Double
+		IL_012b: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
+		IL_0130: nop
+		IL_0131: ldloc.0
+		IL_0132: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
+		IL_0137: ldnull
+		IL_0138: call object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
+		IL_013d: pop
+		IL_013e: nop
+		IL_013f: ldloc.0
+		IL_0140: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
+		IL_0145: ldnull
+		IL_0146: ldc.r8 3
+		IL_014f: call object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, float64)
+		IL_0154: pop
+		IL_0155: ldstr "3"
+		IL_015a: stloc.s 9
+		IL_015c: ldloc.s 9
+		IL_015e: stloc.s 12
+		IL_0160: ldloc.s 12
+		IL_0162: stloc.s 6
+		IL_0164: ldloc.s 9
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ToNumeric(object)
+		IL_016b: stloc.s 13
+		IL_016d: ldloc.s 13
+		IL_016f: ldc.i4.1
+		IL_0170: box [System.Runtime]System.Boolean
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ApplyNumericUpdate(object, object)
+		IL_017a: stloc.s 13
+		IL_017c: ldloc.s 13
+		IL_017e: stloc.s 9
+		IL_0180: ldloc.s 9
+		IL_0182: stloc.s 13
+		IL_0184: ldloc.s 13
+		IL_0186: stloc.s 7
+		IL_0188: ldloc.s 9
+		IL_018a: stloc.s 13
+		IL_018c: ldloc.s 13
+		IL_018e: stloc.s 8
+		IL_0190: ldnull
+		IL_0191: ldstr "global-string"
+		IL_0196: ldloc.s 6
+		IL_0198: ldloc.s 7
+		IL_019a: ldloc.s 8
+		IL_019c: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
+		IL_01a1: pop
+		IL_01a2: ldloc.0
+		IL_01a3: ldstr "3"
+		IL_01a8: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
+		IL_01ad: nop
+		IL_01ae: ldloc.0
+		IL_01af: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
+		IL_01b4: ldnull
+		IL_01b5: call object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
+		IL_01ba: pop
+		IL_01bb: nop
+		IL_01bc: ldloc.0
+		IL_01bd: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
+		IL_01c2: ldnull
+		IL_01c3: ldstr "3"
+		IL_01c8: call object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
+		IL_01cd: pop
+		IL_01ce: ret
 	} // end of method UnaryOperator_PlusPlusPrefix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
@@ -376,7 +376,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/Scope,
@@ -403,28 +403,19 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "major"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003f: stloc.2
-		IL_0040: ldloc.1
-		IL_0041: ldloc.2
-		IL_0042: ldstr "minor"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004c: pop
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldloc.2
-		IL_0055: ldstr "patch"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0027: ldnull
+		IL_0028: ldstr "major"
+		IL_002d: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: ldnull
+		IL_0034: ldstr "minor"
+		IL_0039: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_003e: pop
+		IL_003f: ldnull
+		IL_0040: ldstr "patch"
+		IL_0045: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -383,7 +383,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/Scope,
@@ -410,28 +410,19 @@
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
-		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_002c: stloc.2
-		IL_002d: ldloc.1
-		IL_002e: ldloc.2
-		IL_002f: ldstr "major"
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0039: pop
-		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_003f: stloc.2
-		IL_0040: ldloc.1
-		IL_0041: ldloc.2
-		IL_0042: ldstr "minor"
-		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_004c: pop
-		IL_004d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0052: stloc.2
-		IL_0053: ldloc.1
-		IL_0054: ldloc.2
-		IL_0055: ldstr "patch"
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0027: ldnull
+		IL_0028: ldstr "major"
+		IL_002d: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_0032: pop
+		IL_0033: ldnull
+		IL_0034: ldstr "minor"
+		IL_0039: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_003e: pop
+		IL_003f: ldnull
+		IL_0040: ldstr "patch"
+		IL_0045: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
@@ -273,7 +273,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 94 (0x5e)
+		// Code size: 95 (0x5f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_BoolStringFieldType/Scope,
@@ -314,15 +314,16 @@
 		IL_0040: nop
 		IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0046: stloc.3
-		IL_0047: ldloc.1
-		IL_0048: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0052: stloc.s 4
-		IL_0054: ldloc.3
-		IL_0055: ldloc.s 4
-		IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005c: pop
-		IL_005d: ret
+		IL_0047: ldloc.0
+		IL_0048: castclass Modules.Variable_CapturedConst_BoolStringFieldType/Scope
+		IL_004d: ldnull
+		IL_004e: call object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
+		IL_0053: stloc.s 4
+		IL_0055: ldloc.3
+		IL_0056: ldloc.s 4
+		IL_0058: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005d: pop
+		IL_005e: ret
 	} // end of method Variable_CapturedConst_BoolStringFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_BoolStringFieldType

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
@@ -264,7 +264,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 91 (0x5b)
+		// Code size: 92 (0x5c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_NumberFieldType/Scope,
@@ -302,15 +302,16 @@
 		IL_003d: nop
 		IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0043: stloc.3
-		IL_0044: ldloc.1
-		IL_0045: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_004f: stloc.s 4
-		IL_0051: ldloc.3
-		IL_0052: ldloc.s 4
-		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0059: pop
-		IL_005a: ret
+		IL_0044: ldloc.0
+		IL_0045: castclass Modules.Variable_CapturedConst_NumberFieldType/Scope
+		IL_004a: ldnull
+		IL_004b: call object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
+		IL_0050: stloc.s 4
+		IL_0052: ldloc.3
+		IL_0053: ldloc.s 4
+		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005a: pop
+		IL_005b: ret
 	} // end of method Variable_CapturedConst_NumberFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_NumberFieldType

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
@@ -2245,7 +2245,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2374 (0x946)
+		// Code size: 2377 (0x949)
 		.maxstack 12
 		.locals init (
 			[0] class Modules.Variable_ConstPrimitivePropagation/Scope,
@@ -2409,769 +2409,772 @@
 		.try
 		{
 			IL_0137: nop
-			IL_0138: ldloc.1
-			IL_0139: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0143: pop
-			IL_0144: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0149: stloc.s 32
-			IL_014b: ldloc.s 32
-			IL_014d: ldstr "NO_TDZ"
-			IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0157: pop
-			IL_0158: leave IL_01a8
+			IL_0138: ldloc.0
+			IL_0139: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+			IL_013e: ldnull
+			IL_013f: call object Modules.Variable_ConstPrimitivePropagation/readLate::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
+			IL_0144: pop
+			IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_014a: stloc.s 32
+			IL_014c: ldloc.s 32
+			IL_014e: ldstr "NO_TDZ"
+			IL_0153: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0158: pop
+			IL_0159: leave IL_01a9
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_015d: stloc.s 5
-			IL_015f: ldloc.s 5
-			IL_0161: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0166: dup
-			IL_0167: brtrue IL_017d
+			IL_015e: stloc.s 5
+			IL_0160: ldloc.s 5
+			IL_0162: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0167: dup
+			IL_0168: brtrue IL_017e
 
-			IL_016c: pop
-			IL_016d: ldloc.s 5
-			IL_016f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0174: dup
-			IL_0175: brtrue IL_0189
+			IL_016d: pop
+			IL_016e: ldloc.s 5
+			IL_0170: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0175: dup
+			IL_0176: brtrue IL_018a
 
-			IL_017a: pop
-			IL_017b: rethrow
+			IL_017b: pop
+			IL_017c: rethrow
 
-			IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0182: stloc.s 6
-			IL_0184: br IL_018b
+			IL_017e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0183: stloc.s 6
+			IL_0185: br IL_018c
 
-			IL_0189: stloc.s 6
+			IL_018a: stloc.s 6
 
-			IL_018b: ldloc.s 6
-			IL_018d: stloc.s 7
-			IL_018f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0194: stloc.s 32
-			IL_0196: ldloc.s 32
-			IL_0198: ldstr "TDZ"
-			IL_019d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01a2: pop
-			IL_01a3: leave IL_01a8
+			IL_018c: ldloc.s 6
+			IL_018e: stloc.s 7
+			IL_0190: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0195: stloc.s 32
+			IL_0197: ldloc.s 32
+			IL_0199: ldstr "TDZ"
+			IL_019e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01a3: pop
+			IL_01a4: leave IL_01a9
 		} // end handler
 
-		IL_01a8: ldloc.0
-		IL_01a9: ldc.r8 99
-		IL_01b2: box [System.Runtime]System.Double
-		IL_01b7: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::LATE
-		IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c1: stloc.s 32
-		IL_01c3: ldloc.1
-		IL_01c4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_01ce: stloc.s 34
-		IL_01d0: ldloc.s 32
-		IL_01d2: ldloc.s 34
-		IL_01d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d9: pop
-		IL_01da: ldloc.0
-		IL_01db: ldc.r8 3
-		IL_01e4: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN
-		IL_01e9: nop
+		IL_01a9: ldloc.0
+		IL_01aa: ldc.r8 99
+		IL_01b3: box [System.Runtime]System.Double
+		IL_01b8: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::LATE
+		IL_01bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c2: stloc.s 32
+		IL_01c4: ldloc.0
+		IL_01c5: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+		IL_01ca: ldnull
+		IL_01cb: call object Modules.Variable_ConstPrimitivePropagation/readLate::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
+		IL_01d0: stloc.s 34
+		IL_01d2: ldloc.s 32
+		IL_01d4: ldloc.s 34
+		IL_01d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01db: pop
+		IL_01dc: ldloc.0
+		IL_01dd: ldc.r8 3
+		IL_01e6: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN
+		IL_01eb: nop
 		.try
 		{
-			IL_01ea: nop
-			IL_01eb: ldstr "Assignment to constant variable."
-			IL_01f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-			IL_01f5: throw
+			IL_01ec: nop
+			IL_01ed: ldstr "Assignment to constant variable."
+			IL_01f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+			IL_01f7: throw
 
-			IL_01f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01fb: stloc.s 32
-			IL_01fd: ldloc.s 32
-			IL_01ff: ldstr "NO_CONST_ERROR"
-			IL_0204: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0209: pop
-			IL_020a: leave IL_028c
+			IL_01f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01fd: stloc.s 32
+			IL_01ff: ldloc.s 32
+			IL_0201: ldstr "NO_CONST_ERROR"
+			IL_0206: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_020b: pop
+			IL_020c: leave IL_028e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_020f: stloc.s 8
-			IL_0211: ldloc.s 8
-			IL_0213: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0218: dup
-			IL_0219: brtrue IL_022f
+			IL_0211: stloc.s 8
+			IL_0213: ldloc.s 8
+			IL_0215: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_021a: dup
+			IL_021b: brtrue IL_0231
 
-			IL_021e: pop
-			IL_021f: ldloc.s 8
-			IL_0221: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0226: dup
-			IL_0227: brtrue IL_023b
+			IL_0220: pop
+			IL_0221: ldloc.s 8
+			IL_0223: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0228: dup
+			IL_0229: brtrue IL_023d
 
-			IL_022c: pop
-			IL_022d: rethrow
+			IL_022e: pop
+			IL_022f: rethrow
 
-			IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0234: stloc.s 9
-			IL_0236: br IL_023d
+			IL_0231: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0236: stloc.s 9
+			IL_0238: br IL_023f
 
-			IL_023b: stloc.s 9
+			IL_023d: stloc.s 9
 
-			IL_023d: ldloc.s 9
-			IL_023f: stloc.s 10
-			IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0246: stloc.s 32
-			IL_0248: volatile.
-			IL_024a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_024f: brfalse IL_0265
+			IL_023f: ldloc.s 9
+			IL_0241: stloc.s 10
+			IL_0243: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0248: stloc.s 32
+			IL_024a: volatile.
+			IL_024c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0251: brfalse IL_0267
 
-			IL_0254: ldloc.s 10
-			IL_0256: ldstr "name"
-			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0260: br IL_027b
+			IL_0256: ldloc.s 10
+			IL_0258: ldstr "name"
+			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0262: br IL_027d
 
-			IL_0265: ldloc.s 10
-			IL_0267: ldstr "name"
-			IL_026c: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:97"
-			IL_0271: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0267: ldloc.s 10
+			IL_0269: ldstr "name"
+			IL_026e: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:97"
+			IL_0273: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_34
+			IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_027b: stloc.s 34
-			IL_027d: ldloc.s 32
-			IL_027f: ldloc.s 34
-			IL_0281: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0286: pop
-			IL_0287: leave IL_028c
+			IL_027d: stloc.s 34
+			IL_027f: ldloc.s 32
+			IL_0281: ldloc.s 34
+			IL_0283: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0288: pop
+			IL_0289: leave IL_028e
 		} // end handler
 
-		IL_028c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0291: stloc.s 32
-		IL_0293: ldc.i4.1
-		IL_0294: newarr [System.Runtime]System.Object
-		IL_0299: dup
-		IL_029a: ldc.i4.0
-		IL_029b: ldloc.0
-		IL_029c: stelem.ref
-		IL_029d: stloc.s 29
-		IL_029f: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
-		IL_02a4: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_02a9: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
-		IL_02ae: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_02b3: stloc.s 30
-		IL_02b5: ldc.i4.1
-		IL_02b6: newarr [System.Runtime]System.Object
-		IL_02bb: dup
-		IL_02bc: ldc.i4.0
-		IL_02bd: ldloc.0
-		IL_02be: stelem.ref
-		IL_02bf: stloc.s 29
-		IL_02c1: ldloc.s 29
-		IL_02c3: ldc.i4.0
-		IL_02c4: newarr [System.Runtime]System.Object
-		IL_02c9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_02ce: newobj instance void Modules.Variable_ConstPrimitivePropagation/WrittenReader::.ctor(object[])
-		IL_02d3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_02d8: stloc.s 35
-		IL_02da: ldloc.s 35
-		IL_02dc: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
-		IL_02e1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_02e6: ldstr "prototype"
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_02f0: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_02f5: ldloc.s 35
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02fc: volatile.
-		IL_02fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0303: brfalse IL_0317
+		IL_028e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0293: stloc.s 32
+		IL_0295: ldc.i4.1
+		IL_0296: newarr [System.Runtime]System.Object
+		IL_029b: dup
+		IL_029c: ldc.i4.0
+		IL_029d: ldloc.0
+		IL_029e: stelem.ref
+		IL_029f: stloc.s 29
+		IL_02a1: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
+		IL_02a6: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_02ab: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
+		IL_02b0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_02b5: stloc.s 30
+		IL_02b7: ldc.i4.1
+		IL_02b8: newarr [System.Runtime]System.Object
+		IL_02bd: dup
+		IL_02be: ldc.i4.0
+		IL_02bf: ldloc.0
+		IL_02c0: stelem.ref
+		IL_02c1: stloc.s 29
+		IL_02c3: ldloc.s 29
+		IL_02c5: ldc.i4.0
+		IL_02c6: newarr [System.Runtime]System.Object
+		IL_02cb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_02d0: newobj instance void Modules.Variable_ConstPrimitivePropagation/WrittenReader::.ctor(object[])
+		IL_02d5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_02da: stloc.s 35
+		IL_02dc: ldloc.s 35
+		IL_02de: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
+		IL_02e3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_02e8: ldstr "prototype"
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_02f2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_02f7: ldloc.s 35
+		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02fe: volatile.
+		IL_0300: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0305: brfalse IL_0319
 
-		IL_0308: ldstr "read"
-		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0312: br IL_032b
+		IL_030a: ldstr "read"
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0314: br IL_032d
 
-		IL_0317: ldstr "read"
-		IL_031c: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:111"
-		IL_0321: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
-		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0319: ldstr "read"
+		IL_031e: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:111"
+		IL_0323: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_35
+		IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_032b: stloc.s 34
-		IL_032d: ldloc.s 32
-		IL_032f: ldloc.s 34
-		IL_0331: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0336: pop
-		IL_0337: ldloc.0
-		IL_0338: ldc.r8 6
-		IL_0341: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_PATTERN
-		IL_0346: nop
+		IL_032d: stloc.s 34
+		IL_032f: ldloc.s 32
+		IL_0331: ldloc.s 34
+		IL_0333: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0338: pop
+		IL_0339: ldloc.0
+		IL_033a: ldc.r8 6
+		IL_0343: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_PATTERN
+		IL_0348: nop
 		.try
 		{
-			IL_0347: nop
-			IL_0348: ldc.i4.1
-			IL_0349: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_034e: dup
-			IL_034f: ldc.r8 7
-			IL_0358: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_035d: stloc.s 36
-			IL_035f: ldloc.s 36
-			IL_0361: brfalse IL_0372
+			IL_0349: nop
+			IL_034a: ldc.i4.1
+			IL_034b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0350: dup
+			IL_0351: ldc.r8 7
+			IL_035a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_035f: stloc.s 36
+			IL_0361: ldloc.s 36
+			IL_0363: brfalse IL_0374
 
-			IL_0366: ldloc.s 36
-			IL_0368: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_036d: brfalse IL_0383
+			IL_0368: ldloc.s 36
+			IL_036a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_036f: brfalse IL_0385
 
-			IL_0372: ldloc.s 36
-			IL_0374: ldstr ""
-			IL_0379: ldstr "0"
-			IL_037e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0374: ldloc.s 36
+			IL_0376: ldstr ""
+			IL_037b: ldstr "0"
+			IL_0380: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0383: ldloc.s 36
-			IL_0385: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_038a: stloc.s 11
-			IL_038c: ldc.i4.0
-			IL_038d: stloc.s 12
-			IL_038f: ldc.i4.0
-			IL_0390: stloc.s 13
+			IL_0385: ldloc.s 36
+			IL_0387: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_038c: stloc.s 11
+			IL_038e: ldc.i4.0
+			IL_038f: stloc.s 12
+			IL_0391: ldc.i4.0
+			IL_0392: stloc.s 13
 			.try
 			{
-				IL_0392: ldloc.s 13
-				IL_0394: brtrue IL_03c0
+				IL_0394: ldloc.s 13
+				IL_0396: brtrue IL_03c2
 
-				IL_0399: ldc.i4.1
-				IL_039a: stloc.s 13
-				IL_039c: ldloc.s 11
-				IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
-				IL_03a3: stloc.s 34
-				IL_03a5: ldloc.s 34
-				IL_03a7: brfalse IL_03bd
+				IL_039b: ldc.i4.1
+				IL_039c: stloc.s 13
+				IL_039e: ldloc.s 11
+				IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+				IL_03a5: stloc.s 34
+				IL_03a7: ldloc.s 34
+				IL_03a9: brfalse IL_03bf
 
-				IL_03ac: ldc.i4.0
-				IL_03ad: stloc.s 13
-				IL_03af: ldloc.s 34
-				IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
-				IL_03b6: stloc.s 34
-				IL_03b8: br IL_03c0
+				IL_03ae: ldc.i4.0
+				IL_03af: stloc.s 13
+				IL_03b1: ldloc.s 34
+				IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+				IL_03b8: stloc.s 34
+				IL_03ba: br IL_03c2
 
-				IL_03bd: ldc.i4.1
-				IL_03be: stloc.s 13
+				IL_03bf: ldc.i4.1
+				IL_03c0: stloc.s 13
 
-				IL_03c0: ldstr "Assignment to constant variable."
-				IL_03c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-				IL_03ca: throw
+				IL_03c2: ldstr "Assignment to constant variable."
+				IL_03c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_03cc: throw
 
-				IL_03cb: ldloc.s 13
-				IL_03cd: brtrue IL_03dc
+				IL_03cd: ldloc.s 13
+				IL_03cf: brtrue IL_03de
 
-				IL_03d2: ldc.i4.1
-				IL_03d3: stloc.s 12
-				IL_03d5: ldloc.s 11
-				IL_03d7: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_03d4: ldc.i4.1
+				IL_03d5: stloc.s 12
+				IL_03d7: ldloc.s 11
+				IL_03d9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
 
-				IL_03dc: ldc.i4.1
-				IL_03dd: stloc.s 12
-				IL_03df: leave IL_03fa
+				IL_03de: ldc.i4.1
+				IL_03df: stloc.s 12
+				IL_03e1: leave IL_03fc
 			} // end .try
 			finally
 			{
-				IL_03e4: ldloc.s 12
-				IL_03e6: brtrue IL_03f9
+				IL_03e6: ldloc.s 12
+				IL_03e8: brtrue IL_03fb
 
-				IL_03eb: ldloc.s 13
-				IL_03ed: brtrue IL_03f9
+				IL_03ed: ldloc.s 13
+				IL_03ef: brtrue IL_03fb
 
-				IL_03f2: ldloc.s 11
-				IL_03f4: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_03f4: ldloc.s 11
+				IL_03f6: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_03f9: endfinally
+				IL_03fb: endfinally
 			} // end handler
 
-			IL_03fa: leave IL_047c
+			IL_03fc: leave IL_047e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03ff: stloc.s 14
-			IL_0401: ldloc.s 14
-			IL_0403: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0408: dup
-			IL_0409: brtrue IL_041f
+			IL_0401: stloc.s 14
+			IL_0403: ldloc.s 14
+			IL_0405: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_040a: dup
+			IL_040b: brtrue IL_0421
 
-			IL_040e: pop
-			IL_040f: ldloc.s 14
-			IL_0411: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0416: dup
-			IL_0417: brtrue IL_042b
+			IL_0410: pop
+			IL_0411: ldloc.s 14
+			IL_0413: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0418: dup
+			IL_0419: brtrue IL_042d
 
-			IL_041c: pop
-			IL_041d: rethrow
+			IL_041e: pop
+			IL_041f: rethrow
 
-			IL_041f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0424: stloc.s 15
-			IL_0426: br IL_042d
+			IL_0421: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0426: stloc.s 15
+			IL_0428: br IL_042f
 
-			IL_042b: stloc.s 15
+			IL_042d: stloc.s 15
 
-			IL_042d: ldloc.s 15
-			IL_042f: stloc.s 16
-			IL_0431: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0436: stloc.s 32
-			IL_0438: volatile.
-			IL_043a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-			IL_043f: brfalse IL_0455
+			IL_042f: ldloc.s 15
+			IL_0431: stloc.s 16
+			IL_0433: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0438: stloc.s 32
+			IL_043a: volatile.
+			IL_043c: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0441: brfalse IL_0457
 
-			IL_0444: ldloc.s 16
-			IL_0446: ldstr "name"
-			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0450: br IL_046b
+			IL_0446: ldloc.s 16
+			IL_0448: ldstr "name"
+			IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0452: br IL_046d
 
-			IL_0455: ldloc.s 16
-			IL_0457: ldstr "name"
-			IL_045c: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:179"
-			IL_0461: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
-			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_0457: ldloc.s 16
+			IL_0459: ldstr "name"
+			IL_045e: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:179"
+			IL_0463: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_36
+			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_046b: stloc.s 34
-			IL_046d: ldloc.s 32
-			IL_046f: ldloc.s 34
-			IL_0471: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0476: pop
-			IL_0477: leave IL_047c
+			IL_046d: stloc.s 34
+			IL_046f: ldloc.s 32
+			IL_0471: ldloc.s 34
+			IL_0473: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0478: pop
+			IL_0479: leave IL_047e
 		} // end handler
 
-		IL_047c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0481: stloc.s 32
-		IL_0483: ldc.i4.1
-		IL_0484: newarr [System.Runtime]System.Object
-		IL_0489: dup
-		IL_048a: ldc.i4.0
-		IL_048b: ldloc.0
-		IL_048c: stelem.ref
-		IL_048d: stloc.s 29
-		IL_048f: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
-		IL_0494: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0499: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
-		IL_049e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_04a3: stloc.s 30
-		IL_04a5: ldc.i4.1
-		IL_04a6: newarr [System.Runtime]System.Object
-		IL_04ab: dup
-		IL_04ac: ldc.i4.0
-		IL_04ad: ldloc.0
-		IL_04ae: stelem.ref
-		IL_04af: stloc.s 29
-		IL_04b1: ldloc.s 29
-		IL_04b3: ldc.i4.0
-		IL_04b4: newarr [System.Runtime]System.Object
-		IL_04b9: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_04be: newobj instance void Modules.Variable_ConstPrimitivePropagation/PatternReader::.ctor(object[])
-		IL_04c3: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_04c8: stloc.s 37
-		IL_04ca: ldloc.s 37
-		IL_04cc: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
-		IL_04d1: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_04d6: ldstr "prototype"
-		IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_04e0: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_04e5: ldloc.s 37
-		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04ec: volatile.
-		IL_04ee: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_04f3: brfalse IL_0507
+		IL_047e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0483: stloc.s 32
+		IL_0485: ldc.i4.1
+		IL_0486: newarr [System.Runtime]System.Object
+		IL_048b: dup
+		IL_048c: ldc.i4.0
+		IL_048d: ldloc.0
+		IL_048e: stelem.ref
+		IL_048f: stloc.s 29
+		IL_0491: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
+		IL_0496: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_049b: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
+		IL_04a0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_04a5: stloc.s 30
+		IL_04a7: ldc.i4.1
+		IL_04a8: newarr [System.Runtime]System.Object
+		IL_04ad: dup
+		IL_04ae: ldc.i4.0
+		IL_04af: ldloc.0
+		IL_04b0: stelem.ref
+		IL_04b1: stloc.s 29
+		IL_04b3: ldloc.s 29
+		IL_04b5: ldc.i4.0
+		IL_04b6: newarr [System.Runtime]System.Object
+		IL_04bb: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_04c0: newobj instance void Modules.Variable_ConstPrimitivePropagation/PatternReader::.ctor(object[])
+		IL_04c5: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_04ca: stloc.s 37
+		IL_04cc: ldloc.s 37
+		IL_04ce: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
+		IL_04d3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_04d8: ldstr "prototype"
+		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_04e2: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_04e7: ldloc.s 37
+		IL_04e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04ee: volatile.
+		IL_04f0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_04f5: brfalse IL_0509
 
-		IL_04f8: ldstr "read"
-		IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0502: br IL_051b
+		IL_04fa: ldstr "read"
+		IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0504: br IL_051d
 
-		IL_0507: ldstr "read"
-		IL_050c: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:193"
-		IL_0511: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
-		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0509: ldstr "read"
+		IL_050e: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:193"
+		IL_0513: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_37
+		IL_0518: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_051b: stloc.s 34
-		IL_051d: ldloc.s 32
-		IL_051f: ldloc.s 34
-		IL_0521: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0526: pop
-		IL_0527: ldloc.0
-		IL_0528: ldc.r8 8
-		IL_0531: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_LOOP
-		IL_0536: nop
+		IL_051d: stloc.s 34
+		IL_051f: ldloc.s 32
+		IL_0521: ldloc.s 34
+		IL_0523: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0528: pop
+		IL_0529: ldloc.0
+		IL_052a: ldc.r8 8
+		IL_0533: stfld float64 Modules.Variable_ConstPrimitivePropagation/Scope::WRITTEN_LOOP
+		IL_0538: nop
 		.try
 		{
-			IL_0537: nop
-			IL_0538: ldc.i4.1
-			IL_0539: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_053e: dup
-			IL_053f: ldc.r8 9
-			IL_0548: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-			IL_054d: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-			IL_0552: stloc.s 17
-			IL_0554: ldc.i4.0
-			IL_0555: stloc.s 18
-			IL_0557: ldc.i4.0
-			IL_0558: stloc.s 19
+			IL_0539: nop
+			IL_053a: ldc.i4.1
+			IL_053b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0540: dup
+			IL_0541: ldc.r8 9
+			IL_054a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+			IL_054f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+			IL_0554: stloc.s 17
+			IL_0556: ldc.i4.0
+			IL_0557: stloc.s 18
+			IL_0559: ldc.i4.0
+			IL_055a: stloc.s 19
 			.try
 			{
-				// loop start (head: IL_055a)
-					IL_055a: ldc.i4.1
-					IL_055b: stloc.s 18
-					IL_055d: ldloc.s 17
-					IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
-					IL_0564: stloc.s 34
-					IL_0566: ldloc.s 34
-					IL_0568: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
-					IL_056d: stloc.s 38
-					IL_056f: ldloc.s 38
-					IL_0571: brtrue IL_05a0
+				// loop start (head: IL_055c)
+					IL_055c: ldc.i4.1
+					IL_055d: stloc.s 18
+					IL_055f: ldloc.s 17
+					IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorNext(object)
+					IL_0566: stloc.s 34
+					IL_0568: ldloc.s 34
+					IL_056a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
+					IL_056f: stloc.s 38
+					IL_0571: ldloc.s 38
+					IL_0573: brtrue IL_05a2
 
-					IL_0576: ldloc.s 34
-					IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
-					IL_057d: pop
-					IL_057e: ldc.i4.0
-					IL_057f: stloc.s 18
-					IL_0581: ldstr "Assignment to constant variable."
-					IL_0586: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-					IL_058b: throw
+					IL_0578: ldloc.s 34
+					IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
+					IL_057f: pop
+					IL_0580: ldc.i4.0
+					IL_0581: stloc.s 18
+					IL_0583: ldstr "Assignment to constant variable."
+					IL_0588: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_058d: throw
 
-					IL_058c: br IL_055a
+					IL_058e: br IL_055c
 				// end loop
-				IL_0591: ldloc.s 17
-				IL_0593: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_0598: ldc.i4.1
-				IL_0599: stloc.s 19
-				IL_059b: leave IL_05be
+				IL_0593: ldloc.s 17
+				IL_0595: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_059a: ldc.i4.1
+				IL_059b: stloc.s 19
+				IL_059d: leave IL_05c0
 
-				IL_05a0: ldc.i4.1
-				IL_05a1: stloc.s 18
-				IL_05a3: leave IL_05be
+				IL_05a2: ldc.i4.1
+				IL_05a3: stloc.s 18
+				IL_05a5: leave IL_05c0
 			} // end .try
 			finally
 			{
-				IL_05a8: ldloc.s 18
-				IL_05aa: brtrue IL_05bd
+				IL_05aa: ldloc.s 18
+				IL_05ac: brtrue IL_05bf
 
-				IL_05af: ldloc.s 19
-				IL_05b1: brtrue IL_05bd
+				IL_05b1: ldloc.s 19
+				IL_05b3: brtrue IL_05bf
 
-				IL_05b6: ldloc.s 17
-				IL_05b8: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_05b8: ldloc.s 17
+				IL_05ba: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_05bd: endfinally
+				IL_05bf: endfinally
 			} // end handler
 
-			IL_05be: leave IL_0640
+			IL_05c0: leave IL_0642
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_05c3: stloc.s 20
-			IL_05c5: ldloc.s 20
-			IL_05c7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_05cc: dup
-			IL_05cd: brtrue IL_05e3
+			IL_05c5: stloc.s 20
+			IL_05c7: ldloc.s 20
+			IL_05c9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05ce: dup
+			IL_05cf: brtrue IL_05e5
 
-			IL_05d2: pop
-			IL_05d3: ldloc.s 20
-			IL_05d5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_05da: dup
-			IL_05db: brtrue IL_05ef
+			IL_05d4: pop
+			IL_05d5: ldloc.s 20
+			IL_05d7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_05dc: dup
+			IL_05dd: brtrue IL_05f1
 
-			IL_05e0: pop
-			IL_05e1: rethrow
+			IL_05e2: pop
+			IL_05e3: rethrow
 
-			IL_05e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_05e8: stloc.s 21
-			IL_05ea: br IL_05f1
+			IL_05e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_05ea: stloc.s 21
+			IL_05ec: br IL_05f3
 
-			IL_05ef: stloc.s 21
+			IL_05f1: stloc.s 21
 
-			IL_05f1: ldloc.s 21
-			IL_05f3: stloc.s 22
-			IL_05f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05fa: stloc.s 32
-			IL_05fc: volatile.
-			IL_05fe: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-			IL_0603: brfalse IL_0619
+			IL_05f3: ldloc.s 21
+			IL_05f5: stloc.s 22
+			IL_05f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05fc: stloc.s 32
+			IL_05fe: volatile.
+			IL_0600: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_0605: brfalse IL_061b
 
-			IL_0608: ldloc.s 22
-			IL_060a: ldstr "name"
-			IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0614: br IL_062f
+			IL_060a: ldloc.s 22
+			IL_060c: ldstr "name"
+			IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0616: br IL_0631
 
-			IL_0619: ldloc.s 22
-			IL_061b: ldstr "name"
-			IL_0620: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:248"
-			IL_0625: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
-			IL_062a: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_061b: ldloc.s 22
+			IL_061d: ldstr "name"
+			IL_0622: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:248"
+			IL_0627: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_38
+			IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_062f: stloc.s 34
-			IL_0631: ldloc.s 32
-			IL_0633: ldloc.s 34
-			IL_0635: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_063a: pop
-			IL_063b: leave IL_0640
+			IL_0631: stloc.s 34
+			IL_0633: ldloc.s 32
+			IL_0635: ldloc.s 34
+			IL_0637: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_063c: pop
+			IL_063d: leave IL_0642
 		} // end handler
 
-		IL_0640: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0645: stloc.s 32
-		IL_0647: ldc.i4.1
-		IL_0648: newarr [System.Runtime]System.Object
-		IL_064d: dup
-		IL_064e: ldc.i4.0
-		IL_064f: ldloc.0
-		IL_0650: stelem.ref
-		IL_0651: stloc.s 29
-		IL_0653: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
-		IL_0658: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_065d: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
-		IL_0662: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0667: stloc.s 30
-		IL_0669: ldc.i4.1
-		IL_066a: newarr [System.Runtime]System.Object
-		IL_066f: dup
-		IL_0670: ldc.i4.0
-		IL_0671: ldloc.0
-		IL_0672: stelem.ref
-		IL_0673: stloc.s 29
-		IL_0675: ldloc.s 29
-		IL_0677: ldc.i4.0
-		IL_0678: newarr [System.Runtime]System.Object
-		IL_067d: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_0682: newobj instance void Modules.Variable_ConstPrimitivePropagation/LoopReader::.ctor(object[])
-		IL_0687: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_068c: stloc.s 39
-		IL_068e: ldloc.s 39
-		IL_0690: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
-		IL_0695: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_069a: ldstr "prototype"
-		IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_06a4: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_06a9: ldloc.s 39
-		IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06b0: volatile.
-		IL_06b2: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_06b7: brfalse IL_06cb
+		IL_0642: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0647: stloc.s 32
+		IL_0649: ldc.i4.1
+		IL_064a: newarr [System.Runtime]System.Object
+		IL_064f: dup
+		IL_0650: ldc.i4.0
+		IL_0651: ldloc.0
+		IL_0652: stelem.ref
+		IL_0653: stloc.s 29
+		IL_0655: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
+		IL_065a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_065f: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
+		IL_0664: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0669: stloc.s 30
+		IL_066b: ldc.i4.1
+		IL_066c: newarr [System.Runtime]System.Object
+		IL_0671: dup
+		IL_0672: ldc.i4.0
+		IL_0673: ldloc.0
+		IL_0674: stelem.ref
+		IL_0675: stloc.s 29
+		IL_0677: ldloc.s 29
+		IL_0679: ldc.i4.0
+		IL_067a: newarr [System.Runtime]System.Object
+		IL_067f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_0684: newobj instance void Modules.Variable_ConstPrimitivePropagation/LoopReader::.ctor(object[])
+		IL_0689: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_068e: stloc.s 39
+		IL_0690: ldloc.s 39
+		IL_0692: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
+		IL_0697: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_069c: ldstr "prototype"
+		IL_06a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_06a6: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_06ab: ldloc.s 39
+		IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06b2: volatile.
+		IL_06b4: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_06b9: brfalse IL_06cd
 
-		IL_06bc: ldstr "read"
-		IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_06c6: br IL_06df
+		IL_06be: ldstr "read"
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_06c8: br IL_06e1
 
-		IL_06cb: ldstr "read"
-		IL_06d0: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:262"
-		IL_06d5: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
-		IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_06cd: ldstr "read"
+		IL_06d2: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:262"
+		IL_06d7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_39
+		IL_06dc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_06df: stloc.s 34
-		IL_06e1: ldloc.s 32
-		IL_06e3: ldloc.s 34
-		IL_06e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06ea: pop
-		IL_06eb: ldstr "ab"
-		IL_06f0: brfalse IL_0704
+		IL_06e1: stloc.s 34
+		IL_06e3: ldloc.s 32
+		IL_06e5: ldloc.s 34
+		IL_06e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06ec: pop
+		IL_06ed: ldstr "ab"
+		IL_06f2: brfalse IL_0706
 
-		IL_06f5: ldstr "ab"
-		IL_06fa: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_06ff: brfalse IL_0718
+		IL_06f7: ldstr "ab"
+		IL_06fc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0701: brfalse IL_071a
 
-		IL_0704: ldstr "ab"
-		IL_0709: ldstr ""
-		IL_070e: ldstr "0"
-		IL_0713: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+		IL_0706: ldstr "ab"
+		IL_070b: ldstr ""
+		IL_0710: ldstr "0"
+		IL_0715: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-		IL_0718: ldstr "ab"
-		IL_071d: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
-		IL_0722: stloc.s 23
-		IL_0724: ldc.i4.0
-		IL_0725: stloc.s 24
-		IL_0727: ldc.i4.0
-		IL_0728: stloc.s 25
+		IL_071a: ldstr "ab"
+		IL_071f: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetIterator(object)
+		IL_0724: stloc.s 23
+		IL_0726: ldc.i4.0
+		IL_0727: stloc.s 24
+		IL_0729: ldc.i4.0
+		IL_072a: stloc.s 25
 		.try
 		{
-			IL_072a: ldloc.s 25
-			IL_072c: brtrue IL_075c
+			IL_072c: ldloc.s 25
+			IL_072e: brtrue IL_075e
 
-			IL_0731: ldc.i4.1
-			IL_0732: stloc.s 25
-			IL_0734: ldloc.s 23
-			IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
-			IL_073b: stloc.s 34
-			IL_073d: ldloc.s 34
-			IL_073f: brfalse IL_0759
+			IL_0733: ldc.i4.1
+			IL_0734: stloc.s 25
+			IL_0736: ldloc.s 23
+			IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStep(object)
+			IL_073d: stloc.s 34
+			IL_073f: ldloc.s 34
+			IL_0741: brfalse IL_075b
 
-			IL_0744: ldc.i4.0
-			IL_0745: stloc.s 25
-			IL_0747: ldloc.s 34
-			IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
-			IL_074e: stloc.s 34
-			IL_0750: ldloc.s 34
-			IL_0752: stloc.s 40
-			IL_0754: br IL_075f
+			IL_0746: ldc.i4.0
+			IL_0747: stloc.s 25
+			IL_0749: ldloc.s 34
+			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorDestructuringStepValue(object)
+			IL_0750: stloc.s 34
+			IL_0752: ldloc.s 34
+			IL_0754: stloc.s 40
+			IL_0756: br IL_0761
 
-			IL_0759: ldc.i4.1
-			IL_075a: stloc.s 25
+			IL_075b: ldc.i4.1
+			IL_075c: stloc.s 25
 
-			IL_075c: ldnull
-			IL_075d: stloc.s 40
+			IL_075e: ldnull
+			IL_075f: stloc.s 40
 
-			IL_075f: ldloc.0
-			IL_0760: ldloc.s 40
-			IL_0762: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::DESTRUCTURED
-			IL_0767: ldloc.s 25
-			IL_0769: brtrue IL_0778
+			IL_0761: ldloc.0
+			IL_0762: ldloc.s 40
+			IL_0764: stfld object Modules.Variable_ConstPrimitivePropagation/Scope::DESTRUCTURED
+			IL_0769: ldloc.s 25
+			IL_076b: brtrue IL_077a
 
-			IL_076e: ldc.i4.1
-			IL_076f: stloc.s 24
-			IL_0771: ldloc.s 23
-			IL_0773: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+			IL_0770: ldc.i4.1
+			IL_0771: stloc.s 24
+			IL_0773: ldloc.s 23
+			IL_0775: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
 
-			IL_0778: ldc.i4.1
-			IL_0779: stloc.s 24
-			IL_077b: leave IL_0796
+			IL_077a: ldc.i4.1
+			IL_077b: stloc.s 24
+			IL_077d: leave IL_0798
 		} // end .try
 		finally
 		{
-			IL_0780: ldloc.s 24
-			IL_0782: brtrue IL_0795
+			IL_0782: ldloc.s 24
+			IL_0784: brtrue IL_0797
 
-			IL_0787: ldloc.s 25
-			IL_0789: brtrue IL_0795
+			IL_0789: ldloc.s 25
+			IL_078b: brtrue IL_0797
 
-			IL_078e: ldloc.s 23
-			IL_0790: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+			IL_0790: ldloc.s 23
+			IL_0792: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-			IL_0795: endfinally
+			IL_0797: endfinally
 		} // end handler
 
-		IL_0796: nop
-		IL_0797: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_079c: stloc.s 32
-		IL_079e: ldc.i4.1
-		IL_079f: newarr [System.Runtime]System.Object
-		IL_07a4: dup
-		IL_07a5: ldc.i4.0
-		IL_07a6: ldloc.0
-		IL_07a7: stelem.ref
-		IL_07a8: stloc.s 29
-		IL_07aa: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
-		IL_07af: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07b4: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
-		IL_07b9: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07be: stloc.s 30
-		IL_07c0: ldc.i4.1
-		IL_07c1: newarr [System.Runtime]System.Object
-		IL_07c6: dup
-		IL_07c7: ldc.i4.0
-		IL_07c8: ldloc.0
-		IL_07c9: stelem.ref
-		IL_07ca: stloc.s 29
-		IL_07cc: ldloc.s 29
-		IL_07ce: ldc.i4.0
-		IL_07cf: newarr [System.Runtime]System.Object
-		IL_07d4: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
-		IL_07d9: newobj instance void Modules.Variable_ConstPrimitivePropagation/DestructuredReader::.ctor(object[])
-		IL_07de: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
-		IL_07e3: stloc.s 41
-		IL_07e5: ldloc.s 41
-		IL_07e7: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
-		IL_07ec: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_07f1: ldstr "prototype"
-		IL_07f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
-		IL_07fb: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
-		IL_0800: ldloc.s 41
-		IL_0802: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0807: volatile.
-		IL_0809: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_080e: brfalse IL_0822
+		IL_0798: nop
+		IL_0799: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_079e: stloc.s 32
+		IL_07a0: ldc.i4.1
+		IL_07a1: newarr [System.Runtime]System.Object
+		IL_07a6: dup
+		IL_07a7: ldc.i4.0
+		IL_07a8: ldloc.0
+		IL_07a9: stelem.ref
+		IL_07aa: stloc.s 29
+		IL_07ac: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
+		IL_07b1: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_07b6: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
+		IL_07bb: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_07c0: stloc.s 30
+		IL_07c2: ldc.i4.1
+		IL_07c3: newarr [System.Runtime]System.Object
+		IL_07c8: dup
+		IL_07c9: ldc.i4.0
+		IL_07ca: ldloc.0
+		IL_07cb: stelem.ref
+		IL_07cc: stloc.s 29
+		IL_07ce: ldloc.s 29
+		IL_07d0: ldc.i4.0
+		IL_07d1: newarr [System.Runtime]System.Object
+		IL_07d6: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_07db: newobj instance void Modules.Variable_ConstPrimitivePropagation/DestructuredReader::.ctor(object[])
+		IL_07e0: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_07e5: stloc.s 41
+		IL_07e7: ldloc.s 41
+		IL_07e9: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
+		IL_07ee: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_07f3: ldstr "prototype"
+		IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_07fd: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_0802: ldloc.s 41
+		IL_0804: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0809: volatile.
+		IL_080b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0810: brfalse IL_0824
 
-		IL_0813: ldstr "read"
-		IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_081d: br IL_0836
+		IL_0815: ldstr "read"
+		IL_081a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_081f: br IL_0838
 
-		IL_0822: ldstr "read"
-		IL_0827: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:320"
-		IL_082c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
-		IL_0831: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+		IL_0824: ldstr "read"
+		IL_0829: ldstr "Variable_ConstPrimitivePropagation:Modules.Variable_ConstPrimitivePropagation:__js_module_init__:320"
+		IL_082e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_40
+		IL_0833: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
 
-		IL_0836: stloc.s 40
-		IL_0838: ldloc.s 32
-		IL_083a: ldloc.s 40
-		IL_083c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0841: pop
-		IL_0842: nop
-		IL_0843: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0848: stloc.s 32
-		IL_084a: ldloc.2
-		IL_084b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0850: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0855: stloc.s 40
-		IL_0857: ldloc.s 40
-		IL_0859: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_085e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0863: stloc.s 40
-		IL_0865: ldloc.s 32
-		IL_0867: ldloc.s 40
-		IL_0869: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_086e: pop
-		IL_086f: ldnull
-		IL_0870: stloc.s 26
-		IL_0872: newobj instance void Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::.ctor()
-		IL_0877: stloc.s 27
-		IL_0879: ldc.r8 1
-		IL_0882: box [System.Runtime]System.Double
-		IL_0887: ldc.r8 0.0
-		IL_0890: box [System.Runtime]System.Double
-		IL_0895: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_089a: stloc.s 38
-		IL_089c: ldloc.s 38
-		IL_089e: brtrue IL_08d2
+		IL_0838: stloc.s 40
+		IL_083a: ldloc.s 32
+		IL_083c: ldloc.s 40
+		IL_083e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0843: pop
+		IL_0844: nop
+		IL_0845: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_084a: stloc.s 32
+		IL_084c: ldloc.0
+		IL_084d: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+		IL_0852: ldnull
+		IL_0853: call object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
+		IL_0858: stloc.s 40
+		IL_085a: ldloc.s 40
+		IL_085c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0861: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0866: stloc.s 40
+		IL_0868: ldloc.s 32
+		IL_086a: ldloc.s 40
+		IL_086c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0871: pop
+		IL_0872: ldnull
+		IL_0873: stloc.s 26
+		IL_0875: newobj instance void Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::.ctor()
+		IL_087a: stloc.s 27
+		IL_087c: ldc.r8 1
+		IL_0885: box [System.Runtime]System.Double
+		IL_088a: ldc.r8 0.0
+		IL_0893: box [System.Runtime]System.Double
+		IL_0898: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_089d: stloc.s 38
+		IL_089f: ldloc.s 38
+		IL_08a1: brtrue IL_08d5
 
-		IL_08a3: ldc.r8 1
-		IL_08ac: box [System.Runtime]System.Double
-		IL_08b1: ldc.r8 1
-		IL_08ba: box [System.Runtime]System.Double
-		IL_08bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_08c4: stloc.s 38
-		IL_08c6: ldloc.s 38
-		IL_08c8: brtrue IL_08ec
+		IL_08a6: ldc.r8 1
+		IL_08af: box [System.Runtime]System.Double
+		IL_08b4: ldc.r8 1
+		IL_08bd: box [System.Runtime]System.Double
+		IL_08c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_08c7: stloc.s 38
+		IL_08c9: ldloc.s 38
+		IL_08cb: brtrue IL_08ef
 
-		IL_08cd: br IL_0942
+		IL_08d0: br IL_0945
 
-		IL_08d2: ldloc.s 27
-		IL_08d4: castclass Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0
-		IL_08d9: ldc.r8 5
-		IL_08e2: box [System.Runtime]System.Double
-		IL_08e7: stfld object Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::SKIPPED
+		IL_08d5: ldloc.s 27
+		IL_08d7: castclass Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0
+		IL_08dc: ldc.r8 5
+		IL_08e5: box [System.Runtime]System.Double
+		IL_08ea: stfld object Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0::SKIPPED
 
-		IL_08ec: ldc.i4.2
-		IL_08ed: newarr [System.Runtime]System.Object
-		IL_08f2: dup
-		IL_08f3: ldc.i4.0
-		IL_08f4: ldloc.0
-		IL_08f5: stelem.ref
-		IL_08f6: dup
-		IL_08f7: ldc.i4.1
-		IL_08f8: ldloc.s 27
-		IL_08fa: stelem.ref
-		IL_08fb: stloc.s 29
-		IL_08fd: ldloc.s 29
-		IL_08ff: ldc.i4.0
-		IL_0900: ldelem.ref
-		IL_0901: castclass Modules.Variable_ConstPrimitivePropagation/Scope
-		IL_0906: ldloc.s 29
-		IL_0908: ldc.i4.1
-		IL_0909: ldelem.ref
-		IL_090a: castclass Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0
-		IL_090f: ldloc.s 29
-		IL_0911: newobj instance void Modules.Variable_ConstPrimitivePropagation/ArrowFunction_L122C21/FunctionObject::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope, class Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0, object[])
-		IL_0916: ldc.i4.0
-		IL_0917: conv.r8
-		IL_0918: ldstr ""
-		IL_091d: ldc.i4.0
-		IL_091e: ldc.i4.0
-		IL_091f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation/ArrowFunction_L122C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0924: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_ConstPrimitivePropagation/ArrowFunction_L122C21/FunctionObject>(!!0)
-		IL_0929: stloc.s 42
-		IL_092b: ldloc.s 42
-		IL_092d: ldstr "skippedReader"
-		IL_0932: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0937: stloc.s 40
-		IL_0939: ldloc.s 40
-		IL_093b: stloc.s 26
-		IL_093d: br IL_0942
+		IL_08ef: ldc.i4.2
+		IL_08f0: newarr [System.Runtime]System.Object
+		IL_08f5: dup
+		IL_08f6: ldc.i4.0
+		IL_08f7: ldloc.0
+		IL_08f8: stelem.ref
+		IL_08f9: dup
+		IL_08fa: ldc.i4.1
+		IL_08fb: ldloc.s 27
+		IL_08fd: stelem.ref
+		IL_08fe: stloc.s 29
+		IL_0900: ldloc.s 29
+		IL_0902: ldc.i4.0
+		IL_0903: ldelem.ref
+		IL_0904: castclass Modules.Variable_ConstPrimitivePropagation/Scope
+		IL_0909: ldloc.s 29
+		IL_090b: ldc.i4.1
+		IL_090c: ldelem.ref
+		IL_090d: castclass Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0
+		IL_0912: ldloc.s 29
+		IL_0914: newobj instance void Modules.Variable_ConstPrimitivePropagation/ArrowFunction_L122C21/FunctionObject::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope, class Modules.Variable_ConstPrimitivePropagation/Scope/Switch_L118C0, object[])
+		IL_0919: ldc.i4.0
+		IL_091a: conv.r8
+		IL_091b: ldstr ""
+		IL_0920: ldc.i4.0
+		IL_0921: ldc.i4.0
+		IL_0922: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation/ArrowFunction_L122C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0927: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_ConstPrimitivePropagation/ArrowFunction_L122C21/FunctionObject>(!!0)
+		IL_092c: stloc.s 42
+		IL_092e: ldloc.s 42
+		IL_0930: ldstr "skippedReader"
+		IL_0935: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_093a: stloc.s 40
+		IL_093c: ldloc.s 40
+		IL_093e: stloc.s 26
+		IL_0940: br IL_0945
 
-		IL_0942: ldnull
-		IL_0943: stloc.s 28
-		IL_0945: ret
+		IL_0945: ldnull
+		IL_0946: stloc.s 28
+		IL_0948: ret
 	} // end of method Variable_ConstPrimitivePropagation::__js_module_init__
 
 } // end of class Modules.Variable_ConstPrimitivePropagation

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
@@ -1066,17 +1066,16 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 322 (0x142)
+		// Code size: 292 (0x124)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope,
 			[1] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject,
 			[2] object[],
-			[3] object[],
-			[4] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject,
-			[5] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10/FunctionObject,
-			[6] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10/FunctionObject,
-			[7] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10/FunctionObject
+			[3] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject,
+			[4] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10/FunctionObject,
+			[5] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10/FunctionObject,
+			[6] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::.ctor()
@@ -1102,125 +1101,113 @@
 		IL_0028: ldc.i4.0
 		IL_0029: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 		IL_002e: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::x
-		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0038: stloc.2
-		IL_0039: ldc.i4.1
-		IL_003a: newarr [System.Runtime]System.Object
-		IL_003f: dup
-		IL_0040: ldc.i4.0
-		IL_0041: ldloc.0
-		IL_0042: stelem.ref
-		IL_0043: stloc.3
-		IL_0044: ldloc.3
-		IL_0045: ldc.i4.0
-		IL_0046: ldelem.ref
-		IL_0047: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
-		IL_004c: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject::.ctor(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope)
-		IL_0051: ldc.i4.0
-		IL_0052: conv.r8
-		IL_0053: ldstr ""
-		IL_0058: ldc.i4.0
-		IL_0059: ldc.i4.0
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject>(!!0)
-		IL_0064: stloc.s 4
-		IL_0066: ldloc.1
-		IL_0067: ldloc.2
-		IL_0068: ldloc.s 4
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_006f: pop
-		IL_0070: ldloc.0
-		IL_0071: ldnull
-		IL_0072: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::x
-		IL_0077: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_007c: stloc.2
-		IL_007d: ldc.i4.1
-		IL_007e: newarr [System.Runtime]System.Object
-		IL_0083: dup
-		IL_0084: ldc.i4.0
-		IL_0085: ldloc.0
-		IL_0086: stelem.ref
-		IL_0087: stloc.3
-		IL_0088: ldloc.3
-		IL_0089: ldc.i4.0
-		IL_008a: ldelem.ref
-		IL_008b: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
-		IL_0090: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10/FunctionObject::.ctor(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope)
-		IL_0095: ldc.i4.0
-		IL_0096: conv.r8
-		IL_0097: ldstr ""
-		IL_009c: ldc.i4.0
-		IL_009d: ldc.i4.0
-		IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10/FunctionObject>(!!0)
-		IL_00a8: stloc.s 5
-		IL_00aa: ldloc.1
-		IL_00ab: ldloc.2
-		IL_00ac: ldloc.s 5
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00b3: pop
-		IL_00b4: ldloc.0
-		IL_00b5: ldc.i4.0
-		IL_00b6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00bb: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
-		IL_00c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00c5: stloc.2
-		IL_00c6: ldc.i4.1
-		IL_00c7: newarr [System.Runtime]System.Object
-		IL_00cc: dup
-		IL_00cd: ldc.i4.0
-		IL_00ce: ldloc.0
-		IL_00cf: stelem.ref
-		IL_00d0: stloc.3
-		IL_00d1: ldloc.3
-		IL_00d2: ldc.i4.0
-		IL_00d3: ldelem.ref
-		IL_00d4: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
-		IL_00d9: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10/FunctionObject::.ctor(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope)
-		IL_00de: ldc.i4.0
-		IL_00df: conv.r8
-		IL_00e0: ldstr ""
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldc.i4.0
-		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10/FunctionObject>(!!0)
-		IL_00f1: stloc.s 6
-		IL_00f3: ldloc.1
-		IL_00f4: ldloc.2
-		IL_00f5: ldloc.s 6
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00fc: pop
-		IL_00fd: ldloc.0
-		IL_00fe: ldnull
-		IL_00ff: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
-		IL_0104: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0109: stloc.2
-		IL_010a: ldc.i4.1
-		IL_010b: newarr [System.Runtime]System.Object
-		IL_0110: dup
-		IL_0111: ldc.i4.0
-		IL_0112: ldloc.0
-		IL_0113: stelem.ref
-		IL_0114: stloc.3
-		IL_0115: ldloc.3
-		IL_0116: ldc.i4.0
-		IL_0117: ldelem.ref
-		IL_0118: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
-		IL_011d: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10/FunctionObject::.ctor(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope)
-		IL_0122: ldc.i4.0
-		IL_0123: conv.r8
-		IL_0124: ldstr ""
-		IL_0129: ldc.i4.0
-		IL_012a: ldc.i4.0
-		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0130: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10/FunctionObject>(!!0)
-		IL_0135: stloc.s 7
-		IL_0137: ldloc.1
-		IL_0138: ldloc.2
-		IL_0139: ldloc.s 7
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0140: pop
-		IL_0141: ret
+		IL_0033: ldc.i4.1
+		IL_0034: newarr [System.Runtime]System.Object
+		IL_0039: dup
+		IL_003a: ldc.i4.0
+		IL_003b: ldloc.0
+		IL_003c: stelem.ref
+		IL_003d: stloc.2
+		IL_003e: ldloc.2
+		IL_003f: ldc.i4.0
+		IL_0040: ldelem.ref
+		IL_0041: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
+		IL_0046: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject::.ctor(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope)
+		IL_004b: ldc.i4.0
+		IL_004c: conv.r8
+		IL_004d: ldstr ""
+		IL_0052: ldc.i4.0
+		IL_0053: ldc.i4.0
+		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject>(!!0)
+		IL_005e: stloc.3
+		IL_005f: ldnull
+		IL_0060: ldloc.3
+		IL_0061: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
+		IL_0066: pop
+		IL_0067: ldloc.0
+		IL_0068: ldnull
+		IL_0069: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::x
+		IL_006e: ldc.i4.1
+		IL_006f: newarr [System.Runtime]System.Object
+		IL_0074: dup
+		IL_0075: ldc.i4.0
+		IL_0076: ldloc.0
+		IL_0077: stelem.ref
+		IL_0078: stloc.2
+		IL_0079: ldloc.2
+		IL_007a: ldc.i4.0
+		IL_007b: ldelem.ref
+		IL_007c: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
+		IL_0081: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10/FunctionObject::.ctor(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope)
+		IL_0086: ldc.i4.0
+		IL_0087: conv.r8
+		IL_0088: ldstr ""
+		IL_008d: ldc.i4.0
+		IL_008e: ldc.i4.0
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10/FunctionObject>(!!0)
+		IL_0099: stloc.s 4
+		IL_009b: ldnull
+		IL_009c: ldloc.s 4
+		IL_009e: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
+		IL_00a3: pop
+		IL_00a4: ldloc.0
+		IL_00a5: ldc.i4.0
+		IL_00a6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00ab: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
+		IL_00b0: ldc.i4.1
+		IL_00b1: newarr [System.Runtime]System.Object
+		IL_00b6: dup
+		IL_00b7: ldc.i4.0
+		IL_00b8: ldloc.0
+		IL_00b9: stelem.ref
+		IL_00ba: stloc.2
+		IL_00bb: ldloc.2
+		IL_00bc: ldc.i4.0
+		IL_00bd: ldelem.ref
+		IL_00be: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
+		IL_00c3: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10/FunctionObject::.ctor(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope)
+		IL_00c8: ldc.i4.0
+		IL_00c9: conv.r8
+		IL_00ca: ldstr ""
+		IL_00cf: ldc.i4.0
+		IL_00d0: ldc.i4.0
+		IL_00d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10/FunctionObject>(!!0)
+		IL_00db: stloc.s 5
+		IL_00dd: ldnull
+		IL_00de: ldloc.s 5
+		IL_00e0: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
+		IL_00e5: pop
+		IL_00e6: ldloc.0
+		IL_00e7: ldnull
+		IL_00e8: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
+		IL_00ed: ldc.i4.1
+		IL_00ee: newarr [System.Runtime]System.Object
+		IL_00f3: dup
+		IL_00f4: ldc.i4.0
+		IL_00f5: ldloc.0
+		IL_00f6: stelem.ref
+		IL_00f7: stloc.2
+		IL_00f8: ldloc.2
+		IL_00f9: ldc.i4.0
+		IL_00fa: ldelem.ref
+		IL_00fb: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
+		IL_0100: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10/FunctionObject::.ctor(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope)
+		IL_0105: ldc.i4.0
+		IL_0106: conv.r8
+		IL_0107: ldstr ""
+		IL_010c: ldc.i4.0
+		IL_010d: ldc.i4.0
+		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10/FunctionObject>(!!0)
+		IL_0118: stloc.s 6
+		IL_011a: ldnull
+		IL_011b: ldloc.s 6
+		IL_011d: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
+		IL_0122: pop
+		IL_0123: ret
 	} // end of method Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage::__js_module_init__
 
 } // end of class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
@@ -350,7 +350,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 82 (0x52)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Variable_LetFunctionNestedShadowing/outer/Scope,
@@ -376,21 +376,20 @@
 			IL_0020: ldc.r8 1
 			IL_0029: stloc.2
 			IL_002a: nop
-			IL_002b: ldloc.1
-			IL_002c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0036: pop
-			IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_003c: stloc.s 4
-			IL_003e: ldloc.2
-			IL_003f: box [System.Runtime]System.Double
-			IL_0044: stloc.s 5
-			IL_0046: ldloc.s 4
-			IL_0048: ldloc.s 5
-			IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_004f: pop
-			IL_0050: ldnull
-			IL_0051: ret
+			IL_002b: ldnull
+			IL_002c: call object Modules.Variable_LetFunctionNestedShadowing/outer/inner::__js_call__(object)
+			IL_0031: pop
+			IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0037: stloc.s 4
+			IL_0039: ldloc.2
+			IL_003a: box [System.Runtime]System.Double
+			IL_003f: stloc.s 5
+			IL_0041: ldloc.s 4
+			IL_0043: ldloc.s 5
+			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_004a: pop
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -433,7 +432,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 87 (0x57)
+		// Code size: 82 (0x52)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetFunctionNestedShadowing/Scope,
@@ -465,20 +464,19 @@
 		IL_0026: ldc.r8 0.0
 		IL_002f: stloc.2
 		IL_0030: nop
-		IL_0031: ldloc.1
-		IL_0032: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003c: pop
-		IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0042: stloc.s 4
-		IL_0044: ldloc.2
-		IL_0045: box [System.Runtime]System.Double
-		IL_004a: stloc.s 5
-		IL_004c: ldloc.s 4
-		IL_004e: ldloc.s 5
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0055: pop
-		IL_0056: ret
+		IL_0031: ldnull
+		IL_0032: call object Modules.Variable_LetFunctionNestedShadowing/outer::__js_call__(object)
+		IL_0037: pop
+		IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_003d: stloc.s 4
+		IL_003f: ldloc.2
+		IL_0040: box [System.Runtime]System.Double
+		IL_0045: stloc.s 5
+		IL_0047: ldloc.s 4
+		IL_0049: ldloc.s 5
+		IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0050: pop
+		IL_0051: ret
 	} // end of method Variable_LetFunctionNestedShadowing::__js_module_init__
 
 } // end of class Modules.Variable_LetFunctionNestedShadowing

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetShadowing.verified.txt
@@ -257,7 +257,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 87 (0x57)
+		// Code size: 82 (0x52)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetShadowing/Scope,
@@ -289,20 +289,19 @@
 		IL_0026: ldc.r8 1
 		IL_002f: stloc.2
 		IL_0030: nop
-		IL_0031: ldloc.1
-		IL_0032: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003c: pop
-		IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0042: stloc.s 4
-		IL_0044: ldloc.2
-		IL_0045: box [System.Runtime]System.Double
-		IL_004a: stloc.s 5
-		IL_004c: ldloc.s 4
-		IL_004e: ldloc.s 5
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0055: pop
-		IL_0056: ret
+		IL_0031: ldnull
+		IL_0032: call object Modules.Variable_LetShadowing/f::__js_call__(object)
+		IL_0037: pop
+		IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_003d: stloc.s 4
+		IL_003f: ldloc.2
+		IL_0040: box [System.Runtime]System.Double
+		IL_0045: stloc.s 5
+		IL_0047: ldloc.s 4
+		IL_0049: ldloc.s 5
+		IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0050: pop
+		IL_0051: ret
 	} // end of method Variable_LetShadowing::__js_module_init__
 
 } // end of class Modules.Variable_LetShadowing

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
@@ -275,7 +275,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 340 (0x154)
+		// Code size: 341 (0x155)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_ObjectDestructuring_Captured/Scope,
@@ -391,16 +391,17 @@
 		IL_012f: pop
 		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0135: stloc.s 5
-		IL_0137: ldloc.1
-		IL_0138: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0142: stloc.s 4
-		IL_0144: ldloc.s 5
-		IL_0146: ldstr "compute()="
-		IL_014b: ldloc.s 4
-		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0152: pop
-		IL_0153: ret
+		IL_0137: ldloc.0
+		IL_0138: castclass Modules.Variable_ObjectDestructuring_Captured/Scope
+		IL_013d: ldnull
+		IL_013e: call object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
+		IL_0143: stloc.s 4
+		IL_0145: ldloc.s 5
+		IL_0147: ldstr "compute()="
+		IL_014c: ldloc.s 4
+		IL_014e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0153: pop
+		IL_0154: ret
 	} // end of method Variable_ObjectDestructuring_Captured::__js_module_init__
 
 } // end of class Modules.Variable_ObjectDestructuring_Captured

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
@@ -317,7 +317,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 206 (0xce)
+		// Code size: 207 (0xcf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneCapturedRead/Scope,
@@ -357,69 +357,70 @@
 		.try
 		{
 			IL_0031: nop
-			IL_0032: ldloc.1
-			IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_003d: pop
-			IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0043: stloc.s 7
-			IL_0045: ldloc.s 7
-			IL_0047: ldstr "NO_TDZ"
-			IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0051: pop
-			IL_0052: leave IL_009c
+			IL_0032: ldloc.0
+			IL_0033: castclass Modules.Variable_TemporalDeadZoneCapturedRead/Scope
+			IL_0038: ldnull
+			IL_0039: call object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
+			IL_003e: pop
+			IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0044: stloc.s 7
+			IL_0046: ldloc.s 7
+			IL_0048: ldstr "NO_TDZ"
+			IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0052: pop
+			IL_0053: leave IL_009d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0057: stloc.2
-			IL_0058: ldloc.2
-			IL_0059: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_005e: dup
-			IL_005f: brtrue IL_0074
+			IL_0058: stloc.2
+			IL_0059: ldloc.2
+			IL_005a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_005f: dup
+			IL_0060: brtrue IL_0075
 
-			IL_0064: pop
-			IL_0065: ldloc.2
-			IL_0066: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_006b: dup
-			IL_006c: brtrue IL_007f
+			IL_0065: pop
+			IL_0066: ldloc.2
+			IL_0067: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_006c: dup
+			IL_006d: brtrue IL_0080
 
-			IL_0071: pop
-			IL_0072: rethrow
+			IL_0072: pop
+			IL_0073: rethrow
 
-			IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0079: stloc.3
-			IL_007a: br IL_0080
+			IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_007a: stloc.3
+			IL_007b: br IL_0081
 
-			IL_007f: stloc.3
+			IL_0080: stloc.3
 
-			IL_0080: ldloc.3
-			IL_0081: stloc.s 4
-			IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0088: stloc.s 7
-			IL_008a: ldloc.s 7
-			IL_008c: ldstr "TDZ_CAPTURED"
-			IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0096: pop
-			IL_0097: leave IL_009c
+			IL_0081: ldloc.3
+			IL_0082: stloc.s 4
+			IL_0084: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0089: stloc.s 7
+			IL_008b: ldloc.s 7
+			IL_008d: ldstr "TDZ_CAPTURED"
+			IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0097: pop
+			IL_0098: leave IL_009d
 		} // end handler
 
-		IL_009c: ldloc.0
-		IL_009d: ldstr "ready"
-		IL_00a2: stfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
-		IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ac: stloc.s 7
-		IL_00ae: ldloc.0
-		IL_00af: ldfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
-		IL_00b4: ldstr "Cannot access 'value' before initialization"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00be: stloc.s 8
-		IL_00c0: ldloc.s 7
-		IL_00c2: ldloc.s 8
-		IL_00c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c9: pop
-		IL_00ca: ldnull
-		IL_00cb: stloc.s 5
-		IL_00cd: ret
+		IL_009d: ldloc.0
+		IL_009e: ldstr "ready"
+		IL_00a3: stfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
+		IL_00a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ad: stloc.s 7
+		IL_00af: ldloc.0
+		IL_00b0: ldfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
+		IL_00b5: ldstr "Cannot access 'value' before initialization"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_00bf: stloc.s 8
+		IL_00c1: ldloc.s 7
+		IL_00c3: ldloc.s 8
+		IL_00c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ca: pop
+		IL_00cb: ldnull
+		IL_00cc: stloc.s 5
+		IL_00ce: ret
 	} // end of method Variable_TemporalDeadZoneCapturedRead::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneCapturedRead

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -543,7 +543,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 540 (0x21c)
+		// Code size: 541 (0x21d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakRef_Deref_KeptObjects/Scope,
@@ -582,179 +582,180 @@
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
-		IL_0031: ldloc.1
-		IL_0032: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_003c: stloc.s 7
-		IL_003e: ldloc.0
-		IL_003f: ldloc.s 7
-		IL_0041: stfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004b: stloc.s 8
-		IL_004d: ldstr "Object"
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0057: volatile.
-		IL_0059: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_005e: brfalse IL_0072
+		IL_0031: ldloc.0
+		IL_0032: castclass Modules.WeakRef_Deref_KeptObjects/Scope
+		IL_0037: ldnull
+		IL_0038: call object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
+		IL_003d: stloc.s 7
+		IL_003f: ldloc.0
+		IL_0040: ldloc.s 7
+		IL_0042: stfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
+		IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004c: stloc.s 8
+		IL_004e: ldstr "Object"
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0058: volatile.
+		IL_005a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_005f: brfalse IL_0073
 
-		IL_0063: ldstr "prototype"
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_006d: br IL_0086
+		IL_0064: ldstr "prototype"
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006e: br IL_0087
 
-		IL_0072: ldstr "prototype"
-		IL_0077: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:16"
-		IL_007c: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_0073: ldstr "prototype"
+		IL_0078: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:16"
+		IL_007d: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_0086: stloc.s 7
-		IL_0088: volatile.
-		IL_008a: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_008f: brfalse IL_00a5
+		IL_0087: stloc.s 7
+		IL_0089: volatile.
+		IL_008b: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0090: brfalse IL_00a6
 
-		IL_0094: ldloc.s 7
-		IL_0096: ldstr "toString"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a0: br IL_00bb
+		IL_0095: ldloc.s 7
+		IL_0097: ldstr "toString"
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a1: br IL_00bc
 
-		IL_00a5: ldloc.s 7
-		IL_00a7: ldstr "toString"
-		IL_00ac: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:18"
-		IL_00b1: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+		IL_00a6: ldloc.s 7
+		IL_00a8: ldstr "toString"
+		IL_00ad: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:18"
+		IL_00b2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-		IL_00bb: stloc.s 7
-		IL_00bd: ldloc.s 7
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c4: stloc.s 7
-		IL_00c6: ldloc.0
-		IL_00c7: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-		IL_00cc: stloc.s 9
-		IL_00ce: volatile.
-		IL_00d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_00d5: brfalse IL_00ed
+		IL_00bc: stloc.s 7
+		IL_00be: ldloc.s 7
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c5: stloc.s 7
+		IL_00c7: ldloc.0
+		IL_00c8: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
+		IL_00cd: stloc.s 9
+		IL_00cf: volatile.
+		IL_00d1: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_00d6: brfalse IL_00ee
 
-		IL_00da: ldloc.s 7
-		IL_00dc: ldstr "call"
-		IL_00e1: ldloc.s 9
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e8: br IL_0105
+		IL_00db: ldloc.s 7
+		IL_00dd: ldstr "call"
+		IL_00e2: ldloc.s 9
+		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e9: br IL_0106
 
-		IL_00ed: ldloc.s 7
-		IL_00ef: ldstr "call"
-		IL_00f4: ldloc.s 9
-		IL_00f6: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:21"
-		IL_00fb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
+		IL_00ee: ldloc.s 7
+		IL_00f0: ldstr "call"
+		IL_00f5: ldloc.s 9
+		IL_00f7: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:21"
+		IL_00fc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember1(object, string, object, string, int32&)
 
-		IL_0105: stloc.s 9
-		IL_0107: ldloc.s 8
-		IL_0109: ldloc.s 9
-		IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0110: pop
+		IL_0106: stloc.s 9
+		IL_0108: ldloc.s 8
+		IL_010a: ldloc.s 9
+		IL_010c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0111: pop
 		.try
 		{
-			IL_0111: nop
-			IL_0112: ldc.r8 123
-			IL_011b: box [System.Runtime]System.Double
-			IL_0120: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
-			IL_0125: pop
-			IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_012b: stloc.s 8
-			IL_012d: ldloc.s 8
-			IL_012f: ldstr "primitive target threw:"
-			IL_0134: ldc.i4.0
-			IL_0135: box [System.Runtime]System.Boolean
-			IL_013a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_013f: pop
-			IL_0140: leave IL_01db
+			IL_0112: nop
+			IL_0113: ldc.r8 123
+			IL_011c: box [System.Runtime]System.Double
+			IL_0121: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
+			IL_0126: pop
+			IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012c: stloc.s 8
+			IL_012e: ldloc.s 8
+			IL_0130: ldstr "primitive target threw:"
+			IL_0135: ldc.i4.0
+			IL_0136: box [System.Runtime]System.Boolean
+			IL_013b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0140: pop
+			IL_0141: leave IL_01dc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0145: stloc.2
-			IL_0146: ldloc.2
-			IL_0147: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_014c: dup
-			IL_014d: brtrue IL_0162
+			IL_0146: stloc.2
+			IL_0147: ldloc.2
+			IL_0148: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_014d: dup
+			IL_014e: brtrue IL_0163
 
-			IL_0152: pop
-			IL_0153: ldloc.2
-			IL_0154: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0159: dup
-			IL_015a: brtrue IL_016d
+			IL_0153: pop
+			IL_0154: ldloc.2
+			IL_0155: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_015a: dup
+			IL_015b: brtrue IL_016e
 
-			IL_015f: pop
-			IL_0160: rethrow
+			IL_0160: pop
+			IL_0161: rethrow
 
-			IL_0162: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0167: stloc.3
-			IL_0168: br IL_016e
+			IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0168: stloc.3
+			IL_0169: br IL_016f
 
-			IL_016d: stloc.3
+			IL_016e: stloc.3
 
-			IL_016e: ldloc.3
-			IL_016f: stloc.s 4
-			IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0176: stloc.s 8
-			IL_0178: ldloc.s 8
-			IL_017a: ldstr "primitive target threw:"
-			IL_017f: ldc.i4.1
-			IL_0180: box [System.Runtime]System.Boolean
-			IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_018a: pop
-			IL_018b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0190: stloc.s 8
-			IL_0192: volatile.
-			IL_0194: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_0199: brfalse IL_01af
+			IL_016f: ldloc.3
+			IL_0170: stloc.s 4
+			IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0177: stloc.s 8
+			IL_0179: ldloc.s 8
+			IL_017b: ldstr "primitive target threw:"
+			IL_0180: ldc.i4.1
+			IL_0181: box [System.Runtime]System.Boolean
+			IL_0186: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_018b: pop
+			IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0191: stloc.s 8
+			IL_0193: volatile.
+			IL_0195: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_019a: brfalse IL_01b0
 
-			IL_019e: ldloc.s 4
-			IL_01a0: ldstr "name"
-			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01aa: br IL_01c5
+			IL_019f: ldloc.s 4
+			IL_01a1: ldstr "name"
+			IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ab: br IL_01c6
 
-			IL_01af: ldloc.s 4
-			IL_01b1: ldstr "name"
-			IL_01b6: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:53"
-			IL_01bb: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+			IL_01b0: ldloc.s 4
+			IL_01b2: ldstr "name"
+			IL_01b7: ldstr "WeakRef_Deref_KeptObjects:Modules.WeakRef_Deref_KeptObjects:__js_module_init__:53"
+			IL_01bc: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
 
-			IL_01c5: stloc.s 9
-			IL_01c7: ldloc.s 8
-			IL_01c9: ldstr "primitive target name:"
-			IL_01ce: ldloc.s 9
-			IL_01d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01d5: pop
-			IL_01d6: leave IL_01db
+			IL_01c6: stloc.s 9
+			IL_01c8: ldloc.s 8
+			IL_01ca: ldstr "primitive target name:"
+			IL_01cf: ldloc.s 9
+			IL_01d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01d6: pop
+			IL_01d7: leave IL_01dc
 		} // end handler
 
-		IL_01db: ldc.i4.1
-		IL_01dc: newarr [System.Runtime]System.Object
-		IL_01e1: dup
-		IL_01e2: ldc.i4.0
-		IL_01e3: ldloc.0
-		IL_01e4: stelem.ref
-		IL_01e5: stloc.s 6
-		IL_01e7: ldloc.s 6
-		IL_01e9: ldc.i4.0
-		IL_01ea: ldelem.ref
-		IL_01eb: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_01f0: newobj instance void Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject::.ctor(class Modules.WeakRef_Deref_KeptObjects/Scope)
-		IL_01f5: ldc.i4.0
-		IL_01f6: conv.r8
-		IL_01f7: ldstr ""
-		IL_01fc: ldc.i4.0
+		IL_01dc: ldc.i4.1
+		IL_01dd: newarr [System.Runtime]System.Object
+		IL_01e2: dup
+		IL_01e3: ldc.i4.0
+		IL_01e4: ldloc.0
+		IL_01e5: stelem.ref
+		IL_01e6: stloc.s 6
+		IL_01e8: ldloc.s 6
+		IL_01ea: ldc.i4.0
+		IL_01eb: ldelem.ref
+		IL_01ec: castclass Modules.WeakRef_Deref_KeptObjects/Scope
+		IL_01f1: newobj instance void Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject::.ctor(class Modules.WeakRef_Deref_KeptObjects/Scope)
+		IL_01f6: ldc.i4.0
+		IL_01f7: conv.r8
+		IL_01f8: ldstr ""
 		IL_01fd: ldc.i4.0
-		IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0203: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject>(!!0)
-		IL_0208: stloc.s 10
-		IL_020a: ldloc.s 10
-		IL_020c: ldc.i4.0
-		IL_020d: newarr [System.Runtime]System.Object
-		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0217: pop
-		IL_0218: ldnull
-		IL_0219: stloc.s 5
-		IL_021b: ret
+		IL_01fe: ldc.i4.0
+		IL_01ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0204: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14/FunctionObject>(!!0)
+		IL_0209: stloc.s 10
+		IL_020b: ldloc.s 10
+		IL_020d: ldc.i4.0
+		IL_020e: newarr [System.Runtime]System.Object
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0218: pop
+		IL_0219: ldnull
+		IL_021a: stloc.s 5
+		IL_021c: ret
 	} // end of method WeakRef_Deref_KeptObjects::__js_module_init__
 
 } // end of class Modules.WeakRef_Deref_KeptObjects


### PR DESCRIPTION
Closes #1994

## Summary

- preserve direct typed calls for strict declared functions when their `this`
  binding cannot be observed;
- retain function-value dispatch when the function or a nested arrow reads
  `this`, preserving strict bare-call `this === undefined`;
- add execution and generator coverage for both paths and regenerate affected
  IL snapshots.

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter 'FullyQualifiedName~Jroc.Tests.Function' --no-restore --nologo`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter 'FullyQualifiedName~GeneratorTests' --no-restore --nologo`
- `node scripts/test262/runMvp.js --file "test/language/function-code/10.4.3-1-9-s.js" --variant strict`
- `node scripts/test262/runMvp.js --file "test/language/function-code/10.4.3-1-13-s.js" --variant strict`
- `dotnet build jroc.sln -c Release --no-restore --nologo -warnaserror`

The strict direct-call microbenchmark dropped from ~19.1s to ~0.63s for
30 million `return mul(a, b) + 0` calls, matching the sloppy-mode fast path.
