### PR TITLE
fix: report CI failures when gh log output is empty

### DIFF
--- a/scripts/summarizePrCiFailures.js
+++ b/scripts/summarizePrCiFailures.js
@@ -233,7 +233,7 @@ function parseFailedTestsFromLog(log) {
   return [...failuresByName.values()];
 }
 
-function getFailedTests(check, repo) {
+function getFailedTests(check, repo, runCommand = runGh) {
   const job = parseActionsJobUrl(check.detailsUrl);
   if (!job) {
     return [];
@@ -244,10 +244,35 @@ function getFailedTests(check, repo) {
     ghArgs.push("--repo", repo);
   }
 
+  let primaryLogError = null;
   try {
-    return parseFailedTestsFromLog(runGh(ghArgs));
+    const log = runCommand(ghArgs);
+    if (log) {
+      return parseFailedTestsFromLog(log);
+    }
   } catch (error) {
-    process.stderr.write(`Warning: could not fetch failed job log for ${check.name}: ${error.message}\n`);
+    primaryLogError = error;
+  }
+
+  if (!repo) {
+    if (primaryLogError) {
+      process.stderr.write(`Warning: could not fetch failed job log for ${check.name}: ${primaryLogError.message}\n`);
+    }
+    return [];
+  }
+
+  try {
+    return parseFailedTestsFromLog(runCommand([
+      "api",
+      `repos/${repo}/actions/jobs/${job.jobId}/logs`,
+    ]));
+  } catch (error) {
+    const primaryFailure = primaryLogError
+      ? ` after gh run view failed: ${primaryLogError.message}`
+      : " after gh run view returned no log output";
+    process.stderr.write(
+      `Warning: could not fetch failed job log for ${check.name}${primaryFailure}; `
+      + `Actions job-log API fallback failed: ${error.message}\n`);
     return [];
   }
 }
@@ -326,6 +351,7 @@ if (require.main === module) {
 
 module.exports = {
   parseFailedTestsFromLog,
+  getFailedTests,
   runGh,
   stripActionsLogPrefix,
   truncateCommandFailureOutput,

--- a/scripts/summarizePrCiFailures.test.js
+++ b/scripts/summarizePrCiFailures.test.js
@@ -7,6 +7,7 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const {
+  getFailedTests,
   parseFailedTestsFromLog,
   runGh,
   truncateCommandFailureOutput,
@@ -52,6 +53,39 @@ test("parses failed test names and assertion details from Actions logs", () => {
       "Assert.InRange() Failure: Value not in range",
       "Range:  (0 - 131072)",
       "Actual: 144920",
+    ],
+  }]);
+});
+
+test("falls back to the Actions job-log API when gh run view returns no log", () => {
+  const calls = [];
+  const failures = getFailedTests({
+    name: "build",
+    detailsUrl: "https://github.com/octo/example/actions/runs/123/job/456",
+  }, "octo/example", (args) => {
+    calls.push(args);
+    if (args[0] === "run") {
+      return "";
+    }
+
+    return [
+      "2026-08-24T16:36:15.9582466Z [xUnit.net 00:00:21.20]     Example.Tests.Failure [FAIL]",
+      "2026-08-24T16:36:15.9707835Z   Failed Example.Tests.Failure [2 s]",
+      "2026-08-24T16:36:15.9708764Z   Error Message:",
+      "2026-08-24T16:36:15.9709680Z    Expected: true",
+      "2026-08-24T16:36:15.9711107Z    Actual: false",
+    ].join("\n");
+  });
+
+  assert.deepEqual(calls, [
+    ["run", "view", "123", "--job", "456", "--log-failed", "--repo", "octo/example"],
+    ["api", "repos/octo/example/actions/jobs/456/logs"],
+  ]);
+  assert.deepEqual(failures, [{
+    name: "Example.Tests.Failure",
+    details: [
+      "Expected: true",
+      "Actual: false",
     ],
   }]);
 });


### PR DESCRIPTION
## Problem

`scripts/summarizePrCiFailures.js` reported only the failed check URL for PR
#1996 even though the Actions log contained two ordinary xUnit failures.

The script called:

```text
gh run view <run-id> --job <job-id> --log-failed
```

On the installed GitHub CLI 2.45.0, that command returned an empty successful
response for job `97509761189`. The script treated the empty string as a log
with no failed tests, so its otherwise-correct xUnit/VSTest parser had no input
to summarize. The raw Actions endpoint for the same job returned a 1.17MB
plain-text log, including both test names and their Verify snapshot details.

## Fix

- Keep `gh run view --log-failed` as the fast/default path.
- When it returns no output (or errors), fall back to:

  ```text
  gh api repos/<owner>/<repo>/actions/jobs/<job-id>/logs
  ```

- Parse the fallback response with the existing log parser.
- If both paths fail, report a warning that includes the primary-path outcome
  and fallback failure.

This maintains normal behavior where `gh run view` works and makes the script
resilient to its silent empty-output failure mode.

## Validation

- `JROC_SUMMARIZE_PR_CI_FAILURES_NODE_ONLY=1 node --test scripts/summarizePrCiFailures.test.js`
- Called the fallback against the historical failed job from PR #1996. It
  reported both Test262 integration snapshot failures and their Verify details.
